### PR TITLE
upgrade pyo3-stub-gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -1028,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.1.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen"
-version = "0.20.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e2b9e475ac67c249ef794033ac3cf25a3216fbe5fe4b80cd82ab5a84d88485"
+checksum = "8933f5816871707ba1379189c9fe3ae3511403fc9564914fb085b7686160529f"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1235,14 +1235,14 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
 name = "pyo3-stub-gen-derive"
-version = "0.20.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11633044267957aeda9569863a3a57b3aa2aeebc7144439423c1ddde3d00d887"
+checksum = "d085a7cb2c2a8aa9b660abfbdbb456b2e0872090158398d0524a3a2ae38f0ab0"
 dependencies = [
  "heck",
  "indexmap",
@@ -1582,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1754,14 +1754,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.0",
@@ -1778,27 +1778,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ paste = "1.0"
 # it disabled for Rust-only tests to avoid linker errors with it not being loaded.  See
 # https://pyo3.rs/main/features#extension-module for more.
 pyo3 = { version = "0.27", features = ["abi3-py310", "multiple-pymethods", "num-complex"] }
-pyo3-stub-gen = "0.20"
+pyo3-stub-gen = "0.22"
 rayon = "1.11"
 regex = "1.12"
 thiserror = "2.0"

--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -36,7 +36,7 @@ pub fn stub_info() -> Result<StubInfo> {
 
     let manifest_dir: &::std::path::Path = env!("CARGO_MANIFEST_DIR").as_ref();
     StubInfo::from_project_root(
-        "qiskit_fermions._lib".to_string(),
+        "qiskit_fermions".to_string(),
         manifest_dir.join("../../python"),
         true,
         config,


### PR DESCRIPTION
`pyo3-stub-gen` released [0.21](https://github.com/Jij-Inc/pyo3-stub-gen/releases/tag/0.21.0) today which introduced several changes around their `__init__.pyi` handling. I wanted to play with this a bit and am not sure how to best handle this yet.

The current state of this PR simply changes the root-level module-name to claim to be `qiskit_fermions` rather than `qiskit_fermions._lib` despite the fact that the compiled code _does_ land inside `qiskit_fermions._lib`. We just manually re-export the various functions and classes from our Python module structure anyways.

This seems to work just like before and all is fine without any additional changes. However, we still end up with the parallel `__init__.py` and `__init__.pyi` files but as part of #52 I had figured out how to make the type checker happy (simply by using `TYPE_CHECKING` guards and actually importing from `qiskit_fermions._lib` directly).

That said, I did play a bit with leaving `qiskit_fermions._lib` in the `stub_info` function. That resulted in having to update all the `module` arguments to the `#[pyclass]` and `#[pyfunction]` attributes. This in turn means:
- all the `__init__.pyi` files will end up in a nested structure inside of `qiskit_fermions/_lib` (which resolves the mirrored `__init__.{py,pyi}` files
- the import paths of our functions and classes will _show_ the `qiskit_fermions._lib.*` location rather than the re-exported one (which is not ideal imo)
- this resulted in a new (and somewhat different) type checker errors which I did not manage to resolve (but I also only spend a few minutes on this though)

----

In summary: the current state of the PR _should_ allow us to upgrade and simply "continue as is" and everything appears to work. I'm not sure whether this is a "hacky" solution though and we should rather spend some time in figuring out a more proper solution :thinking: 