### PR TITLE
Provide read-only access to internal operator data structures

### DIFF
--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -113,6 +113,204 @@ pub unsafe extern "C" fn qf_ferm_op_free(op: *mut FermionOperator) {
 
 /// @ingroup qf_ferm_op
 ///
+/// @brief Provides read-only access to the operator's coefficients.
+///
+/// @param op A pointer to the fermionic operator whose coefficients to access.
+/// @param coeffs_out A pointer to the array of complex values into which to write the coefficients.
+/// @param coeffs_len A pointer to the integer into which to write the length of the output array.
+///
+/// @rst
+///
+/// .. note::
+///    This function returns a **copy** of the internal data.
+///
+/// .. seealso::
+///    The explanation of the internal data structure, :ref:`here <qf_ferm_op-implementation>`.
+///
+/// Example
+/// -------
+///
+/// .. code-block:: c
+///     :linenos:
+///
+///     uint64_t num_terms = 2;
+///     uint64_t num_actions = 0;
+///     QkComplex64 coeffs[2] = {{1.0, 0.0}, {0.0, -1.0}};
+///     uint32_t boundaries[3] = {0, 0, 0};
+///     QfFermionOperator *op =
+///         qf_ferm_op_new(num_terms, num_actions, coeffs, NULL, NULL, boundaries);
+///
+///     QkComplex64 *coeffs_out;
+///     uint64_t *coeffs_len;
+///
+///     qf_ferm_op_get_coeffs(op, &coeffs_out, &coeffs_len);
+///
+///     assert(coeffs_len == 2);
+///
+/// @endrst
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qf_ferm_op_get_coeffs(
+    op: *const FermionOperator,
+    coeffs_out: *mut *mut Complex64,
+    coeffs_len: *mut u64,
+) {
+    let op = unsafe { const_ptr_as_ref(op) };
+    unsafe { coeffs_out.write(op.coeffs.as_ptr().cast_mut()) };
+    unsafe { coeffs_len.write(op.coeffs.len().try_into().unwrap()) };
+}
+
+/// @ingroup qf_ferm_op
+///
+/// @brief Provides read-only access to the operator's actions.
+///
+/// @param op A pointer to the fermionic operator whose actions to access.
+/// @param actions_out A pointer to the array of boolean values into which to write the actions.
+/// @param actions_len A pointer to the integer into which to write the length of the output array.
+///
+/// @rst
+///
+/// .. note::
+///    This function returns a **copy** of the internal data.
+///
+/// .. seealso::
+///    The explanation of the internal data structure, :ref:`here <qf_ferm_op-implementation>`.
+///
+/// Example
+/// -------
+///
+/// .. code-block:: c
+///     :linenos:
+///
+///     uint64_t num_terms = 2;
+///     uint64_t num_actions = 2;
+///     bool actions[2] = {true, false};
+///     uint32_t modes[2] = {0, 1};
+///     QkComplex64 coeffs[2] = {{1.0, 0.0}, {0.0, -1.0}};
+///     uint32_t boundaries[3] = {0, 0, 2};
+///     QfFermionOperator *op =
+///         qf_ferm_op_new(num_terms, num_actions, coeffs, actions, modes, boundaries);
+///
+///     QkComplex64 *actions_out;
+///     uint64_t *actions_len;
+///
+///     qf_ferm_op_get_actions(op, &actions_out, &actions_len);
+///
+///     assert(actions_len == 2);
+///
+/// @endrst
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qf_ferm_op_get_actions(
+    op: *const FermionOperator,
+    actions_out: *mut *mut bool,
+    actions_len: *mut u64,
+) {
+    let op = unsafe { const_ptr_as_ref(op) };
+    unsafe { actions_out.write(op.actions.as_ptr().cast_mut()) };
+    unsafe { actions_len.write(op.actions.len().try_into().unwrap()) };
+}
+
+/// @ingroup qf_ferm_op
+///
+/// @brief Provides read-only access to the operator's acted-upon mode indices.
+///
+/// @param op A pointer to the fermionic operator whose modes to access.
+/// @param modes_out A pointer to the array of boolean values into which to write the modes.
+/// @param modes_len A pointer to the integer into which to write the length of the output array.
+///
+/// @rst
+///
+/// .. note::
+///    This function returns a **copy** of the internal data.
+///
+/// .. seealso::
+///    The explanation of the internal data structure, :ref:`here <qf_ferm_op-implementation>`.
+///
+/// Example
+/// -------
+///
+/// .. code-block:: c
+///     :linenos:
+///
+///     uint64_t num_terms = 2;
+///     uint64_t num_actions = 2;
+///     bool actions[2] = {true, false};
+///     uint32_t modes[2] = {0, 1};
+///     QkComplex64 coeffs[2] = {{1.0, 0.0}, {0.0, -1.0}};
+///     uint32_t boundaries[3] = {0, 0, 2};
+///     QfFermionOperator *op =
+///         qf_ferm_op_new(num_terms, num_actions, coeffs, actions, modes, boundaries);
+///
+///     QkComplex64 *modes_out;
+///     uint64_t *modes_len;
+///
+///     qf_ferm_op_get_modes(op, &modes_out, &modes_len);
+///
+///     assert(modes_len == 2);
+///
+/// @endrst
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qf_ferm_op_get_modes(
+    op: *const FermionOperator,
+    modes_out: *mut *mut u32,
+    modes_len: *mut u64,
+) {
+    let op = unsafe { const_ptr_as_ref(op) };
+    unsafe { modes_out.write(op.modes.as_ptr().cast_mut()) };
+    unsafe { modes_len.write(op.modes.len().try_into().unwrap()) };
+}
+
+/// @ingroup qf_ferm_op
+///
+/// @brief Provides read-only access to the indices indicating the boundaries between operator terms.
+///
+/// @param op A pointer to the fermionic operator whose boundaries to access.
+/// @param boundaries_out A pointer to the array of boolean values into which to write the boundaries.
+/// @param boundaries_len A pointer to the integer into which to write the length of the output array.
+///
+/// @rst
+///
+/// .. note::
+///    This function returns a **copy** of the internal data.
+///
+/// .. seealso::
+///    The explanation of the internal data structure, :ref:`here <qf_ferm_op-implementation>`.
+///
+/// Example
+/// -------
+///
+/// .. code-block:: c
+///     :linenos:
+///
+///     uint64_t num_terms = 2;
+///     uint64_t num_actions = 2;
+///     bool actions[2] = {true, false};
+///     uint32_t modes[2] = {0, 1};
+///     QkComplex64 coeffs[2] = {{1.0, 0.0}, {0.0, -1.0}};
+///     uint32_t boundaries[3] = {0, 0, 2};
+///     QfFermionOperator *op =
+///         qf_ferm_op_new(num_terms, num_actions, coeffs, actions, modes, boundaries);
+///
+///     QkComplex64 *boundaries_out;
+///     uint64_t *boundaries_len;
+///
+///     qf_ferm_op_get_boundaries(op, &boundaries_out, &boundaries_len);
+///
+///     assert(boundaries_len == 3);
+///
+/// @endrst
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qf_ferm_op_get_boundaries(
+    op: *const FermionOperator,
+    boundaries_out: *mut *mut usize,
+    boundaries_len: *mut u64,
+) {
+    let op = unsafe { const_ptr_as_ref(op) };
+    unsafe { boundaries_out.write(op.boundaries.as_ptr().cast_mut()) };
+    unsafe { boundaries_len.write(op.boundaries.len().try_into().unwrap()) };
+}
+
+/// @ingroup qf_ferm_op
+///
 /// @brief Constructs the additive identity operator.
 ///
 /// @return A pointer to the created operator.

--- a/crates/cext/src/operators/majorana_operator.rs
+++ b/crates/cext/src/operators/majorana_operator.rs
@@ -108,6 +108,152 @@ pub unsafe extern "C" fn qf_maj_op_free(op: *mut MajoranaOperator) {
 
 /// @ingroup qf_maj_op
 ///
+/// @brief Provides read-only access to the operator's coefficients.
+///
+/// @param op A pointer to the majorana operator whose coefficients to access.
+/// @param coeffs_out A pointer to the array of complex values into which to write the coefficients.
+/// @param coeffs_len A pointer to the integer into which to write the length of the output array.
+///
+/// @rst
+///
+/// .. note::
+///    This function returns a **copy** of the internal data.
+///
+/// .. seealso::
+///    The explanation of the internal data structure, :ref:`here <qf_maj_op-implementation>`.
+///
+/// Example
+/// -------
+///
+/// .. code-block:: c
+///     :linenos:
+///
+///     uint64_t num_terms = 2;
+///     uint64_t num_modes = 0;
+///     QkComplex64 coeffs[2] = {{1.0, 0.0}, {0.0, -1.0}};
+///     uint32_t boundaries[3] = {0, 0, 0};
+///     QfMajoranaOperator *op =
+///         qf_maj_op_new(num_terms, num_modes, coeffs, NULL, boundaries);
+///
+///     QkComplex64 *coeffs_out;
+///     uint64_t *coeffs_len;
+///
+///     qf_maj_op_get_coeffs(op, &coeffs_out, &coeffs_len);
+///
+///     assert(coeffs_len == 2);
+///
+/// @endrst
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qf_maj_op_get_coeffs(
+    op: *const MajoranaOperator,
+    coeffs_out: *mut *mut Complex64,
+    coeffs_len: *mut u64,
+) {
+    let op = unsafe { const_ptr_as_ref(op) };
+    unsafe { coeffs_out.write(op.coeffs.as_ptr().cast_mut()) };
+    unsafe { coeffs_len.write(op.coeffs.len().try_into().unwrap()) };
+}
+
+/// @ingroup qf_maj_op
+///
+/// @brief Provides read-only access to the operator's acted-upon mode indices.
+///
+/// @param op A pointer to the majorana operator whose modes to access.
+/// @param modes_out A pointer to the array of boolean values into which to write the modes.
+/// @param modes_len A pointer to the integer into which to write the length of the output array.
+///
+/// @rst
+///
+/// .. note::
+///    This function returns a **copy** of the internal data.
+///
+/// .. seealso::
+///    The explanation of the internal data structure, :ref:`here <qf_maj_op-implementation>`.
+///
+/// Example
+/// -------
+///
+/// .. code-block:: c
+///     :linenos:
+///
+///     uint64_t num_terms = 2;
+///     bool actions[2] = {true, false};
+///     uint32_t modes[2] = {0, 1};
+///     QkComplex64 coeffs[2] = {{1.0, 0.0}, {0.0, -1.0}};
+///     uint32_t boundaries[3] = {0, 0, 2};
+///     QfMajoranaOperator *op =
+///         qf_maj_op_new(num_terms, num_actions, coeffs, modes, boundaries);
+///
+///     QkComplex64 *modes_out;
+///     uint64_t *modes_len;
+///
+///     qf_maj_op_get_modes(op, &modes_out, &modes_len);
+///
+///     assert(modes_len == 2);
+///
+/// @endrst
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qf_maj_op_get_modes(
+    op: *const MajoranaOperator,
+    modes_out: *mut *mut u32,
+    modes_len: *mut u64,
+) {
+    let op = unsafe { const_ptr_as_ref(op) };
+    unsafe { modes_out.write(op.modes.as_ptr().cast_mut()) };
+    unsafe { modes_len.write(op.modes.len().try_into().unwrap()) };
+}
+
+/// @ingroup qf_maj_op
+///
+/// @brief Provides read-only access to the indices indicating the boundaries between operator terms.
+///
+/// @param op A pointer to the majorana operator whose boundaries to access.
+/// @param boundaries_out A pointer to the array of boolean values into which to write the boundaries.
+/// @param boundaries_len A pointer to the integer into which to write the length of the output array.
+///
+/// @rst
+///
+/// .. note::
+///    This function returns a **copy** of the internal data.
+///
+/// .. seealso::
+///    The explanation of the internal data structure, :ref:`here <qf_maj_op-implementation>`.
+///
+/// Example
+/// -------
+///
+/// .. code-block:: c
+///     :linenos:
+///
+///     uint64_t num_terms = 2;
+///     uint64_t num_modes = 2;
+///     uint32_t modes[2] = {0, 1};
+///     QkComplex64 coeffs[2] = {{1.0, 0.0}, {0.0, -1.0}};
+///     uint32_t boundaries[3] = {0, 0, 2};
+///     QfMajoranaOperator *op =
+///         qf_maj_op_new(num_terms, num_modes, coeffs, modes, boundaries);
+///
+///     QkComplex64 *boundaries_out;
+///     uint64_t *boundaries_len;
+///
+///     qf_maj_op_get_boundaries(op, &boundaries_out, &boundaries_len);
+///
+///     assert(boundaries_len == 3);
+///
+/// @endrst
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qf_maj_op_get_boundaries(
+    op: *const MajoranaOperator,
+    boundaries_out: *mut *mut usize,
+    boundaries_len: *mut u64,
+) {
+    let op = unsafe { const_ptr_as_ref(op) };
+    unsafe { boundaries_out.write(op.boundaries.as_ptr().cast_mut()) };
+    unsafe { boundaries_len.write(op.boundaries.len().try_into().unwrap()) };
+}
+
+/// @ingroup qf_maj_op
+///
 /// @brief Constructs the additive identity operator.
 ///
 /// @return A pointer to the created operator.

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -56,6 +56,26 @@ pub struct FermionOperator {
 crate::impl_operator_macro!(FermionOperator);
 
 impl FermionOperator {
+    #[inline]
+    pub fn coeffs(&self) -> &[Complex64] {
+        &self.coeffs
+    }
+
+    #[inline]
+    pub fn actions(&self) -> &[bool] {
+        &self.actions
+    }
+
+    #[inline]
+    pub fn modes(&self) -> &[u32] {
+        &self.modes
+    }
+
+    #[inline]
+    pub fn boundaries(&self) -> &[usize] {
+        &self.boundaries
+    }
+
     fn _append_term(&mut self, coeff: Complex64, actions: &[bool], modes: &[u32]) {
         // WARNING: this does not handle `groups` by design!
         self.coeffs.push(coeff);

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -53,6 +53,21 @@ pub struct MajoranaOperator {
 crate::impl_operator_macro!(MajoranaOperator);
 
 impl MajoranaOperator {
+    #[inline]
+    pub fn coeffs(&self) -> &[Complex64] {
+        &self.coeffs
+    }
+
+    #[inline]
+    pub fn modes(&self) -> &[u32] {
+        &self.modes
+    }
+
+    #[inline]
+    pub fn boundaries(&self) -> &[usize] {
+        &self.boundaries
+    }
+
     fn _append_term(&mut self, coeff: Complex64, modes: &[u32]) {
         // WARNING: this does not handle `groups` by design!
         self.coeffs.push(coeff);

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -76,6 +76,8 @@ impl FermionOperatorDataIter {
 ///
 /// ----
 ///
+/// .. _FermionOperator-implementation:
+///
 /// Implementation
 /// ==============
 ///
@@ -95,6 +97,10 @@ impl FermionOperatorDataIter {
 ///
 /// Entries in ``actions`` indicate creation (annihilation) operators by ``True`` (``False``).
 /// Fermionic modes indexed by ``modes`` are considered spinless.
+///
+/// .. note::
+///    You may access **read-only copies** of these internal arrays via their respective methods:
+///    :meth:`.get_coeffs`, :meth:`.get_actions`, :meth:`.get_modes`, and :meth:`.get_boundaries`.
 ///
 /// This data structure allows for very efficient construction and manipulation of operators.
 /// However, it implies that duplicate terms may be contained in an operator at any moment.
@@ -367,6 +373,98 @@ impl PyFermionOperator {
                 groups: None,
             },
         }
+    }
+
+    /// Returns a read-only list of the operator's coefficients.
+    ///
+    /// .. note::
+    ///    This method returns a **copy** of the internal data.
+    ///
+    /// .. seealso::
+    ///    The explanation of the internal data structure,
+    ///    :ref:`here <FermionOperator-implementation>`.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator.one()
+    ///     >>> op += -1j * FermionOperator.one()
+    ///     >>> op.get_coeffs()
+    ///     [(1+0j), -1j]
+    ///
+    /// Returns:
+    ///     A list of the operator's coefficients.
+    fn get_coeffs(&self) -> Vec<Complex64> {
+        self.inner.coeffs().to_vec()
+    }
+
+    /// Returns a read-only list of the operator's actions.
+    ///
+    /// .. note::
+    ///    This method returns a **copy** of the internal data.
+    ///
+    /// .. seealso::
+    ///    The explanation of the internal data structure,
+    ///    :ref:`here <FermionOperator-implementation>`.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator.one()
+    ///     >>> op += FermionOperator.from_dict({((True, 0), (False, 1)): 1.0})
+    ///     >>> op.get_actions()
+    ///     [True, False]
+    ///
+    /// Returns:
+    ///     A list of the operator's actions.
+    fn get_actions(&self) -> Vec<bool> {
+        self.inner.actions().to_vec()
+    }
+
+    /// Returns a read-only list of the operator's acted-upon mode indices.
+    ///
+    /// .. note::
+    ///    This method returns a **copy** of the internal data.
+    ///
+    /// .. seealso::
+    ///    The explanation of the internal data structure,
+    ///    :ref:`here <FermionOperator-implementation>`.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator.one()
+    ///     >>> op += FermionOperator.from_dict({((True, 0), (False, 1)): 1.0})
+    ///     >>> op.get_modes()
+    ///     [0, 1]
+    ///
+    /// Returns:
+    ///     A list of the operator's modes.
+    fn get_modes(&self) -> Vec<u32> {
+        self.inner.modes().to_vec()
+    }
+
+    /// Returns a read-only list of the indices indicating the boundaries between operator terms.
+    ///
+    /// .. note::
+    ///    This method returns a **copy** of the internal data.
+    ///
+    /// .. seealso::
+    ///    The explanation of the internal data structure,
+    ///    :ref:`here <FermionOperator-implementation>`.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator.one()
+    ///     >>> op += FermionOperator.from_dict({((True, 0), (False, 1)): 1.0})
+    ///     >>> op.get_boundaries()
+    ///     [0, 0, 2]
+    ///
+    /// Returns:
+    ///     A list of the operator's terms boundaries.
+    fn get_boundaries(&self) -> Vec<usize> {
+        self.inner.boundaries().to_vec()
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, _py: Python<'_>) -> PyResult<bool> {

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -83,6 +83,8 @@ impl MajoranaOperatorDataIter {
 ///
 /// ----
 ///
+/// .. _MajoranaOperator-implementation:
+///
 /// Implementation
 /// ==============
 ///
@@ -101,6 +103,10 @@ impl MajoranaOperatorDataIter {
 ///
 /// The integers in ``modes`` index the Majorana modes, :math:`j`. When using the convenience
 /// function :py:func:`.gamma`, even (odd) indices are used for :math`\gamma` (:math:`\gamma'`).
+///
+/// .. note::
+///    You may access **read-only copies** of these internal arrays via their respective methods:
+///    :meth:`.get_coeffs`, :meth:`.get_modes`, and :meth:`.get_boundaries`.
 ///
 /// This data structure allows for very efficient construction and manipulation of operators.
 /// However, it implies that duplicate terms may be contained in an operator at any moment.
@@ -360,6 +366,75 @@ impl PyMajoranaOperator {
                 groups: None,
             },
         }
+    }
+
+    /// Returns a read-only list of the operator's coefficients.
+    ///
+    /// .. note::
+    ///    This method returns a *copy* of the internal data.
+    ///
+    /// .. seealso::
+    ///    The explanation of the internal data structure,
+    ///    :ref:`here <MajoranaOperator-implementation>`.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import MajoranaOperator
+    ///     >>> op = MajoranaOperator.one()
+    ///     >>> op += -1j * MajoranaOperator.one()
+    ///     >>> op.get_coeffs()
+    ///     [(1+0j), -1j]
+    ///
+    /// Returns:
+    ///     A list of the operator's coefficients.
+    fn get_coeffs(&self) -> Vec<Complex64> {
+        self.inner.coeffs().to_vec()
+    }
+
+    /// Returns a read-only list of the operator's acted-upon mode indices.
+    ///
+    /// .. note::
+    ///    This method returns a **copy** of the internal data.
+    ///
+    /// .. seealso::
+    ///    The explanation of the internal data structure,
+    ///    :ref:`here <MajoranaOperator-implementation>`.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import MajoranaOperator
+    ///     >>> op = MajoranaOperator.one()
+    ///     >>> op += MajoranaOperator.from_dict({(0, 1): 1.0})
+    ///     >>> op.get_modes()
+    ///     [0, 1]
+    ///
+    /// Returns:
+    ///     A list of the operator's modes.
+    fn get_modes(&self) -> Vec<u32> {
+        self.inner.modes().to_vec()
+    }
+
+    /// Returns a read-only list of the indices indicating the boundaries between operator terms.
+    ///
+    /// .. note::
+    ///    This method returns a **copy** of the internal data.
+    ///
+    /// .. seealso::
+    ///    The explanation of the internal data structure,
+    ///    :ref:`here <MajoranaOperator-implementation>`.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import MajoranaOperator
+    ///     >>> op = MajoranaOperator.one()
+    ///     >>> op += MajoranaOperator.from_dict({(0, 1): 1.0})
+    ///     >>> op.get_boundaries()
+    ///     [0, 0, 2]
+    ///
+    /// Returns:
+    ///     A list of the operator's terms boundaries.
+    fn get_boundaries(&self) -> Vec<usize> {
+        self.inner.boundaries().to_vec()
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, _py: Python<'_>) -> PyResult<bool> {

--- a/docs/cdoc/qf-ferm-op.rst
+++ b/docs/cdoc/qf-ferm-op.rst
@@ -40,6 +40,8 @@ and the number of fermionic modes acted upon by the operator minus 1.
 
 ----
 
+.. _qf_ferm_op-implementation:
+
 Implementation
 ==============
 
@@ -59,6 +61,14 @@ commonly used for sparse matrices. More concretely, a single operator contains 4
 
 Entries in ``actions`` indicate creation (annihilation) operators by ``True`` (``False``).
 Fermionic modes indexed by ``modes`` are considered spinless.
+
+.. note::
+   You may access **read-only copies** of these internal arrays via their respective functions:
+
+   - :c:func:`qf_ferm_op_get_coeffs`
+   - :c:func:`qf_ferm_op_get_actions`
+   - :c:func:`qf_ferm_op_get_modes`
+   - :c:func:`qf_ferm_op_get_boundaries`
 
 This data structure allows for very efficient construction and manipulation of operators.
 However, it implies that duplicate terms may be contained in an operator at any moment.

--- a/docs/cdoc/qf-maj-op.rst
+++ b/docs/cdoc/qf-maj-op.rst
@@ -47,6 +47,8 @@ fermionic modes acted upon by the operator minus 1.
 
 ----
 
+.. _qf_maj_op-implementation:
+
 Implementation
 ==============
 
@@ -65,6 +67,13 @@ commonly used for sparse matrices. More concretely, a single operator contains 4
 
 The integers in ``modes`` index the Majorana modes, :math:`j`. When using the convenience
 function :py:func:`.gamma`, even (odd) indices are used for :math`\gamma` (:math:`\gamma'`).
+
+.. note::
+   You may access **read-only copies** of these internal arrays via their respective functions:
+
+   - :c:func:`qf_maj_op_get_coeffs`
+   - :c:func:`qf_maj_op_get_modes`
+   - :c:func:`qf_maj_op_get_boundaries`
 
 This data structure allows for very efficient construction and manipulation of operators.
 However, it implies that duplicate terms may be contained in an operator at any moment.

--- a/tests/c/test_fermion_operator.c
+++ b/tests/c/test_fermion_operator.c
@@ -50,6 +50,60 @@ static int test_new(void) {
     return Ok;
 }
 
+static int test_getters(void) {
+    uint64_t num_terms = 3;
+    uint64_t num_actions = 4;
+    bool actions[4] = {true, false, true, false};
+    uint32_t modes[4] = {0, 1, 2, 3};
+    QkComplex64 coeffs[3] = {{1.0, 0.0}, {-1.0, 0.0}, {0.0, -1.0}};
+    uint32_t boundaries[4] = {0, 0, 2, 4};
+    QfFermionOperator *op =
+        qf_ferm_op_new(num_terms, num_actions, coeffs, actions, modes, boundaries);
+
+    bool passed_all = true;
+
+    QkComplex64 *coeffs_out;
+    uint64_t coeffs_len;
+    qf_ferm_op_get_coeffs(op, &coeffs_out, &coeffs_len);
+    passed_all = passed_all && (coeffs_len == num_terms);
+
+    for (uint64_t i = 0; i < num_terms; i++) {
+        passed_all = passed_all && (coeffs_out[i].re == coeffs[i].re);
+        passed_all = passed_all && (coeffs_out[i].im == coeffs[i].im);
+    }
+
+    bool *actions_out;
+    uint64_t actions_len;
+    qf_ferm_op_get_actions(op, &actions_out, &actions_len);
+    passed_all = passed_all && (actions_len == num_actions);
+
+    uint32_t *modes_out;
+    uint64_t modes_len;
+    qf_ferm_op_get_modes(op, &modes_out, &modes_len);
+    passed_all = passed_all && (modes_len == num_actions);
+
+    for (uint64_t i = 0; i < num_actions; i++) {
+        passed_all = passed_all && (actions_out[i] == actions[i]);
+        passed_all = passed_all && (modes_out[i] == modes[i]);
+    }
+
+    size_t *boundaries_out;
+    uint64_t boundaries_len;
+    qf_ferm_op_get_boundaries(op, &boundaries_out, &boundaries_len);
+    passed_all = passed_all && (boundaries_len == 4);
+
+    for (uint64_t i = 0; i < 4; i++) {
+        passed_all = passed_all && (boundaries_out[i] == boundaries[i]);
+    }
+
+    qf_ferm_op_free(op);
+
+    if (!passed_all) {
+        return EqualityError;
+    }
+    return Ok;
+}
+
 static int test_add(void) {
     QfFermionOperator *zero = qf_ferm_op_zero();
     QfFermionOperator *one = qf_ferm_op_one();
@@ -617,6 +671,7 @@ static int test_groups(void) {
 int test_fermion_operator(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_new);
+    num_failed += RUN_TEST(test_getters);
     num_failed += RUN_TEST(test_add);
     num_failed += RUN_TEST(test_add_term);
     num_failed += RUN_TEST(test_equiv_pos);

--- a/tests/c/test_majorana_operator.c
+++ b/tests/c/test_majorana_operator.c
@@ -45,6 +45,52 @@ static int test_new(void) {
     return Ok;
 }
 
+static int test_getters(void) {
+    uint64_t num_terms = 3;
+    uint64_t num_modes = 4;
+    uint32_t modes[4] = {0, 1, 2, 3};
+    QkComplex64 coeffs[3] = {{1.0, 0.0}, {-1.0, 0.0}, {0.0, -1.0}};
+    uint32_t boundaries[4] = {0, 0, 2, 4};
+    QfMajoranaOperator *op = qf_maj_op_new(num_terms, num_modes, coeffs, modes, boundaries);
+
+    bool passed_all = true;
+
+    QkComplex64 *coeffs_out;
+    uint64_t coeffs_len;
+    qf_maj_op_get_coeffs(op, &coeffs_out, &coeffs_len);
+    passed_all = passed_all && (coeffs_len == num_terms);
+
+    for (uint64_t i = 0; i < num_terms; i++) {
+        passed_all = passed_all && (coeffs_out[i].re == coeffs[i].re);
+        passed_all = passed_all && (coeffs_out[i].im == coeffs[i].im);
+    }
+
+    uint32_t *modes_out;
+    uint64_t modes_len;
+    qf_maj_op_get_modes(op, &modes_out, &modes_len);
+    passed_all = passed_all && (modes_len == num_modes);
+
+    for (uint64_t i = 0; i < num_modes; i++) {
+        passed_all = passed_all && (modes_out[i] == modes[i]);
+    }
+
+    size_t *boundaries_out;
+    uint64_t boundaries_len;
+    qf_maj_op_get_boundaries(op, &boundaries_out, &boundaries_len);
+    passed_all = passed_all && (boundaries_len == 4);
+
+    for (uint64_t i = 0; i < 4; i++) {
+        passed_all = passed_all && (boundaries_out[i] == boundaries[i]);
+    }
+
+    qf_maj_op_free(op);
+
+    if (!passed_all) {
+        return EqualityError;
+    }
+    return Ok;
+}
+
 static int test_add(void) {
     QfMajoranaOperator *zero = qf_maj_op_zero();
     QfMajoranaOperator *one = qf_maj_op_one();
@@ -529,6 +575,7 @@ static int test_groups(void) {
 int test_majorana_operator(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_new);
+    num_failed += RUN_TEST(test_getters);
     num_failed += RUN_TEST(test_add);
     num_failed += RUN_TEST(test_add_term);
     num_failed += RUN_TEST(test_equiv_pos);

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -12,6 +12,7 @@
 
 from abc import ABC, abstractmethod
 
+import numpy as np
 import pytest
 from qiskit_fermions.operators import FermionOperator, ann, cre
 from qiskit_fermions.operators.library import anti_commutator, commutator
@@ -21,6 +22,25 @@ class FermionOperatorTests(ABC):
     @staticmethod
     @abstractmethod
     def get_class() -> type[FermionOperator]: ...
+
+    def test_getters(self, subtests):
+        cls = self.get_class()
+
+        coeffs = [1e-10, 2, 3, 4, -4]
+        actions = [True, True, False, False]
+        modes = [0, 0, 1, 1]
+        boundaries = [0, 0, 1, 2, 3, 4]
+
+        op = cls(coeffs, actions, modes, boundaries)
+
+        with subtests.test("coeffs"):
+            assert np.allclose(op.get_coeffs(), coeffs)
+        with subtests.test("actions"):
+            assert np.all(op.get_actions() == actions)
+        with subtests.test("modes"):
+            assert np.all(op.get_modes() == modes)
+        with subtests.test("boundaries"):
+            assert np.all(op.get_boundaries() == boundaries)
 
     def test_zero(self):
         cls = self.get_class()

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -12,6 +12,7 @@
 
 from abc import ABC, abstractmethod
 
+import numpy as np
 import pytest
 from qiskit_fermions.operators import MajoranaOperator, gamma
 from qiskit_fermions.operators.library import anti_commutator, commutator
@@ -21,6 +22,22 @@ class MajoranaOperatorTests(ABC):
     @staticmethod
     @abstractmethod
     def get_class() -> type[MajoranaOperator]: ...
+
+    def test_getters(self, subtests):
+        cls = self.get_class()
+
+        coeffs = [1e-10, 2, 3, 4, -4]
+        modes = [0, 0, 1, 1]
+        boundaries = [0, 0, 1, 2, 3, 4]
+
+        op = cls(coeffs, modes, boundaries)
+
+        with subtests.test("coeffs"):
+            assert np.allclose(op.get_coeffs(), coeffs)
+        with subtests.test("modes"):
+            assert np.all(op.get_modes() == modes)
+        with subtests.test("boundaries"):
+            assert np.all(op.get_boundaries() == boundaries)
 
     def test_zero(self):
         cls = self.get_class()


### PR DESCRIPTION
To give users more flexibility and power to implement custom logic around our operators, we should consider exposing the internal arrays of our operator classes to the public APIs.

Specifically, this will make prototyping/implementing a simple storing functionality (#42) very easy, by simply dumping and loading the arrays to `.npz` archives.

---

Before merging, we should consider a few things:
- Is this something we want to keep long-term or should mark as unstable API that may be removed on short notice in the future?
    - **YES** since there are several use cases where getting access to (e.g.) the acted-upon indices an easy to parse format can be very useful (for example consider figuring out the set of mode indices that an operator has support on; this would be annoying to extract manually by iterating the terms versus just accessing a read-only copy of the internal operator array).
- I don't think we should expose property `setter` functions because this is more likely to break the internal data structure. But I may be convinced otherwise if a good argument and use case can be brought forward.
    - This PR now provides read-only copies of the internal data, as simple lists rather than numpy arrays.
- What about exposing these arrays to the C API? Shall this be done in this PR or separately?
    - Now included in this PR.

---

Definite TODOs for this PR:
- [x] Can we resolve the `pyo3-stub-gen` issue with non-numpy-scalar values (`usize` and `bool`)?
- [x] Document the getter methods in the Python API docs.