### PR TITLE
feat: add the `sandwich` argument to `FermionOperator.normal_ordered`

### DIFF
--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -736,9 +736,9 @@ pub unsafe extern "C" fn qf_ferm_op_simplify(
 ///
 /// - ``NULL``: both groups are ordered lexicographically descending (e.g. ``+_1 +_0 -_1 -_0``)
 /// - ``True``: larger indices appear towards the middle, i.e. creation actions are
-///   lexicographically ascending while annihilation are descending (e.g. ``+_0 +_1 -_1 -_0``)
+///   lexicographically ascending while annihilation ones are descending (e.g. ``+_0 +_1 -_1 -_0``)
 /// - ``False``: smaller indices appear towards the middle, i.e. creation actions are
-///   lexicographically descending while annihilation are ascending (e.g. ``+_1 +_0 -_0 -_1``)
+///   lexicographically descending while annihilation ones are ascending (e.g. ``+_1 +_0 -_0 -_1``)
 ///
 /// @param op A pointer to the operator.
 /// @param sandwich A pointer to a boolean value. This pointer may be ``NULL``.

--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -729,11 +729,19 @@ pub unsafe extern "C" fn qf_ferm_op_simplify(
 ///
 /// @brief Returns an equivalent operator with normal ordered terms.
 ///
-/// The normal order of an operator term is defined such that all creation actions before all
-/// annihilation actions and the modes of actions within each group descend lexicographically
-/// (e.g. ``+_1 +_0 -_1 -_0``).
+/// The normal order of an operator term is defined such that all creation actions appear before
+/// all annihilation actions.
+/// Within each group, the acted-upon modes are ordered lexicographically. Whether their order
+/// is ascending or descending depends upon the value of the ``sandwich`` argument:
+///
+/// - ``NULL``: both groups are ordered lexicographically descending (e.g. ``+_1 +_0 -_1 -_0``)
+/// - ``True``: larger indices appear towards the middle, i.e. creation actions are
+///   lexicographically ascending while annihilation are descending (e.g. ``+_0 +_1 -_1 -_0``)
+/// - ``False``: smaller indices appear towards the middle, i.e. creation actions are
+///   lexicographically descending while annihilation are ascending (e.g. ``+_1 +_0 -_0 -_1``)
 ///
 /// @param op A pointer to the operator.
+/// @param sandwich A pointer to a boolean value. This pointer may be ``NULL``.
 ///
 /// @return A pointer to the created operator.
 ///

--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -756,7 +756,7 @@ pub unsafe extern "C" fn qf_ferm_op_simplify(
 ///     QkComplex64 coeff = {1.0, 0.0};
 ///     qf_ferm_op_add_term(op, 4, actions, modes, &coeff);
 ///
-///     QfFermionOperator *normal_ordered = qf_ferm_op_normal_ordered(op);
+///     QfFermionOperator *normal_ordered = qf_ferm_op_normal_ordered(op, NULL);
 ///
 ///     uint64_t num_terms = 4;
 ///     uint64_t num_actions = 8;
@@ -775,11 +775,18 @@ pub unsafe extern "C" fn qf_ferm_op_simplify(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qf_ferm_op_normal_ordered(
     op: *const FermionOperator,
+    sandwich: *const bool,
 ) -> *mut FermionOperator {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let op = unsafe { const_ptr_as_ref(op) };
 
-    let result = op.normal_ordered();
+    let sandwich = if sandwich.is_null() {
+        None
+    } else {
+        unsafe { Some(sandwich.as_ref().unwrap()) }
+    };
+
+    let result = op.normal_ordered(sandwich.copied());
     Box::into_raw(Box::new(result))
 }
 

--- a/crates/cext/src/operators/majorana_operator.rs
+++ b/crates/cext/src/operators/majorana_operator.rs
@@ -728,7 +728,7 @@ pub unsafe extern "C" fn qf_maj_op_simplify(
 ///     QkComplex64 coeff = {1.0, 0.0};
 ///     qf_maj_op_add_term(op, 4, modes, &coeff);
 ///
-///     QfMajoranaOperator *normal_ordered = qf_maj_op_normal_ordered(op);
+///     QfMajoranaOperator *normal_ordered = qf_maj_op_normal_ordered(op, true);
 ///
 ///     QkComplex64 coeff_minus = {-1.0, 0.0};
 ///     QfMajoranaOperator *expected = qf_maj_op_zero();

--- a/crates/core/src/mappers/library/majorana_fermion.rs
+++ b/crates/core/src/mappers/library/majorana_fermion.rs
@@ -228,7 +228,7 @@ mod tests {
         };
 
         let fer_op = majorana_to_fermion(&maj_op);
-        let normal = fer_op.normal_ordered();
+        let normal = fer_op.normal_ordered(None);
         let canon = normal.simplify(1e-8);
 
         let expected = FermionOperator {
@@ -252,7 +252,7 @@ mod tests {
         };
 
         let fer_op = majorana_to_fermion(&maj_op);
-        let normal = fer_op.normal_ordered();
+        let normal = fer_op.normal_ordered(None);
         let canon = normal.simplify(1e-8);
 
         let expected = FermionOperator {

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -102,15 +102,15 @@ impl FermionOperator {
         Some(groups)
     }
 
-    pub fn normal_ordered(&self) -> Self {
+    pub fn normal_ordered(&self, sandwich: Option<bool>) -> Self {
         let mut result = Self::zero();
         self.iter()
-            .for_each(|term| result.__iadd__(&_normal_ordered_term(term)));
+            .for_each(|term| result.__iadd__(&_normal_ordered_term(term, sandwich)));
         result
     }
 
     pub fn is_hermitian(&self, atol: f64) -> bool {
-        let mut diff = (self.__sub__(&self.adjoint())).normal_ordered();
+        let mut diff = (self.__sub__(&self.adjoint())).normal_ordered(None);
         diff.ichop(atol);
         diff.equiv(&Self::zero(), atol)
     }
@@ -167,7 +167,10 @@ impl FermionOperator {
     }
 }
 
-fn _normal_ordered_term(term_view: FermionOperatorTermView) -> FermionOperator {
+fn _normal_ordered_term(
+    term_view: FermionOperatorTermView,
+    sandwich: Option<bool>,
+) -> FermionOperator {
     let mut coeffs = vec![];
     let mut actions = vec![];
     let mut modes = vec![];
@@ -184,18 +187,26 @@ fn _normal_ordered_term(term_view: FermionOperatorTermView) -> FermionOperator {
                 let (action_left, index_left) = term[j - 1];
                 if *action_right == *action_left {
                     // both create or both destroy
-                    match (index_right).cmp(index_left) {
-                        Ordering::Equal => {
+                    match ((index_right).cmp(index_left), sandwich, *action_left) {
+                        (Ordering::Equal, _, _) => {
                             // operators are the same, so product is zero
                             zero = true;
                             break;
                         }
-                        Ordering::Greater => {
+                        (Ordering::Greater, None, _)
+                        | (Ordering::Less, Some(true), true)
+                        | (Ordering::Less, Some(false), false)
+                        | (Ordering::Greater, Some(true), false)
+                        | (Ordering::Greater, Some(false), true) => {
                             // swap operators and update sign
                             term.swap(j - 1, j);
                             parity = !parity;
                         }
-                        Ordering::Less => {}
+                        (Ordering::Less, None, _)
+                        | (Ordering::Greater, Some(true), true)
+                        | (Ordering::Greater, Some(false), false)
+                        | (Ordering::Less, Some(true), false)
+                        | (Ordering::Less, Some(false), true) => {}
                     }
                 } else if *action_right && !*action_left {
                     // create on right and destroy on left
@@ -832,7 +843,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), op);
+        assert_eq!(op.normal_ordered(None), op);
     }
 
     #[test]
@@ -853,7 +864,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(None), expected);
     }
 
     #[test]
@@ -874,7 +885,85 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(None), expected);
+    }
+
+    #[test]
+    fn test_normal_ordered_sandwich_none() {
+        let op = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0)],
+            actions: vec![false, false, true, true],
+            modes: vec![0, 1, 0, 1],
+            boundaries: vec![0, 4],
+            groups: None,
+        };
+
+        let expected = FermionOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(1.0, 0.0),
+                Complex64::new(1.0, 0.0),
+                Complex64::new(-1.0, 0.0),
+            ],
+            actions: vec![true, true, false, false, true, false, true, false],
+            modes: vec![1, 0, 1, 0, 0, 0, 1, 1],
+            boundaries: vec![0, 4, 6, 8, 8],
+            groups: None,
+        };
+
+        assert_eq!(op.normal_ordered(None), expected);
+    }
+
+    #[test]
+    fn test_normal_ordered_sandwich_true() {
+        let op = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0)],
+            actions: vec![false, false, true, true],
+            modes: vec![1, 0, 0, 1],
+            boundaries: vec![0, 4],
+            groups: None,
+        };
+
+        let expected = FermionOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(-1.0, 0.0),
+                Complex64::new(-1.0, 0.0),
+                Complex64::new(1.0, 0.0),
+            ],
+            actions: vec![true, true, false, false, true, false, true, false],
+            modes: vec![0, 1, 1, 0, 0, 0, 1, 1],
+            boundaries: vec![0, 4, 6, 8, 8],
+            groups: None,
+        };
+
+        assert_eq!(op.normal_ordered(Some(true)), expected);
+    }
+
+    #[test]
+    fn test_normal_ordered_sandwich_false() {
+        let op = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0)],
+            actions: vec![false, false, true, true],
+            modes: vec![0, 1, 1, 0],
+            boundaries: vec![0, 4],
+            groups: None,
+        };
+
+        let expected = FermionOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(-1.0, 0.0),
+                Complex64::new(-1.0, 0.0),
+                Complex64::new(1.0, 0.0),
+            ],
+            actions: vec![true, true, false, false, true, false, true, false],
+            modes: vec![1, 0, 0, 1, 1, 1, 0, 0],
+            boundaries: vec![0, 4, 6, 8, 8],
+            groups: None,
+        };
+
+        assert_eq!(op.normal_ordered(Some(false)), expected);
     }
 
     #[test]

--- a/crates/core/src/operators/grouping/electronic_structure.rs
+++ b/crates/core/src/operators/grouping/electronic_structure.rs
@@ -235,7 +235,7 @@ mod tests {
             "We should not have any group indices yet!"
         );
 
-        let mut normal = op.normal_ordered().simplify(1e-16);
+        let mut normal = op.normal_ordered(None).simplify(1e-16);
 
         let res = group_terms_by_electronic_structure(&mut normal, 2 * fcidump.norb, false);
         assert!(res.is_ok(), "We should not have a GroupingError here!");
@@ -287,7 +287,7 @@ mod tests {
             "We should not have any group indices yet!"
         );
 
-        let mut normal = op.normal_ordered().simplify(1e-16);
+        let mut normal = op.normal_ordered(None).simplify(1e-16);
         // NOTE: we know that the normal-ordered operator here is in chemist's integral order
         // because it was generated from an FCIDump. Thus, we can convert it to physicist's
         // integral order by manually manipulating the acted-upon mode indices of the two-body

--- a/crates/core/src/operators/library/commutators.rs
+++ b/crates/core/src/operators/library/commutators.rs
@@ -164,7 +164,7 @@ mod tests {
             groups: None,
         };
         let comm = double_commutator(&op1, &op2, &op3, false);
-        let normal_ordered = comm.normal_ordered();
+        let normal_ordered = comm.normal_ordered(None);
         let canon = normal_ordered.simplify(1e-8);
         assert_eq!(canon, FermionOperator::zero());
     }

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -706,9 +706,11 @@ impl PyFermionOperator {
     /// - ``None`` (default): both groups are ordered lexicographically descending (e.g.
     ///   ``+_1 +_0 -_1 -_0``)
     /// - ``True``: larger indices appear towards the middle, i.e. creation actions are
-    ///   lexicographically ascending while annihilation are descending (e.g. ``+_0 +_1 -_1 -_0``)
+    ///   lexicographically ascending while annihilation ones are descending (e.g.
+    ///   ``+_0 +_1 -_1 -_0``)
     /// - ``False``: smaller indices appear towards the middle, i.e. creation actions are
-    ///   lexicographically descending while annihilation are ascending (e.g. ``+_1 +_0 -_0 -_1``)
+    ///   lexicographically descending while annihilation ones are ascending (e.g.
+    ///   ``+_1 +_0 -_0 -_1``)
     ///
     /// .. note::
     ///    When a term is being reordered, the anti-commutation relations have to be taken into

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -719,9 +719,10 @@ impl PyFermionOperator {
     ///
     /// Returns:
     ///     An equivalent but normal-ordered operator.
-    fn normal_ordered(&self) -> Self {
+    #[pyo3(signature = (sandwich=None))]
+    fn normal_ordered(&self, sandwich: Option<bool>) -> Self {
         Self {
-            inner: self.inner.normal_ordered(),
+            inner: self.inner.normal_ordered(sandwich),
         }
     }
 

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -698,9 +698,17 @@ impl PyFermionOperator {
 
     /// Returns an equivalent operator with normal ordered terms.
     ///
-    /// The normal order of an operator term is defined such that all creation actions before all
-    /// annihilation actions and the modes of actions within each group descend lexicographically
-    /// (e.g. ``+_1 +_0 -_1 -_0``).
+    /// The normal order of an operator term is defined such that all creation actions appear
+    /// before all annihilation actions.
+    /// Within each group, the acted-upon modes are ordered lexicographically. Whether their order
+    /// is ascending or descending depends upon the value of the ``sandwich`` argument:
+    ///
+    /// - ``None`` (default): both groups are ordered lexicographically descending (e.g.
+    ///   ``+_1 +_0 -_1 -_0``)
+    /// - ``True``: larger indices appear towards the middle, i.e. creation actions are
+    ///   lexicographically ascending while annihilation are descending (e.g. ``+_0 +_1 -_1 -_0``)
+    /// - ``False``: smaller indices appear towards the middle, i.e. creation actions are
+    ///   lexicographically descending while annihilation are ascending (e.g. ``+_1 +_0 -_0 -_1``)
     ///
     /// .. note::
     ///    When a term is being reordered, the anti-commutation relations have to be taken into
@@ -716,6 +724,16 @@ impl PyFermionOperator {
     ///      -1.000000e0 +0.000000e0j * (+_0 -_0)
     ///      -1.000000e0 +0.000000e0j * (+_1 -_1)
     ///      -1.000000e0 +0.000000e0j * (+_1 +_0 -_1 -_0)
+    ///     >>> print(op.normal_ordered(sandwich=True).simplify())
+    ///       1.000000e0 +0.000000e0j * ()
+    ///      -1.000000e0 +0.000000e0j * (+_0 -_0)
+    ///       1.000000e0 +0.000000e0j * (+_0 +_1 -_1 -_0)
+    ///      -1.000000e0 +0.000000e0j * (+_1 -_1)
+    ///     >>> print(op.normal_ordered(sandwich=False).simplify())
+    ///       1.000000e0 +0.000000e0j * ()
+    ///      -1.000000e0 +0.000000e0j * (+_0 -_0)
+    ///      -1.000000e0 +0.000000e0j * (+_1 -_1)
+    ///       1.000000e0 +0.000000e0j * (+_1 +_0 -_0 -_1)
     ///
     /// Returns:
     ///     An equivalent but normal-ordered operator.

--- a/tests/c/test_commutators.c
+++ b/tests/c/test_commutators.c
@@ -30,7 +30,7 @@ static int test_ferm_op_commutator(void) {
 
     QfFermionOperator *comm = qf_ferm_op_commutator(op1, op2);
 
-    QfFermionOperator *normal = qf_ferm_op_normal_ordered(comm);
+    QfFermionOperator *normal = qf_ferm_op_normal_ordered(comm, NULL);
     QfFermionOperator *canon = qf_ferm_op_simplify(normal, 1e-8);
 
     qf_ferm_op_ichop(canon, 1e-8);
@@ -62,7 +62,7 @@ static int test_ferm_op_anti_commutator(void) {
 
     QfFermionOperator *anti_comm = qf_ferm_op_anti_commutator(op1, op2);
 
-    QfFermionOperator *normal = qf_ferm_op_normal_ordered(anti_comm);
+    QfFermionOperator *normal = qf_ferm_op_normal_ordered(anti_comm, NULL);
     QfFermionOperator *canon = qf_ferm_op_simplify(normal, 1e-8);
 
     qf_ferm_op_ichop(canon, 1e-8);
@@ -98,7 +98,7 @@ static int test_ferm_op_double_commutator(void) {
 
     QfFermionOperator *double_comm = qf_ferm_op_double_commutator(op1, op2, op3, false);
 
-    QfFermionOperator *normal = qf_ferm_op_normal_ordered(double_comm);
+    QfFermionOperator *normal = qf_ferm_op_normal_ordered(double_comm, NULL);
     QfFermionOperator *canon = qf_ferm_op_simplify(normal, 1e-8);
 
     qf_ferm_op_ichop(canon, 1e-8);

--- a/tests/c/test_fermion_operator.c
+++ b/tests/c/test_fermion_operator.c
@@ -291,19 +291,19 @@ static int test_adjoint(void) {
 
 static int test_normal_ordered(void) {
     QfFermionOperator *op = qf_ferm_op_zero();
-    bool action[4] = {false, true, false, true};
-    uint32_t modes[4] = {1, 1, 0, 0};
+    bool action[4] = {false, false, true, true};
+    uint32_t modes[4] = {0, 1, 0, 1};
     QkComplex64 coeff = {1.0, 0.0};
     qf_ferm_op_add_term(op, 4, action, modes, &coeff);
 
-    QfFermionOperator *normal_ordered = qf_ferm_op_normal_ordered(op);
+    QfFermionOperator *normal_ordered = qf_ferm_op_normal_ordered(op, NULL);
 
     uint64_t num_terms = 4;
     uint64_t num_actions = 8;
-    bool actions_exp[8] = {true, false, true, false, true, true, false, false};
-    uint32_t modes_exp[8] = {0, 0, 1, 1, 1, 0, 1, 0};
-    QkComplex64 coeffs_exp[4] = {{1.0, 0.0}, {-1.0, 0.0}, {-1.0, 0.0}, {-1.0, 0.0}};
-    uint32_t boundaries_exp[5] = {0, 0, 2, 4, 8};
+    bool actions_exp[8] = {true, true, false, false, true, false, true, false};
+    uint32_t modes_exp[8] = {1, 0, 1, 0, 0, 0, 1, 1};
+    QkComplex64 coeffs_exp[4] = {{1.0, 0.0}, {1.0, 0.0}, {1.0, 0.0}, {-1.0, 0.0}};
+    uint32_t boundaries_exp[5] = {0, 4, 6, 8, 8};
     QfFermionOperator *expected =
         qf_ferm_op_new(num_terms, num_actions, coeffs_exp, actions_exp, modes_exp, boundaries_exp);
 
@@ -311,6 +311,68 @@ static int test_normal_ordered(void) {
 
     qf_ferm_op_free(op);
     qf_ferm_op_free(normal_ordered);
+    qf_ferm_op_free(expected);
+
+    if (!is_equal) {
+        return EqualityError;
+    }
+    return Ok;
+}
+
+static int test_sandwich_ordered_true(void) {
+    QfFermionOperator *op = qf_ferm_op_zero();
+    bool action[4] = {false, false, true, true};
+    uint32_t modes[4] = {1, 0, 0, 1};
+    QkComplex64 coeff = {1.0, 0.0};
+    qf_ferm_op_add_term(op, 4, action, modes, &coeff);
+
+    bool sandwich = true;
+    QfFermionOperator *sandwich_ordered = qf_ferm_op_normal_ordered(op, &sandwich);
+
+    uint64_t num_terms = 4;
+    uint64_t num_actions = 8;
+    bool actions_exp[8] = {true, true, false, false, true, false, true, false};
+    uint32_t modes_exp[8] = {0, 1, 1, 0, 0, 0, 1, 1};
+    QkComplex64 coeffs_exp[4] = {{1.0, 0.0}, {-1.0, 0.0}, {-1.0, 0.0}, {1.0, 0.0}};
+    uint32_t boundaries_exp[5] = {0, 4, 6, 8, 8};
+    QfFermionOperator *expected =
+        qf_ferm_op_new(num_terms, num_actions, coeffs_exp, actions_exp, modes_exp, boundaries_exp);
+
+    bool is_equal = qf_ferm_op_equiv(sandwich_ordered, expected, 1e-10);
+
+    qf_ferm_op_free(op);
+    qf_ferm_op_free(sandwich_ordered);
+    qf_ferm_op_free(expected);
+
+    if (!is_equal) {
+        return EqualityError;
+    }
+    return Ok;
+}
+
+static int test_sandwich_ordered_false(void) {
+    QfFermionOperator *op = qf_ferm_op_zero();
+    bool action[4] = {false, false, true, true};
+    uint32_t modes[4] = {0, 1, 1, 0};
+    QkComplex64 coeff = {1.0, 0.0};
+    qf_ferm_op_add_term(op, 4, action, modes, &coeff);
+
+    bool sandwich = false;
+    QfFermionOperator *sandwich_ordered = qf_ferm_op_normal_ordered(op, &sandwich);
+
+    uint64_t num_terms = 4;
+    uint64_t num_actions = 8;
+    bool actions_exp[8] = {true, true, false, false, true, false, true, false};
+    uint32_t modes_exp[8] = {1, 0, 0, 1, 1, 1, 0, 0};
+    QkComplex64 coeffs_exp[4] = {{1.0, 0.0}, {-1.0, 0.0}, {-1.0, 0.0}, {1.0, 0.0}};
+    uint32_t boundaries_exp[5] = {0, 4, 6, 8, 8};
+    QfFermionOperator *expected =
+        qf_ferm_op_new(num_terms, num_actions, coeffs_exp, actions_exp, modes_exp, boundaries_exp);
+
+    bool is_equal = qf_ferm_op_equiv(sandwich_ordered, expected, 1e-10);
+
+    qf_ferm_op_free(op);
+    qf_ferm_op_free(sandwich_ordered);
     qf_ferm_op_free(expected);
 
     if (!is_equal) {
@@ -566,6 +628,8 @@ int test_fermion_operator(void) {
     num_failed += RUN_TEST(test_simplify_vs_ichop);
     num_failed += RUN_TEST(test_adjoint);
     num_failed += RUN_TEST(test_normal_ordered);
+    num_failed += RUN_TEST(test_sandwich_ordered_true);
+    num_failed += RUN_TEST(test_sandwich_ordered_false);
     num_failed += RUN_TEST(test_is_hermitian);
     num_failed += RUN_TEST(test_many_body_order);
     num_failed += RUN_TEST(test_conserves_particle_number);

--- a/tests/c/test_grouping.c
+++ b/tests/c/test_grouping.c
@@ -40,7 +40,7 @@ static int test_group_terms_by_electronic_structure(void) {
     QfFermionOperator *op = qf_ferm_op_from_fcidump(fcidump);
     qf_fcidump_free(fcidump);
 
-    QfFermionOperator *normal = qf_ferm_op_normal_ordered(op);
+    QfFermionOperator *normal = qf_ferm_op_normal_ordered(op, NULL);
     qf_ferm_op_free(op);
 
     QfExitCode exit = qf_group_terms_by_electronic_structure(normal, 4, false);

--- a/tests/c/test_majorana_fermion.c
+++ b/tests/c/test_majorana_fermion.c
@@ -54,7 +54,7 @@ static int test_majorana_to_fermion(void) {
     qf_maj_op_add_term(maj_op, 2, modes_maj, &coeff);
 
     QfFermionOperator *result = qf_majorana_to_fermion(maj_op);
-    QfFermionOperator *canon = qf_ferm_op_normal_ordered(result);
+    QfFermionOperator *canon = qf_ferm_op_normal_ordered(result, NULL);
 
     uint64_t num_terms = 2;
     uint64_t num_actions = 2;

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -231,6 +231,45 @@ class FermionOperatorTests(ABC):
             expected = cls.from_dict({(): 1, ((True, 0), (False, 0)): -1})
             assert op.normal_ordered().equiv(expected)
 
+    def test_normal_ordered_sandwich(self, subtests):
+        cls = self.get_class()
+
+        with subtests.test("sandwich=none"):
+            op = cls.from_dict({((False, 0), (False, 1), (True, 0), (True, 1)): 1})
+            expected = cls.from_dict(
+                {
+                    ((True, 1), (True, 0), (False, 1), (False, 0)): 1,
+                    ((True, 0), (False, 0)): 1,
+                    ((True, 1), (False, 1)): 1,
+                    (): -1,
+                }
+            )
+            assert op.normal_ordered(sandwich=None).equiv(expected)
+
+        with subtests.test("sandwich=True"):
+            op = cls.from_dict({((False, 1), (False, 0), (True, 0), (True, 1)): 1})
+            expected = cls.from_dict(
+                {
+                    ((True, 0), (True, 1), (False, 1), (False, 0)): 1,
+                    ((True, 0), (False, 0)): -1,
+                    ((True, 1), (False, 1)): -1,
+                    (): 1,
+                }
+            )
+            assert op.normal_ordered(sandwich=True).equiv(expected)
+
+        with subtests.test("sandwich=False"):
+            op = cls.from_dict({((False, 0), (False, 1), (True, 1), (True, 0)): 1})
+            expected = cls.from_dict(
+                {
+                    ((True, 1), (True, 0), (False, 0), (False, 1)): 1,
+                    ((True, 0), (False, 0)): -1,
+                    ((True, 1), (False, 1)): -1,
+                    (): 1,
+                }
+            )
+            assert op.normal_ordered(sandwich=False).equiv(expected)
+
     def test_is_hermitian(self):
         cls = self.get_class()
 


### PR DESCRIPTION
The normal-ordering of the `FermionOperator` is always sorting the creation and annihilation operators by descending indices. This commit adds a new argument to the function which permits the order to become a "sandwich" order, where one group has ascending and the other descending indices (depending on the boolean value of the `sandwich` argument). Although still corresponding to the same operator, this form can be more natural to work with in certain scenarios so it makes sense to make it easy to access for our users.

---

- [x] I still need to update the API docs before merging