### PR TITLE
feat: implements the `InitializeModes` fermionic gate

### DIFF
--- a/python/qiskit_fermions/circuit/library/__init__.py
+++ b/python/qiskit_fermions/circuit/library/__init__.py
@@ -26,10 +26,13 @@ This module provides a library of :class:`.FermionGate` implementations.
    :template: autosummary/class_without_inheritance.rst
 
    Evolution
+   InitializeModes
 """
 
 from .evolution import Evolution
+from .initialize_modes import InitializeModes
 
 __all__ = [
     "Evolution",
+    "InitializeModes",
 ]

--- a/python/qiskit_fermions/circuit/library/initialize_modes.py
+++ b/python/qiskit_fermions/circuit/library/initialize_modes.py
@@ -1,0 +1,44 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Mode initialization gate."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+
+from .. import FermionGate
+
+
+class InitializeModes(FermionGate):
+    """Implements the fermionic mode initialization.
+
+    .. caution::
+       This is an early development prototype. Beware of changes to its interface without warning
+       during the pre-release development of this package.
+    """
+
+    def __init__(self, occupation: Sequence[bool]) -> None:
+        """Initializes the modes of a :class:`.FermionRegister` with the provided occupation.
+
+        Args:
+            occupation: a sequence of booleans indicating the occupation for each mode in the
+                :class:`.FermionRegister` being initialized by this gate.
+        """
+        self.occupation = np.asarray(occupation, dtype=bool)
+        """The sequence of booleans indicating the occupation for each mode in the
+        :class:`~.FermionRegister` being initialized by this gate."""
+        """The operator under which to time-evolve the acted-upon fermionic modes."""
+
+        super().__init__("InitializeModes", len(self.occupation), [])

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -79,15 +79,22 @@ provides builtin plugins:
    :toctree: ../stubs/
 
    EvolutionSynthesis
+   InitializeModesSynthesis
 """
 
 from .layout import CustomF2QLayout, TrivialF2QLayout
-from .synthesis import EvolutionSynthesis, F2QSynthesis, F2QSynthesisPlugin
+from .synthesis import (
+    EvolutionSynthesis,
+    F2QSynthesis,
+    F2QSynthesisPlugin,
+    InitializeModesSynthesis,
+)
 
 __all__ = [
     "CustomF2QLayout",
     "EvolutionSynthesis",
     "F2QSynthesis",
     "F2QSynthesisPlugin",
+    "InitializeModesSynthesis",
     "TrivialF2QLayout",
 ]

--- a/python/qiskit_fermions/transpiler/passes/synthesis/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/__init__.py
@@ -13,10 +13,12 @@
 """Synthesis passes."""
 
 from .evolution import EvolutionSynthesis
+from .initialize_modes import InitializeModesSynthesis
 from .synthesis import F2QSynthesis, F2QSynthesisPlugin
 
 __all__ = [
     "EvolutionSynthesis",
     "F2QSynthesis",
     "F2QSynthesisPlugin",
+    "InitializeModesSynthesis",
 ]

--- a/python/qiskit_fermions/transpiler/passes/synthesis/initialize_modes.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/initialize_modes.py
@@ -10,59 +10,40 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Fermion-operator evolution gate synthesis."""
+"""Mode initialization synthesis."""
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING
-
+import numpy as np
 from qiskit.circuit import QuantumCircuit
-from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.converters import circuit_to_dag
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode
-from qiskit.quantum_info import SparseObservable
 
 from ... import F2QLayout
 from ..utils import _parse_node_indices
 
-if TYPE_CHECKING:
-    from qiskit_fermions._lib.operators.fermion_operator import FermionOperator
-    from qiskit_fermions._lib.operators.majorana_operator import MajoranaOperator
-else:
-    from qiskit_fermions.operators import FermionOperator, MajoranaOperator
 
+class InitializeModesSynthesis:
+    """A :class:`.F2QSynthesisPlugin` for transpiling a :class:`.InitializeModes`.
 
-# TODO: add an OperatorProtocol to avoid hard-coding this list of types from our package
-MapperFunction = Callable[[FermionOperator | MajoranaOperator], SparseObservable]
-"""The function signature for :attr:`mapper_fn`."""
+    .. caution::
+       This is an early development prototype. Beware of changes to its interface without warning
+       during the pre-release development of this package.
 
+    .. warning::
+       This transpilation pass plugin is known to have certain limitations, including:
 
-class EvolutionSynthesis:
-    """A :class:`.F2QSynthesisPlugin` for transpiling a :class:`.Evolution`."""
-
-    def __init__(self, mapper_fn: MapperFunction) -> None:
-        """Initializes the transpilation plugin.
-
-        Args:
-            mapper_fn: the fermion-to-qubit operator mapping function.
-        """
-        super().__init__()
-
-        self.mapper_fn: MapperFunction = mapper_fn
-        """The fermion-to-qubit operator mapping function.
-
-        .. note::
-           It is the user's responsibility to ensure that this function is in-sync with the global
-           transpilation :class:`~qiskit_fermions.transpiler.F2QLayout` setting.
-        """
+       - assuming an occupation-basis encoding (like Jordan-Wigner)
+       - assuming a trivial fermion-to-qubit layout (i.e. no change in their register lengths)
+       - assuming a 1-to-1 mapping of fermionic mode indices to qubit indices
+    """
 
     def run(self, in_node: DAGOpNode, out_dag: DAGCircuit, *, f2q_layout: F2QLayout):
         """Runs this transpilation plugin.
 
         Args:
             in_node: the input fermion-based circuit instruction. When this plugin gets called, the
-                ``in_node.op`` attribute `must` be of type :class:`.Evolution`.
+                ``in_node.op`` attribute `must` be of type :class:`.InitializeModes`.
             out_dag: the output qubit-based circuit.
             f2q_layout: the global transpilation :class:`~qiskit_fermions.transpiler.F2QLayout`
                 setting.
@@ -81,19 +62,19 @@ class EvolutionSynthesis:
 
         if len(encountered_fermion_registers) > 1:
             raise NotImplementedError(
-                "Cannot map an Evolution gate acting on fermionic modes that are spread across "
-                "multiple FermionRegister instances."
+                "Cannot map an InitializeModes gate acting on fermionic modes that are spread "
+                "across multiple FermionRegister instances."
             )
 
         freg = encountered_fermion_registers.pop()
         qreg = f2q_layout[freg]
 
-        local_op = in_node.op.operator
-        global_op = local_op.relabel_modes(global_fermion_indices)
-        pauli_op = self.mapper_fn(global_op).simplify()
-
         circ = QuantumCircuit(qreg)
-        circ.append(PauliEvolutionGate(pauli_op, time=in_node.op.params[0]), qreg)
+
+        local_occupation = in_node.op.occupation
+        global_occupied_indices = np.asarray(global_fermion_indices)[np.nonzero(local_occupation)]
+        circ.x(global_occupied_indices.tolist())
+
         new_dag = circuit_to_dag(circ)
 
         out_dag.compose(new_dag, qubits=list(qreg), front=False, inplace=True)

--- a/python/qiskit_fermions/transpiler/passes/utils.py
+++ b/python/qiskit_fermions/transpiler/passes/utils.py
@@ -1,0 +1,48 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utility methods for transpiler passes."""
+
+from __future__ import annotations
+
+from qiskit.circuit import QuantumRegister
+from qiskit.dagcircuit import DAGOpNode
+
+from .. import F2QLayout
+
+
+def _parse_node_indices(
+    in_node: DAGOpNode, f2q_layout: F2QLayout
+) -> tuple[set[QuantumRegister], list[int]]:
+    """Parse the mode indices that a :ext:class:`~qiskit.dagcircuit.DAGOpNode` acts upon.
+
+    Given a node of a :ext:class:`~qiskit.dagcircuit.DAGCircuit` and a :type:`.F2QLayout` this
+    function parses the node's indices and maps them to the global mode indices of the
+    respective register from the ``f2q_layout``.
+
+    Args:
+        in_node: the node whose indices to parse.
+        f2q_layout: the mapping of fermionic to qubit registers.
+
+    Returns:
+        The set of fermionic mode registers and global mode indices acted upon by ``in_node``.
+    """
+    encountered_fermion_registers: set[QuantumRegister] = set()
+    global_fermion_indices = []
+    for fermion in in_node.qargs:
+        for freg in f2q_layout:
+            if fermion in freg:
+                encountered_fermion_registers.add(freg)
+                global_fermion_indices.append(freg.index(fermion))
+                break
+
+    return encountered_fermion_registers, global_fermion_indices

--- a/tests/python/circuit/library/test_initialize_modes.py
+++ b/tests/python/circuit/library/test_initialize_modes.py
@@ -1,0 +1,45 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Mode initialization tests."""
+
+from __future__ import annotations
+
+import numpy as np
+from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit.library import InitializeModes
+
+
+def _test_initialize_modes(occupation):
+    num_fermions = len(occupation)
+    init = InitializeModes(occupation)
+    circ = FermionCircuit(num_fermions)
+    circ.append(init, circ.fermions)
+
+    # TODO: perform a better assertion instead of accessing an internal attribute here
+    gates = circ._inner.data
+
+    assert len(gates) == 1
+    assert isinstance(gates[0].operation, InitializeModes)
+    assert gates[0].operation.occupation.shape == (num_fermions,)
+    assert np.allclose(gates[0].operation.occupation, occupation)
+
+
+def test_initialize_modes_gate(subtests):
+    with subtests.test("from list"):
+        _test_initialize_modes([True, False, True, False])
+
+    with subtests.test("from tuple"):
+        _test_initialize_modes((True, False, True, False))
+
+    with subtests.test("from np.ndarray"):
+        _test_initialize_modes(np.asarray([True, False, True, False], dtype=bool))

--- a/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
+++ b/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
@@ -1,0 +1,66 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Mode initialization synthesis tests."""
+
+from __future__ import annotations
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.quantum_info import Statevector
+from qiskit.transpiler import PassManager
+from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit.library import InitializeModes
+from qiskit_fermions.transpiler.passes.layout import TrivialF2QLayout
+from qiskit_fermions.transpiler.passes.synthesis import F2QSynthesis, InitializeModesSynthesis
+
+
+def test_initialize_modes_global_gate_synthesis():
+    occupation = [True, False, True, False]
+    num_fermions = len(occupation)
+    circ = FermionCircuit(num_fermions)
+    init = InitializeModes(occupation)
+    circ.append(init, circ.fermions)
+
+    synth = F2QSynthesis()
+    synth.plugins[InitializeModes] = InitializeModesSynthesis()
+
+    pm = PassManager([TrivialF2QLayout(), synth])
+
+    # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
+    qu_circ = pm.run(circ._inner)
+
+    expected = QuantumCircuit(num_fermions)
+    expected.x(0)
+    expected.x(2)
+
+    assert Statevector(qu_circ) == Statevector(expected)
+
+
+def test_initialize_modes_local_gate_synthesis():
+    occupation = [True, False]
+    num_fermions = 4
+    circ = FermionCircuit(num_fermions)
+    init = InitializeModes(occupation)
+    circ.append(init, circ.fermions[1:3])
+
+    synth = F2QSynthesis()
+    synth.plugins[InitializeModes] = InitializeModesSynthesis()
+
+    pm = PassManager([TrivialF2QLayout(), synth])
+
+    # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
+    qu_circ = pm.run(circ._inner)
+
+    expected = QuantumCircuit(num_fermions)
+    expected.x(1)
+
+    assert Statevector(qu_circ) == Statevector(expected)


### PR DESCRIPTION
This adds a first draft of a `FermionGate` for initializing the occupation of a fermionic register.

For now, this implementation is naive in the sense of its synthesis plugin always naively mapping to `X` gates on the indices indicated by the occupation vector provided inside the gate.

In other words:
- the synthesis plugin assumes an occupation-basis encoding (like Jordan-Wigner)
- the synthesis plugin cannot handle non trivial fermion-to-qubit layouts
- the synthesis plugin does not account for possibly different fermion-to-qubit index routing

As such, this PR adds a base implementation for prototyping and testing purposes rather than addressing all the open questions outlined in #55. 