### PR TITLE
feat: implement right-multiplication for operators

### DIFF
--- a/crates/core/src/mappers/library/majorana_fermion.rs
+++ b/crates/core/src/mappers/library/majorana_fermion.rs
@@ -12,7 +12,7 @@
 
 use num_complex::Complex64;
 
-use crate::operators::{OperatorMacro, OperatorTrait};
+use crate::operators::OperatorTrait;
 use crate::operators::fermion_operator::{FermionAction, FermionOperator};
 use crate::operators::majorana_operator::{MajoranaAction, MajoranaOperator};
 
@@ -34,7 +34,7 @@ pub fn fermion_to_majorana(fer_op: &FermionOperator) -> MajoranaOperator {
         let mut mapped_term = MajoranaOperator::one();
 
         term.iter()
-            .for_each(|action| mapped_term = map_fermion_action(action).__and__(&mapped_term));
+            .for_each(|action| mapped_term.__imatmul__(&map_fermion_action(action)));
 
         mapped_term.__imul__(term.coeff);
 
@@ -68,7 +68,7 @@ pub fn majorana_to_fermion(maj_op: &MajoranaOperator) -> FermionOperator {
         let mut mapped_term = FermionOperator::one();
 
         term.iter()
-            .for_each(|action| mapped_term = map_majorana_action(action).__and__(&mapped_term));
+            .for_each(|action| mapped_term.__imatmul__(&map_majorana_action(action)));
 
         mapped_term.__imul__(term.coeff);
 

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -233,6 +233,28 @@ fn _normal_ordered_term(term_view: FermionOperatorTermView) -> FermionOperator {
     }
 }
 
+fn _compose(
+    a: &FermionOperator,
+    b: &FermionOperator,
+) -> (Vec<Complex64>, Vec<bool>, Vec<u32>, Vec<usize>) {
+    let mut coeffs = vec![];
+    let mut actions = vec![];
+    let mut modes = vec![];
+    let mut boundaries = vec![0];
+
+    for left in a.iter() {
+        for right in b.iter() {
+            coeffs.push(left.coeff * right.coeff);
+            actions.extend_from_slice(right.actions);
+            actions.extend_from_slice(left.actions);
+            modes.extend_from_slice(right.modes);
+            modes.extend_from_slice(left.modes);
+            boundaries.push(modes.len());
+        }
+    }
+    (coeffs, actions, modes, boundaries)
+}
+
 impl OperatorTrait for FermionOperator {
     fn zero() -> Self {
         Self {
@@ -300,26 +322,12 @@ impl OperatorTrait for FermionOperator {
     }
 
     fn __iand__(&mut self, other: &Self) {
-        let mut coeffs = vec![];
-        let mut actions = vec![];
-        let mut modes = vec![];
-        let mut boundaries = vec![0];
+        (self.coeffs, self.actions, self.modes, self.boundaries) = _compose(self, other);
+        self.groups = None;
+    }
 
-        for left in self.iter() {
-            for right in other.iter() {
-                coeffs.push(left.coeff * right.coeff);
-                actions.extend_from_slice(right.actions);
-                actions.extend_from_slice(left.actions);
-                modes.extend_from_slice(right.modes);
-                modes.extend_from_slice(left.modes);
-                boundaries.push(modes.len());
-            }
-        }
-
-        self.coeffs = coeffs;
-        self.actions = actions;
-        self.modes = modes;
-        self.boundaries = boundaries;
+    fn __imatmul__(&mut self, other: &Self) {
+        (self.coeffs, self.actions, self.modes, self.boundaries) = _compose(other, self);
         self.groups = None;
     }
 
@@ -632,6 +640,74 @@ mod tests {
         op1 &= op2;
         assert_eq!(
             op1,
+            FermionOperator {
+                coeffs: vec![
+                    Complex64::new(3.0, 0.0),
+                    Complex64::new(8.0, 0.0),
+                    Complex64::new(4.5, 0.0),
+                    Complex64::new(12.0, 0.0),
+                ],
+                actions: vec![true, false, true, false, true, false, true, false],
+                modes: vec![1, 0, 0, 1, 1, 0, 0, 1],
+                boundaries: vec![0, 0, 2, 4, 8],
+                groups: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_matmul() {
+        let op1 = FermionOperator {
+            coeffs: vec![Complex64::new(2.0, 0.0), Complex64::new(3.0, 0.0)],
+            actions: vec![true, false],
+            modes: vec![0, 1],
+            boundaries: vec![0, 0, 2],
+            groups: None,
+        };
+        let op2 = FermionOperator {
+            coeffs: vec![Complex64::new(1.5, 0.0), Complex64::new(4.0, 0.0)],
+            actions: vec![true, false],
+            modes: vec![1, 0],
+            boundaries: vec![0, 0, 2],
+            groups: None,
+        };
+        let result = op2.__matmul__(&op1);
+        assert_eq!(
+            result,
+            FermionOperator {
+                coeffs: vec![
+                    Complex64::new(3.0, 0.0),
+                    Complex64::new(8.0, 0.0),
+                    Complex64::new(4.5, 0.0),
+                    Complex64::new(12.0, 0.0),
+                ],
+                actions: vec![true, false, true, false, true, false, true, false],
+                modes: vec![1, 0, 0, 1, 1, 0, 0, 1],
+                boundaries: vec![0, 0, 2, 4, 8],
+                groups: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_matmul_assign() {
+        let op1 = FermionOperator {
+            coeffs: vec![Complex64::new(2.0, 0.0), Complex64::new(3.0, 0.0)],
+            actions: vec![true, false],
+            modes: vec![0, 1],
+            boundaries: vec![0, 0, 2],
+            groups: None,
+        };
+        let mut op2 = FermionOperator {
+            coeffs: vec![Complex64::new(1.5, 0.0), Complex64::new(4.0, 0.0)],
+            actions: vec![true, false],
+            modes: vec![1, 0],
+            boundaries: vec![0, 0, 2],
+            groups: None,
+        };
+        op2.__imatmul__(&op1);
+        assert_eq!(
+            op2,
             FermionOperator {
                 coeffs: vec![
                     Complex64::new(3.0, 0.0),

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -252,6 +252,25 @@ fn reduce_pairs(tpl: &[u32]) -> Vec<u32> {
     reduced
 }
 
+fn _compose(
+    a: &MajoranaOperator,
+    b: &MajoranaOperator,
+) -> (Vec<Complex64>, Vec<u32>, Vec<usize>) {
+    let mut coeffs = vec![];
+    let mut modes = vec![];
+    let mut boundaries = vec![0];
+
+    for left in a.iter() {
+        for right in b.iter() {
+            coeffs.push(left.coeff * right.coeff);
+            modes.extend_from_slice(right.modes);
+            modes.extend_from_slice(left.modes);
+            boundaries.push(modes.len());
+        }
+    }
+    (coeffs, modes, boundaries)
+}
+
 impl OperatorTrait for MajoranaOperator {
     fn zero() -> Self {
         Self {
@@ -313,22 +332,12 @@ impl OperatorTrait for MajoranaOperator {
     }
 
     fn __iand__(&mut self, other: &Self) {
-        let mut coeffs = vec![];
-        let mut modes = vec![];
-        let mut boundaries = vec![0];
+        (self.coeffs, self.modes, self.boundaries) = _compose(self, other);
+        self.groups = None;
+    }
 
-        for left in self.iter() {
-            for right in other.iter() {
-                coeffs.push(left.coeff * right.coeff);
-                modes.extend_from_slice(right.modes);
-                modes.extend_from_slice(left.modes);
-                boundaries.push(modes.len());
-            }
-        }
-
-        self.coeffs = coeffs;
-        self.modes = modes;
-        self.boundaries = boundaries;
+    fn __imatmul__(&mut self, other: &Self) {
+        (self.coeffs, self.modes, self.boundaries) = _compose(other, self);
         self.groups = None;
     }
 
@@ -615,6 +624,68 @@ mod tests {
         op1 &= op2;
         assert_eq!(
             op1,
+            MajoranaOperator {
+                coeffs: vec![
+                    Complex64::new(3.0, 0.0),
+                    Complex64::new(8.0, 0.0),
+                    Complex64::new(4.5, 0.0),
+                    Complex64::new(12.0, 0.0),
+                ],
+                modes: vec![1, 0, 0, 1, 1, 0, 0, 1],
+                boundaries: vec![0, 0, 2, 4, 8],
+                groups: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_matmul() {
+        let op1 = MajoranaOperator {
+            coeffs: vec![Complex64::new(2.0, 0.0), Complex64::new(3.0, 0.0)],
+            modes: vec![0, 1],
+            boundaries: vec![0, 0, 2],
+            groups: None,
+        };
+        let op2 = MajoranaOperator {
+            coeffs: vec![Complex64::new(1.5, 0.0), Complex64::new(4.0, 0.0)],
+            modes: vec![1, 0],
+            boundaries: vec![0, 0, 2],
+            groups: None,
+        };
+        let result = op2.__matmul__(&op1);
+        assert_eq!(
+            result,
+            MajoranaOperator {
+                coeffs: vec![
+                    Complex64::new(3.0, 0.0),
+                    Complex64::new(8.0, 0.0),
+                    Complex64::new(4.5, 0.0),
+                    Complex64::new(12.0, 0.0),
+                ],
+                modes: vec![1, 0, 0, 1, 1, 0, 0, 1],
+                boundaries: vec![0, 0, 2, 4, 8],
+                groups: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_matmul_assign() {
+        let op1 = MajoranaOperator {
+            coeffs: vec![Complex64::new(2.0, 0.0), Complex64::new(3.0, 0.0)],
+            modes: vec![0, 1],
+            boundaries: vec![0, 0, 2],
+            groups: None,
+        };
+        let mut op2 = MajoranaOperator {
+            coeffs: vec![Complex64::new(1.5, 0.0), Complex64::new(4.0, 0.0)],
+            modes: vec![1, 0],
+            boundaries: vec![0, 0, 2],
+            groups: None,
+        };
+        op2.__imatmul__(&op1);
+        assert_eq!(
+            op2,
             MajoranaOperator {
                 coeffs: vec![
                     Complex64::new(3.0, 0.0),

--- a/crates/core/src/operators/mod.rs
+++ b/crates/core/src/operators/mod.rs
@@ -23,6 +23,7 @@ pub trait OperatorTrait {
     fn __iadd__(&mut self, other: &Self);
     fn __imul__(&mut self, other: Complex64);
     fn __iand__(&mut self, other: &Self);
+    fn __imatmul__(&mut self, other: &Self);
     fn ichop(&mut self, atol: f64);
 }
 
@@ -33,6 +34,7 @@ pub trait OperatorMacro {
     fn __div__(&self, other: Complex64) -> Self;
     fn __neg__(&self) -> Self;
     fn __and__(&self, other: &Self) -> Self;
+    fn __matmul__(&self, other: &Self) -> Self;
     fn __pow__(&self, exponent: usize) -> Self;
 
     // more in-place operations
@@ -107,6 +109,15 @@ macro_rules! impl_operator_macro {
             {
                 let mut result = self.clone();
                 result.__iand__(other);
+                result
+            }
+
+            fn __matmul__(&self, other: &Self) -> Self
+            where
+                Self: OperatorTrait,
+            {
+                let mut result = self.clone();
+                result.__imatmul__(other);
                 result
             }
 

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -250,6 +250,15 @@ impl FermionOperatorDataIter {
 ///       1.200000e1 +0.000000e0j * (+_0)
 ///       9.000000e0 +0.000000e0j * (+_0 +_0)
 ///
+/// .. note::
+///    For convenience, the right-multiplication is implemented by ``c = a @ b`` (resulting in
+///    :math:`C = A B`).
+///
+/// .. doctest::
+///
+///     >>> (op1 @ op2).equiv(op2 & op1)
+///     True
+///
 /// Other Operations
 /// ^^^^^^^^^^^^^^^^
 ///

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -251,6 +251,15 @@ impl MajoranaOperatorDataIter {
 ///       1.200000e1 +0.000000e0j * (0)
 ///       9.000000e0 +0.000000e0j * (0 0)
 ///
+/// .. note::
+///    For convenience, the right-multiplication is implemented by ``c = a @ b`` (resulting in
+///    :math:`C = A B`).
+///
+/// .. doctest::
+///
+///     >>> (op1 @ op2).equiv(op2 & op1)
+///     True
+///
 /// Other Operations
 /// ^^^^^^^^^^^^^^^^
 ///

--- a/crates/pyext/src/operators/mod.rs
+++ b/crates/pyext/src/operators/mod.rs
@@ -79,6 +79,16 @@ macro_rules! impl_operator_magic_methods {
             fn __iand__(&mut self, other: &Self) {
                 self.inner.__iand__(&other.inner);
             }
+
+            fn __matmul__(&self, other: &Self) -> Self {
+                Self {
+                    inner: self.inner.__matmul__(&other.inner),
+                }
+            }
+
+            fn __imatmul__(&mut self, other: &Self) {
+                self.inner.__imatmul__(&other.inner);
+            }
         }
     };
 }


### PR DESCRIPTION
This is a useful feature to have on our Python API (where users can write short-hand notation like `a @ b`) since this ordering can be more intuitive when reading operators like in an equation. I don't see a reason to expose this to the C API as of now, since there one always writes a long form like `qf_ferm_op_compose(left, right)` and can simply exchange the argument order to get the other form.

Closes #76 