### PR TITLE
fix: correct order of operations inside majorana <> fermion mapping

### DIFF
--- a/crates/core/src/mappers/library/majorana_fermion.rs
+++ b/crates/core/src/mappers/library/majorana_fermion.rs
@@ -12,7 +12,7 @@
 
 use num_complex::Complex64;
 
-use crate::operators::OperatorTrait;
+use crate::operators::{OperatorMacro, OperatorTrait};
 use crate::operators::fermion_operator::{FermionAction, FermionOperator};
 use crate::operators::majorana_operator::{MajoranaAction, MajoranaOperator};
 
@@ -34,7 +34,7 @@ pub fn fermion_to_majorana(fer_op: &FermionOperator) -> MajoranaOperator {
         let mut mapped_term = MajoranaOperator::one();
 
         term.iter()
-            .for_each(|action| mapped_term.__iand__(&map_fermion_action(action)));
+            .for_each(|action| mapped_term = map_fermion_action(action).__and__(&mapped_term));
 
         mapped_term.__imul__(term.coeff);
 
@@ -68,7 +68,7 @@ pub fn majorana_to_fermion(maj_op: &MajoranaOperator) -> FermionOperator {
         let mut mapped_term = FermionOperator::one();
 
         term.iter()
-            .for_each(|action| mapped_term.__iand__(&map_majorana_action(action)));
+            .for_each(|action| mapped_term = map_majorana_action(action).__and__(&mapped_term));
 
         mapped_term.__imul__(term.coeff);
 
@@ -141,7 +141,7 @@ mod tests {
         let canon = normal.simplify(1e-8);
 
         let expected = MajoranaOperator {
-            coeffs: vec![Complex64::new(0.5, 0.0), Complex64::new(0.0, 0.5)],
+            coeffs: vec![Complex64::new(0.5, 0.0), Complex64::new(0.0, -0.5)],
             modes: vec![1, 0],
             boundaries: vec![0, 0, 2],
             groups: None,
@@ -165,7 +165,7 @@ mod tests {
         let canon = normal.simplify(1e-8);
 
         let expected = MajoranaOperator {
-            coeffs: vec![Complex64::new(0.0, 0.5), Complex64::new(0.0, -0.5)],
+            coeffs: vec![Complex64::new(0.0, -0.5), Complex64::new(0.0, 0.5)],
             modes: vec![3, 0, 2, 1],
             boundaries: vec![0, 2, 4],
             groups: None,
@@ -232,7 +232,7 @@ mod tests {
         let canon = normal.simplify(1e-8);
 
         let expected = FermionOperator {
-            coeffs: vec![Complex64::new(0.0, -1.0), Complex64::new(0.0, 2.0)],
+            coeffs: vec![Complex64::new(0.0, 1.0), Complex64::new(0.0, -2.0)],
             actions: vec![true, false],
             modes: vec![0, 0],
             boundaries: vec![0, 0, 2],
@@ -256,7 +256,7 @@ mod tests {
         let canon = normal.simplify(1e-8);
 
         let expected = FermionOperator {
-            coeffs: vec![Complex64::new(0.0, 2.0), Complex64::new(0.0, 2.0)],
+            coeffs: vec![Complex64::new(0.0, -2.0), Complex64::new(0.0, -2.0)],
             actions: vec![true, false, true, false],
             modes: vec![0, 1, 1, 0],
             boundaries: vec![0, 2, 4],

--- a/crates/pyext/src/mappers/library/majorana_fermion.rs
+++ b/crates/pyext/src/mappers/library/majorana_fermion.rs
@@ -54,7 +54,7 @@ use qiskit_fermions_core::mappers::library::majorana_fermion::{
 ///     >>> maj_op = fermion_to_majorana(fer_op)
 ///     >>> print(maj_op.normal_ordered().simplify())
 ///      5.000000e-1 +0.000000e0j * ()
-///      0.000000e0+5.000000e-1j * (1 0)
+///      0.000000e0-5.000000e-1j * (1 0)
 ///
 /// ..
 #[gen_stub_pyfunction(module = "qiskit_fermions.mappers.library.majorana")]
@@ -99,8 +99,8 @@ pub fn py_fermion_to_majorana(fer_op: PyFermionOperator) -> PyMajoranaOperator {
 ///     >>> maj_op = MajoranaOperator.from_dict({(0, 1): 1})
 ///     >>> fer_op = majorana_to_fermion(maj_op)
 ///     >>> print(fer_op.normal_ordered().simplify())
-///      0.000000e0 -1.000000e0j * ()
-///      0.000000e0 +2.000000e0j * (+_0 -_0)
+///      0.000000e0 +1.000000e0j * ()
+///      0.000000e0 -2.000000e0j * (+_0 -_0)
 ///
 /// ..
 #[gen_stub_pyfunction(module = "qiskit_fermions.mappers.library.majorana")]

--- a/tests/c/test_majorana_fermion.c
+++ b/tests/c/test_majorana_fermion.c
@@ -29,7 +29,7 @@ static int test_fermion_to_majorana(void) {
     uint64_t num_terms = 2;
     uint64_t num_modes = 2;
     uint32_t modes[2] = {1, 0};
-    QkComplex64 exp_coeffs[2] = {{0.5, 0.0}, {0.0, 0.5}};
+    QkComplex64 exp_coeffs[2] = {{0.5, 0.0}, {0.0, -0.5}};
     uint32_t boundaries[3] = {0, 0, 2};
     QfMajoranaOperator *expected =
         qf_maj_op_new(num_terms, num_modes, exp_coeffs, modes, boundaries);
@@ -60,7 +60,7 @@ static int test_majorana_to_fermion(void) {
     uint64_t num_actions = 2;
     bool actions[2] = {true, false};
     uint32_t modes[2] = {0, 0};
-    QkComplex64 exp_coeffs[2] = {{0.0, -1.0}, {0.0, 2.0}};
+    QkComplex64 exp_coeffs[2] = {{0.0, 1.0}, {0.0, -2.0}};
     uint32_t boundaries[3] = {0, 0, 2};
     QfFermionOperator *expected =
         qf_ferm_op_new(num_terms, num_actions, exp_coeffs, actions, modes, boundaries);

--- a/tests/python/mappers/library/test_majorana_fermion.py
+++ b/tests/python/mappers/library/test_majorana_fermion.py
@@ -18,7 +18,7 @@ def test_fermion_to_majorana():
     fer_op = FermionOperator.from_dict({((True, 0), (False, 0)): 1})
     maj_op = fermion_to_majorana(fer_op)
     canon = maj_op.normal_ordered()
-    expected = MajoranaOperator.from_dict({(): 0.5, (1, 0): 0.5j})
+    expected = MajoranaOperator.from_dict({(): 0.5, (1, 0): -0.5j})
     assert canon.equiv(expected)
 
 
@@ -26,5 +26,5 @@ def test_majorana_to_fermion():
     maj_op = MajoranaOperator.from_dict({(0, 1): 1})
     fer_op = majorana_to_fermion(maj_op)
     canon = fer_op.normal_ordered()
-    expected = FermionOperator.from_dict({(): -1j, ((True, 0), (False, 0)): 2j})
+    expected = FermionOperator.from_dict({(): 1j, ((True, 0), (False, 0)): -2j})
     assert canon.equiv(expected)


### PR DESCRIPTION
The mapping functions to convert between Majorana and Fermion operators incorrectly ordered the individual actions within each term, resulting in wrong signs of the expected outcomes. The unittests actually hard-coded faulty expected outcomes which this commit addresses.

Closes #77