### PR TITLE
refactor: leverage new in-place arithmetics with QkObs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
   [![License](https://img.shields.io/github/license/Qiskit/qiskit-fermions?label=License)](LICENSE.txt)
   [![Docs](https://img.shields.io/badge/%F0%9F%93%84%20Docs-stable-blue.svg)](https://qiskit.github.io/qiskit-fermions/)
-  [![Qiskit](https://img.shields.io/badge/Qiskit%20-%20%3E%3D2.3%20-%20%236133BD?logo=Qiskit)](https://github.com/Qiskit/qiskit)
+  [![Qiskit](https://img.shields.io/badge/Qiskit%20-%20%3E%3D2.4%20-%20%236133BD?logo=Qiskit)](https://github.com/Qiskit/qiskit)
   [![Python](https://img.shields.io/badge/python-3.10%7C3.11%7C3.12%7C3.13-blue.svg)](https://www.python.org/)
   [![rustc](https://img.shields.io/badge/rustc-1.91+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
   ![Platform](https://img.shields.io/badge/%F0%9F%92%BB%20Platform-Linux%20%7C%20macOS-informational)

--- a/crates/core/src/mappers/library/jordan_wigner.rs
+++ b/crates/core/src/mappers/library/jordan_wigner.rs
@@ -12,7 +12,6 @@
 
 use crate::operators::fermion_operator::{FermionAction, FermionOperator};
 use rayon::prelude::*;
-use std::mem::MaybeUninit;
 use std::sync::{Arc, Mutex};
 
 fn map_action(action: FermionAction, num_qubits: u32) -> *mut qiskit_sys::QkObs {
@@ -91,26 +90,15 @@ pub fn jordan_wigner(fer_op: &FermionOperator, num_qubits: u32) -> *mut qiskit_s
                 mapped_term = new_term;
             });
 
-            let scaled_term = unsafe { qiskit_sys::qk_obs_multiply(mapped_term, &qk_coeff) };
+            let canon_term = unsafe { qiskit_sys::qk_obs_canonicalize(mapped_term, 1e-18) };
             unsafe { qiskit_sys::qk_obs_free(mapped_term) };
-
-            let canon_term = unsafe { qiskit_sys::qk_obs_canonicalize(scaled_term, 1e-18) };
-            unsafe { qiskit_sys::qk_obs_free(scaled_term) };
 
             let qubit_op = qubit_ops[pool.current_thread_index().unwrap()]
                 // this should never lock because we have one item per thread
                 .lock()
                 .unwrap();
 
-            // PERF: we are addinf the terms one-by-one manually since this is significantly more
-            // efficient that many repetitive calls to qk_obs_add. In-place addition support within
-            // Qiskit would alleviate the need for this.
-            let num_add_terms = unsafe { qiskit_sys::qk_obs_num_terms(canon_term) };
-            let mut term = MaybeUninit::uninit();
-            (0..num_add_terms).for_each(|j| unsafe {
-                qiskit_sys::qk_obs_term(canon_term, j as u64, term.as_mut_ptr());
-                qiskit_sys::qk_obs_add_term(qubit_op.ptr, term.as_ptr());
-            });
+            unsafe { qiskit_sys::qk_obs_scaled_add_inplace(qubit_op.ptr, canon_term, &qk_coeff)};
 
             unsafe { qiskit_sys::qk_obs_free(canon_term) };
         });
@@ -125,16 +113,8 @@ pub fn jordan_wigner(fer_op: &FermionOperator, num_qubits: u32) -> *mut qiskit_s
             {
                 |op1: Wrapper, op2| {
                     let op_locked = op2.lock().unwrap();
-
-                    let num_add_terms = unsafe { qiskit_sys::qk_obs_num_terms(op_locked.ptr) };
-                    let mut term = MaybeUninit::uninit();
-                    (0..num_add_terms).for_each(|j| unsafe {
-                        qiskit_sys::qk_obs_term(op_locked.ptr, j as u64, term.as_mut_ptr());
-                        qiskit_sys::qk_obs_add_term(op1.ptr, term.as_ptr());
-                    });
-
+                    unsafe { qiskit_sys::qk_obs_add_inplace(op1.ptr, op_locked.ptr) };
                     unsafe { qiskit_sys::qk_obs_free(op_locked.ptr) };
-
                     op1
                 }
             },
@@ -148,19 +128,11 @@ pub fn jordan_wigner(fer_op: &FermionOperator, num_qubits: u32) -> *mut qiskit_s
                     let num_add_terms1 = unsafe { qiskit_sys::qk_obs_num_terms(op1.ptr) };
                     let num_add_terms2 = unsafe { qiskit_sys::qk_obs_num_terms(op2.ptr) };
                     if num_add_terms1 > num_add_terms2 {
-                        let mut term = MaybeUninit::uninit();
-                        (0..num_add_terms2).for_each(|j| unsafe {
-                            qiskit_sys::qk_obs_term(op2.ptr, j as u64, term.as_mut_ptr());
-                            qiskit_sys::qk_obs_add_term(op1.ptr, term.as_ptr());
-                        });
+                        unsafe { qiskit_sys::qk_obs_add_inplace(op1.ptr, op2.ptr) };
                         unsafe { qiskit_sys::qk_obs_free(op2.ptr) };
                         op1
                     } else {
-                        let mut term = MaybeUninit::uninit();
-                        (0..num_add_terms1).for_each(|j| unsafe {
-                            qiskit_sys::qk_obs_term(op1.ptr, j as u64, term.as_mut_ptr());
-                            qiskit_sys::qk_obs_add_term(op2.ptr, term.as_ptr());
-                        });
+                        unsafe { qiskit_sys::qk_obs_add_inplace(op2.ptr, op1.ptr) };
                         unsafe { qiskit_sys::qk_obs_free(op1.ptr) };
                         op2
                     }


### PR DESCRIPTION
This refactors the Jordan-Wigner mapper logic to leverage some upcoming C API functions in Qiskit 2.4.

See https://github.com/Qiskit/qiskit/pull/15598 and https://github.com/Qiskit/qiskit/pull/15599 for more details.

Closes #14. As discussed there, while the performance gains are not as large as I had hoped, the source code becomes a lot cleaner. And since we already instruct users to install from source anyways, I'm fine merging this ahead of the 2.4 release of Qiskit.