### PR TITLE
feat: implements the `OrbitalRotation` gate

### DIFF
--- a/python/qiskit_fermions/circuit/library/__init__.py
+++ b/python/qiskit_fermions/circuit/library/__init__.py
@@ -27,12 +27,15 @@ This module provides a library of :class:`.FermionGate` implementations.
 
    Evolution
    InitializeModes
+   OrbitalRotation
 """
 
 from .evolution import Evolution
 from .initialize_modes import InitializeModes
+from .orbital_rotation import OrbitalRotation
 
 __all__ = [
     "Evolution",
     "InitializeModes",
+    "OrbitalRotation",
 ]

--- a/python/qiskit_fermions/circuit/library/initialize_modes.py
+++ b/python/qiskit_fermions/circuit/library/initialize_modes.py
@@ -39,6 +39,5 @@ class InitializeModes(FermionGate):
         self.occupation = np.asarray(occupation, dtype=bool)
         """The sequence of booleans indicating the occupation for each mode in the
         :class:`~.FermionRegister` being initialized by this gate."""
-        """The operator under which to time-evolve the acted-upon fermionic modes."""
 
         super().__init__("InitializeModes", len(self.occupation), [])

--- a/python/qiskit_fermions/circuit/library/orbital_rotation.py
+++ b/python/qiskit_fermions/circuit/library/orbital_rotation.py
@@ -1,0 +1,34 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Orbital rotation gate."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .. import FermionGate
+
+
+class OrbitalRotation(FermionGate):
+    """Implements an orbital rotation."""
+
+    def __init__(self, rotation_unitary: np.ndarray) -> None:
+        """Initializes the orbital rotation.
+
+        Args:
+            rotation_unitary: the unitary matrix representing the orbital rotation coefficients.
+        """
+        self.rotation_unitary = rotation_unitary
+        """The unitary matrix representing the orbital rotation coefficients."""
+
+        super().__init__("OrbitalRotation", self.rotation_unitary.shape[0], [])

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -80,6 +80,7 @@ provides builtin plugins:
 
    EvolutionSynthesis
    InitializeModesSynthesis
+   OrbitalRotationSynthesis
 """
 
 from .layout import CustomF2QLayout, TrivialF2QLayout
@@ -88,6 +89,7 @@ from .synthesis import (
     F2QSynthesis,
     F2QSynthesisPlugin,
     InitializeModesSynthesis,
+    OrbitalRotationSynthesis,
 )
 
 __all__ = [
@@ -96,5 +98,6 @@ __all__ = [
     "F2QSynthesis",
     "F2QSynthesisPlugin",
     "InitializeModesSynthesis",
+    "OrbitalRotationSynthesis",
     "TrivialF2QLayout",
 ]

--- a/python/qiskit_fermions/transpiler/passes/synthesis/orbital_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/orbital_rotation.py
@@ -1,0 +1,93 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Orbital rotation synthesis."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import PhaseGate, XXPlusYYGate
+from qiskit.converters import circuit_to_dag
+from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+
+if TYPE_CHECKING:
+    from qiskit_fermions._lib.linalg.givens import givens_decomposition
+else:
+    from qiskit_fermions.linalg import givens_decomposition
+
+from ... import F2QLayout
+from ..utils import _parse_node_indices
+
+
+class OrbitalRotationSynthesis:
+    """A :class:`.F2QSynthesisPlugin` for transpiling a :class:`.OrbitalRotation`.
+
+    .. warning::
+       This transpilation pass plugin is known to have certain limitations, including:
+
+       - assuming an occupation-basis encoding (like Jordan-Wigner)
+       - assuming a trivial fermion-to-qubit layout (i.e. no change in their register lengths)
+       - assuming a 1-to-1 mapping of fermionic mode indices to qubit indices
+    """
+
+    def run(self, in_node: DAGOpNode, out_dag: DAGCircuit, *, f2q_layout: F2QLayout):
+        """Runs this transpilation plugin.
+
+        Args:
+            in_node: the input fermion-based circuit instruction. When this plugin gets called, the
+                ``in_node.op`` attribute `must` be of type :class:`.OrbitalRotation`.
+            out_dag: the output qubit-based circuit.
+            f2q_layout: the global transpilation :class:`~qiskit_fermions.transpiler.F2QLayout`
+                setting.
+
+        .. seealso::
+           The documentation of :class:`.F2QSynthesisPlugin` for more detailed explanations of the
+           arguments.
+
+        Raises:
+            NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
+                multiple :type:`~qiskit_fermions.circuit.FermionRegister` instances.
+        """
+        encountered_fermion_registers, global_fermion_indices = _parse_node_indices(
+            in_node, f2q_layout
+        )
+
+        if len(encountered_fermion_registers) > 1:
+            raise NotImplementedError(
+                "Cannot map an OrbitalRotation gate acting on fermionic modes that are spread "
+                "across multiple FermionRegister instances."
+            )
+
+        freg = encountered_fermion_registers.pop()
+        qreg = f2q_layout[freg]
+
+        circ = QuantumCircuit(qreg)
+
+        givens_rotations, phase_shifts = givens_decomposition(in_node.op.rotation_unitary)
+        for c, s, i, j in givens_rotations:
+            c_angle = np.acos(c)
+            if not np.isclose(c_angle, 0.0):
+                circ.append(
+                    XXPlusYYGate(2 * c_angle, np.angle(s) - 0.5 * np.pi),
+                    (global_fermion_indices[i], global_fermion_indices[j]),
+                )
+        for i, p in enumerate(phase_shifts):
+            p_angle = np.angle(p)
+            if not np.isclose(p_angle, 0.0):
+                circ.append(PhaseGate(p_angle), (global_fermion_indices[i],))
+
+        new_dag = circuit_to_dag(circ)
+
+        out_dag.compose(new_dag, qubits=list(qreg), front=False, inplace=True)

--- a/tests/python/linalg/test_givens.py
+++ b/tests/python/linalg/test_givens.py
@@ -16,14 +16,7 @@ import numpy as np
 import pytest
 from qiskit_fermions.linalg import givens_decomposition
 
-
-def random_unitary(dim: int, *, seed=None, dtype=complex) -> np.ndarray:
-    rng = np.random.default_rng(seed)
-    z = rng.standard_normal((dim, dim)).astype(dtype, copy=False)
-    z += 1j * rng.standard_normal((dim, dim)).astype(dtype, copy=False)
-    q, r = np.linalg.qr(z)
-    d = np.diagonal(r)
-    return q * (d / np.abs(d))
+from ..utils import random_unitary
 
 
 @pytest.mark.parametrize("dim", range(1, 11))

--- a/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
+++ b/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
@@ -1,0 +1,64 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Orbital rotation synthesis tests."""
+
+from __future__ import annotations
+
+from qiskit.transpiler import PassManager
+from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit.library import OrbitalRotation
+from qiskit_fermions.transpiler.passes.layout import TrivialF2QLayout
+from qiskit_fermions.transpiler.passes.synthesis import F2QSynthesis, OrbitalRotationSynthesis
+
+from ...utils import random_unitary
+
+
+def test_orbital_rotation_global_gate_synthesis():
+    num_fermions = 6
+    rotation_unitary = random_unitary(num_fermions, seed=42)
+    circ = FermionCircuit(num_fermions)
+    rot = OrbitalRotation(rotation_unitary)
+    circ.append(rot, circ.fermions)
+
+    synth = F2QSynthesis()
+    synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
+
+    pm = PassManager([TrivialF2QLayout(), synth])
+
+    # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
+    qu_circ = pm.run(circ._inner)
+
+    ops = qu_circ.count_ops()
+    assert ops == {"xx_plus_yy": 15, "p": 6}
+
+
+def test_initialize_modes_local_gate_synthesis():
+    num_fermions = 6
+    rotation_unitary_a = random_unitary(num_fermions // 2, seed=42)
+    rotation_unitary_b = random_unitary(num_fermions // 2, seed=43)
+    circ = FermionCircuit(num_fermions)
+    rot_a = OrbitalRotation(rotation_unitary_a)
+    circ.append(rot_a, circ.fermions[:3])
+    rot_b = OrbitalRotation(rotation_unitary_b)
+    circ.append(rot_b, circ.fermions[3:])
+
+    synth = F2QSynthesis()
+    synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
+
+    pm = PassManager([TrivialF2QLayout(), synth])
+
+    # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
+    qu_circ = pm.run(circ._inner)
+
+    ops = qu_circ.count_ops()
+    assert ops == {"xx_plus_yy": 6, "p": 6}

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -10,17 +10,15 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Synthesis passes."""
+"""Testing utilities."""
 
-from .evolution import EvolutionSynthesis
-from .initialize_modes import InitializeModesSynthesis
-from .orbital_rotation import OrbitalRotationSynthesis
-from .synthesis import F2QSynthesis, F2QSynthesisPlugin
+import numpy as np
 
-__all__ = [
-    "EvolutionSynthesis",
-    "F2QSynthesis",
-    "F2QSynthesisPlugin",
-    "InitializeModesSynthesis",
-    "OrbitalRotationSynthesis",
-]
+
+def random_unitary(dim: int, *, seed=None, dtype=complex) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    z = rng.standard_normal((dim, dim)).astype(dtype, copy=False)
+    z += 1j * rng.standard_normal((dim, dim)).astype(dtype, copy=False)
+    q, r = np.linalg.qr(z)
+    d = np.diagonal(r)
+    return q * (d / np.abs(d))


### PR DESCRIPTION
In similar vain to #83, this adds a first prototype for an `OrbitalRotation` gate to the circuit library.
This also has similar limitations in the sense its synthesis plugin making several assumption about the fermion-to-qubit mapping.

Closes #54