### PR TITLE
docs: fix rendering of doctests

### DIFF
--- a/crates/pyext/src/mappers/library/jordan_wigner.rs
+++ b/crates/pyext/src/mappers/library/jordan_wigner.rs
@@ -53,6 +53,7 @@ use qiskit_fermions_core::mappers::library::jordan_wigner::jordan_wigner;
 /// upon, one can specify the number of qubits to map onto when calling this function.
 ///
 /// .. doctest::
+///
 ///     >>> from qiskit_fermions.mappers.library import jordan_wigner
 ///     >>> from qiskit_fermions.operators import FermionOperator
 ///     >>> fop = FermionOperator.from_dict(

--- a/crates/pyext/src/mappers/library/majorana_fermion.rs
+++ b/crates/pyext/src/mappers/library/majorana_fermion.rs
@@ -47,6 +47,7 @@ use qiskit_fermions_core::mappers::library::majorana_fermion::{
 /// =====
 ///
 /// .. doctest::
+///
 ///     >>> from qiskit_fermions.mappers.library import fermion_to_majorana
 ///     >>> from qiskit_fermions.operators import FermionOperator
 ///     >>> fer_op = FermionOperator.from_dict({((True, 0), (False, 0)): 1})
@@ -92,6 +93,7 @@ pub fn py_fermion_to_majorana(fer_op: PyFermionOperator) -> PyMajoranaOperator {
 /// =====
 ///
 /// .. doctest::
+///
 ///     >>> from qiskit_fermions.mappers.library import majorana_to_fermion
 ///     >>> from qiskit_fermions.operators import MajoranaOperator
 ///     >>> maj_op = MajoranaOperator.from_dict({(0, 1): 1})

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -105,6 +105,7 @@ impl FermionOperatorDataIter {
 /// An operator can be constructed directly by providing the arrays outlined above:
 ///
 /// .. doctest::
+///
 ///     >>> from qiskit_fermions.operators import FermionOperator
 ///     >>> coeffs = [1.0, 2.0, -3.0, 4.0j, -0.5j]
 ///     >>> actions = [True, False, False, True, True, True, False, False]
@@ -121,6 +122,7 @@ impl FermionOperatorDataIter {
 /// For convenience, it is possible to construct an operator from a Python dictionary like so:
 ///
 /// .. doctest::
+///
 ///     >>> from qiskit_fermions.operators import cre, ann
 ///     >>> op = FermionOperator.from_dict(
 ///     ...     {
@@ -155,6 +157,7 @@ impl FermionOperatorDataIter {
 /// cannot be iterated over directly:
 ///
 /// .. doctest::
+///
 ///     >>> list(iter(op))
 ///     Traceback (most recent call last):
 ///       ...
@@ -163,6 +166,7 @@ impl FermionOperatorDataIter {
 /// Instead, this class provides custom iterators to fulfill this purpose:
 ///
 /// .. doctest::
+///
 ///     >>> list(sorted(op.iter_terms()))
 ///     [([], (1+0j)), ([(False, 0)], (-3+0j)), ([(False, 0), (True, 1)], 4j), ([(True, 0)], (2+0j)), ([(True, 0), (True, 1), (False, 2), (False, 3)], (-0-0.5j))]
 ///
@@ -185,6 +189,7 @@ impl FermionOperatorDataIter {
 /// ^^^^^^^^^^^^^^^^^^^^
 ///
 /// .. doctest::
+///
 ///     >>> op = FermionOperator.one()
 ///     >>> (op + op).simplify()
 ///     FermionOperator.from_dict({(): 2+0j})
@@ -201,6 +206,7 @@ impl FermionOperatorDataIter {
 /// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ///
 /// .. doctest::
+///
 ///     >>> op = FermionOperator.one()
 ///     >>> (2 * op).simplify()
 ///     FermionOperator.from_dict({(): 2+0j})
@@ -222,6 +228,7 @@ impl FermionOperatorDataIter {
 ///    operator that performs "first ``a`` and then ``b``".
 ///
 /// .. doctest::
+///
 ///     >>> op1 = FermionOperator.from_dict({(): 2.0, (cre(0),): 3.0})
 ///     >>> op2 = FermionOperator.from_dict({(): 1.5, (ann(1),): 4.0})
 ///     >>> comp = (op1 & op2).simplify()
@@ -304,6 +311,7 @@ impl PyFermionOperator {
     /// Constructs a new operator from a dictionary.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict(
     ///     ...     {
@@ -432,6 +440,7 @@ impl PyFermionOperator {
     /// Adding the operator that is constructed by this method to another one has no effect.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({(): 2.0})
     ///     >>> zero = FermionOperator.zero()
@@ -451,6 +460,7 @@ impl PyFermionOperator {
     /// Composing the operator that is constructed by this method with another one has no effect.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({(): 2.0})
     ///     >>> one = FermionOperator.one()
@@ -494,6 +504,7 @@ impl PyFermionOperator {
     /// magnitude which should not be truncated:
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> coeffs = [1e-5] * int(1e5)
     ///     >>> boundaries = [0] + [0] * int(1e5)
@@ -522,6 +533,7 @@ impl PyFermionOperator {
     ///    separate coefficients for duplicate terms consider calling :meth:`.simplify` instead!
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({(): 1e-4, ((True, 0),): 1e-6, ((False, 0),): 1e-10})
     ///     >>> print(op)
@@ -549,6 +561,7 @@ impl PyFermionOperator {
     ///    Mutating the iteration items does **not** affect the underlying operator data.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({(): 2.0, ((True, 0),): 1.0, ((False, 1),): -1.0j})
     ///     >>> list(sorted(op.iter_terms()))
@@ -575,6 +588,7 @@ impl PyFermionOperator {
     /// - the coefficients are complex conjugated
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({(): -1.0j, ((True, 0), (False, 1)): 1.0})
     ///     >>> adj = op.adjoint()
@@ -597,6 +611,7 @@ impl PyFermionOperator {
     /// ``atol``.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({(): 1e-7})
     ///     >>> zero = FermionOperator.zero()
@@ -627,6 +642,7 @@ impl PyFermionOperator {
     ///    number of terms may change.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({((False, 1), (True, 1), (False, 0), (True, 0)): 1})
     ///     >>> print(op.normal_ordered().simplify())
@@ -650,6 +666,7 @@ impl PyFermionOperator {
     ///    of ``self`` and its :meth:`.adjoint` and :meth:`.zero`.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({
     ///     ...     ((True, 0), (False, 1)): 1.00001j,
@@ -678,6 +695,7 @@ impl PyFermionOperator {
     ///    operator.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({
     ///     ...     ((True, 0), (False, 1), (True, 2), (False, 3)): 1,
@@ -694,6 +712,7 @@ impl PyFermionOperator {
     /// Returns whether this operator is particle-number conserving.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({((True, 0), (False, 1)): 1})
     ///     >>> op.conserves_particle_number()

--- a/crates/pyext/src/operators/library/electronic_integrals.rs
+++ b/crates/pyext/src/operators/library/electronic_integrals.rs
@@ -36,6 +36,7 @@ impl PyFermionOperator {
     /// the array, and :math:`n` is the number of orbitals, ``norb``.
     ///
     /// .. doctest::
+    ///
     ///    >>> import numpy as np
     ///    >>> from qiskit_fermions.operators import FermionOperator
     ///    >>> one_body_a = np.array([1.0, 2.0, 3.0])
@@ -86,6 +87,7 @@ impl PyFermionOperator {
     /// of orbitals, ``norb``.
     ///
     /// .. doctest::
+    ///
     ///    >>> import numpy as np
     ///    >>> from qiskit_fermions.operators import FermionOperator
     ///    >>> one_body_a = np.array([1.0, 2.0, 3.0])
@@ -156,6 +158,7 @@ impl PyFermionOperator {
     ///     index permutations :math:`(i,j,k,l)` that index this 4-dimensional array.
     ///
     /// .. doctest::
+    ///
     ///    >>> import numpy as np
     ///    >>> from qiskit_fermions.operators import FermionOperator
     ///    >>> two_body_aa = np.arange(1, 7, dtype=float)
@@ -217,6 +220,7 @@ impl PyFermionOperator {
     ///     index :math:`ijkl` as an abuse of notation.)
     ///
     /// .. doctest::
+    ///
     ///    >>> import numpy as np
     ///    >>> from qiskit_fermions.operators import FermionOperator
     ///    >>> two_body_aa = np.arange(1, 7, dtype=float)

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -111,6 +111,7 @@ impl MajoranaOperatorDataIter {
 /// An operator can be constructed directly by providing the arrays outlined above:
 ///
 /// .. doctest::
+///
 ///     >>> from qiskit_fermions.operators import MajoranaOperator
 ///     >>> coeffs = [1.0, -2.0, 3.0j, -0.5j]
 ///     >>> modes = [0, 1, 0, 2, 0, 1, 2, 3]
@@ -125,6 +126,7 @@ impl MajoranaOperatorDataIter {
 /// For convenience, it is possible to construct an operator from a Python dictionary like so:
 ///
 /// .. doctest::
+///
 ///     >>> from qiskit_fermions.operators import gamma
 ///     >>> op = MajoranaOperator.from_dict(
 ///     ...     {
@@ -156,6 +158,7 @@ impl MajoranaOperatorDataIter {
 /// cannot be iterated over directly:
 ///
 /// .. doctest::
+///
 ///     >>> list(iter(op))
 ///     Traceback (most recent call last):
 ///       ...
@@ -164,6 +167,7 @@ impl MajoranaOperatorDataIter {
 /// Instead, this class provides custom iterators to fulfill this purpose:
 ///
 /// .. doctest::
+///
 ///     >>> list(sorted(op.iter_terms()))
 ///     [([], (1+0j)), ([0, 1], (-2+0j)), ([0, 1, 2, 3], (-0-0.5j)), ([0, 2], 3j)]
 ///
@@ -186,6 +190,7 @@ impl MajoranaOperatorDataIter {
 /// ^^^^^^^^^^^^^^^^^^^^
 ///
 /// .. doctest::
+///
 ///     >>> op = MajoranaOperator.one()
 ///     >>> (op + op).simplify()
 ///     MajoranaOperator.from_dict({(): 2+0j})
@@ -202,6 +207,7 @@ impl MajoranaOperatorDataIter {
 /// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ///
 /// .. doctest::
+///
 ///     >>> op = MajoranaOperator.one()
 ///     >>> (2 * op).simplify()
 ///     MajoranaOperator.from_dict({(): 2+0j})
@@ -223,6 +229,7 @@ impl MajoranaOperatorDataIter {
 ///    operator that performs "first ``a`` and then ``b``".
 ///
 /// .. doctest::
+///
 ///     >>> op1 = MajoranaOperator.from_dict({(): 2.0, (gamma(0, False),): 3.0})
 ///     >>> op2 = MajoranaOperator.from_dict({(): 1.5, (gamma(0, True),): 4.0})
 ///     >>> comp = (op1 & op2).simplify()
@@ -300,6 +307,7 @@ impl PyMajoranaOperator {
     /// Constructs a new operator from a dictionary.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict(
     ///     ...     {
@@ -414,6 +422,7 @@ impl PyMajoranaOperator {
     /// Adding the operator that is constructed by this method to another one has no effect.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({(): 2.0})
     ///     >>> zero = MajoranaOperator.zero()
@@ -433,6 +442,7 @@ impl PyMajoranaOperator {
     /// Composing the operator that is constructed by this method with another one has no effect.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({(): 2.0})
     ///     >>> one = MajoranaOperator.one()
@@ -476,6 +486,7 @@ impl PyMajoranaOperator {
     /// magnitude which should not be truncated:
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> coeffs = [1e-5] * int(1e5)
     ///     >>> boundaries = [0] + [0] * int(1e5)
@@ -504,6 +515,7 @@ impl PyMajoranaOperator {
     ///    separate coefficients for duplicate terms consider calling :meth:`.simplify` instead!
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({(): 1e-4, (0,): 1e-6, (1,): 1e-10})
     ///     >>> print(op)
@@ -531,6 +543,7 @@ impl PyMajoranaOperator {
     ///    Mutating the iteration items does **not** affect the underlying operator data.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({(): 2.0, (0,): 1.0, (1,): -1.0j})
     ///     >>> list(sorted(op.iter_terms()))
@@ -557,6 +570,7 @@ impl PyMajoranaOperator {
     /// - the coefficients are complex conjugated
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({(): -1.0j, (gamma(0, False), gamma(0, True)): 1.0})
     ///     >>> adj = op.adjoint()
@@ -579,6 +593,7 @@ impl PyMajoranaOperator {
     /// ``atol``.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({(): 1e-7})
     ///     >>> zero = MajoranaOperator.zero()
@@ -606,6 +621,7 @@ impl PyMajoranaOperator {
     /// ``[\gamma(1, True), \gamma(1, False), \gamma(0, True), \gamma(0, False)] = [3, 2, 1, 0]``.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({(gamma(0, False), gamma(0, True), gamma(0, False)): 1})
     ///     >>> print(op.normal_ordered(reduce=False))
@@ -633,6 +649,7 @@ impl PyMajoranaOperator {
     ///    of ``self`` and its :meth:`.adjoint` and :meth:`.zero`.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({
     ///     ...     (0, 1, 2, 3): 1.00001j,
@@ -661,6 +678,7 @@ impl PyMajoranaOperator {
     ///    operator.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({(0, 1, 2, 3): 1})
     ///     >>> op.many_body_order()
@@ -678,6 +696,7 @@ impl PyMajoranaOperator {
     ///    An operator is considered even when all of its terms contain an even number of actions.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({(0, 1): 1})
     ///     >>> op.is_even()

--- a/python/qiskit_fermions/mappers/fermion_generators.py
+++ b/python/qiskit_fermions/mappers/fermion_generators.py
@@ -40,6 +40,7 @@ def map_fermion_action_generators(
        If ``compose=None`` it must also support composition of two instances via ``__and__``.
 
     .. doctest::
+
         >>> from qiskit_fermions.mappers import map_fermion_action_generators
         >>> from qiskit_fermions.operators import FermionAction, FermionOperator, ann, cre
         >>> from qiskit.quantum_info import SparsePauliOp

--- a/python/qiskit_fermions/mappers/majorana_generators.py
+++ b/python/qiskit_fermions/mappers/majorana_generators.py
@@ -40,6 +40,7 @@ def map_majorana_action_generators(
        If ``compose=None`` it must also support composition of two instances via ``__and__``.
 
     .. doctest::
+
         >>> from qiskit_fermions.mappers import map_majorana_action_generators
         >>> from qiskit_fermions.operators import MajoranaAction, MajoranaOperator, gamma
         >>> from qiskit.quantum_info import SparsePauliOp

--- a/python/qiskit_fermions/operators/library/commutators.py
+++ b/python/qiskit_fermions/operators/library/commutators.py
@@ -68,6 +68,7 @@ def commutator(op_a: SupportsCommutators, op_b: SupportsCommutators) -> Supports
        Both inputs must be of the same operator type. This will also determine the output type.
 
     .. doctest::
+
        >>> from qiskit_fermions.operators import FermionOperator
        >>> from qiskit_fermions.operators.library import commutator
        >>> op1 = FermionOperator.from_dict({((True, 0), (False, 0)): 1})
@@ -102,6 +103,7 @@ def anti_commutator(op_a: SupportsCommutators, op_b: SupportsCommutators) -> Sup
        Both inputs must be of the same operator type. This will also determine the output type.
 
     .. doctest::
+
        >>> from qiskit_fermions.operators import FermionOperator
        >>> from qiskit_fermions.operators.library import anti_commutator
        >>> op1 = FermionOperator.from_dict({((True, 0), (False, 0)): 1})
@@ -147,6 +149,7 @@ def double_commutator(
        All three inputs must be of the same operator type. This will also determine the output type.
 
     .. doctest::
+
        >>> from qiskit_fermions.operators import FermionOperator
        >>> from qiskit_fermions.operators.library import anti_commutator
        >>> op1 = FermionOperator.from_dict({((True, 0), (False, 0)): 1})


### PR DESCRIPTION
Somewhere along the latest changes, the rendering of the doctest code in Sphinx broke (presumably as a result of #36 although I did not verify that).

Ensuring an empty line after the `.. doctest::` RST directive fixes the rendering as expected :+1: