### PR TITLE
docs: fix left-over mentions of `indices`

### DIFF
--- a/docs/cdoc/qf-commutators.rst
+++ b/docs/cdoc/qf-commutators.rst
@@ -39,13 +39,13 @@ Example
    QfFermionOperator *op1 = qf_ferm_op_zero();
    QkComplex64 coeff1 = {1.0, 0.0};
    bool action1[2] = {true, false};
-   uint32_t indices1[2] = {0, 0};
-   qf_ferm_op_add_term(op1, 2, action1, indices1, &coeff1);
+   uint32_t modes1[2] = {0, 0};
+   qf_ferm_op_add_term(op1, 2, action1, modes1, &coeff1);
    QfFermionOperator *op2 = qf_ferm_op_zero();
    QkComplex64 coeff2 = {2.0, 0.0};
    bool action2[2] = {false, true};
-   uint32_t indices2[2] = {0, 0};
-   qf_ferm_op_add_term(op2, 2, action2, indices2, &coeff2);
+   uint32_t modes2[2] = {0, 0};
+   qf_ferm_op_add_term(op2, 2, action2, modes2, &coeff2);
 
    QfFermionOperator *comm = qf_ferm_op_commutator(op1, op2);
 
@@ -79,13 +79,13 @@ Example
    QfFermionOperator *op1 = qf_ferm_op_zero();
    QkComplex64 coeff1 = {1.0, 0.0};
    bool action1[2] = {true, false};
-   uint32_t indices1[2] = {0, 0};
-   qf_ferm_op_add_term(op1, 2, action1, indices1, &coeff1);
+   uint32_t modes1[2] = {0, 0};
+   qf_ferm_op_add_term(op1, 2, action1, modes1, &coeff1);
    QfFermionOperator *op2 = qf_ferm_op_zero();
    QkComplex64 coeff2 = {2.0, 0.0};
    bool action2[2] = {false, true};
-   uint32_t indices2[2] = {0, 0};
-   qf_ferm_op_add_term(op2, 2, action2, indices2, &coeff2);
+   uint32_t modes2[2] = {0, 0};
+   qf_ferm_op_add_term(op2, 2, action2, modes2, &coeff2);
 
    QfFermionOperator *anti_comm = qf_ferm_op_anti_commutator(op1, op2);
 
@@ -133,17 +133,17 @@ Example
    QfFermionOperator *op1 = qf_ferm_op_zero();
    QkComplex64 coeff1 = {1.0, 0.0};
    bool action1[2] = {true, false};
-   uint32_t indices1[2] = {0, 0};
-   qf_ferm_op_add_term(op1, 2, action1, indices1, &coeff1);
+   uint32_t modes1[2] = {0, 0};
+   qf_ferm_op_add_term(op1, 2, action1, modes1, &coeff1);
    QfFermionOperator *op2 = qf_ferm_op_zero();
    QkComplex64 coeff2 = {2.0, 0.0};
    bool action2[2] = {false, true};
-   uint32_t indices2[2] = {0, 0};
-   qf_ferm_op_add_term(op2, 2, action2, indices2, &coeff2);
+   uint32_t modes2[2] = {0, 0};
+   qf_ferm_op_add_term(op2, 2, action2, modes2, &coeff2);
    QfFermionOperator *op3 = qf_ferm_op_zero();
-   qf_ferm_op_add_term(op3, 2, action1, indices1, &coeff1);
+   qf_ferm_op_add_term(op3, 2, action1, modes1, &coeff1);
    QkComplex64 coeff3 = {2.0, 0.5};
-   qf_ferm_op_add_term(op3, 2, action2, indices2, &coeff3);
+   qf_ferm_op_add_term(op3, 2, action2, modes2, &coeff3);
 
    QfFermionOperator *double_comm = qf_ferm_op_double_commutator(op1, op2, op3, false);
 

--- a/docs/cdoc/qf-ferm-op.rst
+++ b/docs/cdoc/qf-ferm-op.rst
@@ -53,12 +53,12 @@ commonly used for sparse matrices. More concretely, a single operator contains 4
    ============== =================================================================================
    ``coeffs``     A vector of complex coefficients consisting of two 64-bit floating point numbers.
    ``actions``    A vector of booleans storing the nature of the second-quantization actions.
-   ``indices``    A vector of 32-bit integers storing the fermionic mode indices acted upon.
-   ``boundaries`` A vector of integers indicating the boundaries in ``actions`` and ``indices``.
+   ``modes``      A vector of 32-bit integers storing the fermionic mode indices acted upon.
+   ``boundaries`` A vector of integers indicating the boundaries in ``actions`` and ``modes``.
    ============== =================================================================================
 
 Entries in ``actions`` indicate creation (annihilation) operators by ``True`` (``False``).
-Fermionic modes indexed by ``indices`` are considered spinless.
+Fermionic modes indexed by ``modes`` are considered spinless.
 
 This data structure allows for very efficient construction and manipulation of operators.
 However, it implies that duplicate terms may be contained in an operator at any moment.


### PR DESCRIPTION
A quick follow-up to #40 because I overlooked these few mentions of `indices` in the C API docs.