### PR TITLE
ci: use pip install --no-build-isolation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -76,9 +76,7 @@ jobs:
         run: |
           pip install --pre qiskit
           pip install --group build --group coverage
-          export QISKIT_LIB=$(python -c "import qiskit; print(qiskit.capi.get_lib())")
-          export QISKIT_INCLUDE=$(python -c "import qiskit; print(qiskit.capi.get_include())")
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e .
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e .
 
       - name: Python coverage
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,9 +55,7 @@ jobs:
         run: |
           pip install --pre qiskit
           pip install --group build --group docs
-          export QISKIT_LIB=$(python -c "import qiskit; print(qiskit.capi.get_lib())")
-          export QISKIT_INCLUDE=$(python -c "import qiskit; print(qiskit.capi.get_include())")
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e .
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e .
 
       - name: Build docs
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,9 +46,7 @@ jobs:
         run: |
           pip install --pre qiskit
           pip install --group build --group lint
-          export QISKIT_LIB=$(python -c "import qiskit; print(qiskit.capi.get_lib())")
-          export QISKIT_INCLUDE=$(python -c "import qiskit; print(qiskit.capi.get_include())")
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e .
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e .
 
       - name: Run lint check
         shell: bash

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -108,9 +108,7 @@ jobs:
         run: |
           pip install --pre qiskit
           pip install --group build --group coverage
-          export QISKIT_LIB=$(python -c "import qiskit; print(qiskit.capi.get_lib())")
-          export QISKIT_INCLUDE=$(python -c "import qiskit; print(qiskit.capi.get_include())")
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e .
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e .
 
       - name: Python tests
         if: ${{ matrix.os != 'windows-latest' }}

--- a/docs/install-py.rst
+++ b/docs/install-py.rst
@@ -21,26 +21,12 @@ simple:
 
       $ pip install --group build
 
-3. Configure your shell environment with the location of your Qiskit
-   installation.
-
-   .. hint::
-      You _may_ be able to skip this step, depending on how ``pip`` resolves the
-      location of the installed Qiskit during the build process. If you _do_ try
-      to skip this step and obtain an error that the ``_accelerate.*.so``
-      library cannot be found, ensure that you set these environment variables
-      before trying the next step again.
+3. Install the ``qiskit-fermions`` Python package into your environment with
+   ``--no-build-isolation`` to ensure that ``qiskit`` is available correctly:
 
    .. code:: console
 
-      $ export QISKIT_LIB=$(python -c "import qiskit; print(qiskit.capi.get_lib())")
-      $ export QISKIT_INCLUDE=$(python -c "import qiskit; print(qiskit.capi.get_include())")
-
-4. Install the ``qiskit-fermions`` Python package into your environment:
-
-   .. code:: console
-
-      $ pip install .
+      $ pip install --no-build-isolation .
 
    .. hint::
 
@@ -49,7 +35,7 @@ simple:
 
       .. code:: console
 
-         $ SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e .
+         $ SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e .
 
 5. (optional) Verify the installation by running the Python unittests:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@
 requires = [
     "setuptools>=77.0",
     "setuptools-rust",
-    "qiskit==2.4.0rc3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -38,7 +37,6 @@ dependencies = [
 build = [
     "setuptools>=77.0",
     "setuptools-rust",
-    "qiskit==2.4.0rc3",
 ]
 style = [
     "ruff==0.15.8",


### PR DESCRIPTION
This allows us to rely on qiskit already installed inside the Python environment and build qiskit-fermions within that environment rather than an isolated build env. This in turns gives us runtime-access to the QISKIT_LIB and QISKIT_INCLUDE locations without requiring the user to have to specify these env vars.

Closes #70 