### PR TITLE
feat: add a Python-level `OperatorTrait` protocol

### DIFF
--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -64,22 +64,6 @@ impl FermionOperator {
         self.boundaries.push(self.modes.len());
     }
 
-    pub fn simplify(&self, atol: f64) -> Self {
-        let mut terms = HashMap::new();
-        for term in self.iter() {
-            terms
-                .entry((term.modes, term.actions))
-                .and_modify(|c| *c += term.coeff)
-                .or_insert(term.coeff);
-        }
-        let mut out = Self::zero();
-        terms
-            .iter()
-            .filter(|((_, _), coeff)| coeff.abs() > atol)
-            .for_each(|((modes, actions), coeff)| out._append_term(*coeff, actions, modes));
-        out
-    }
-
     pub fn iter(&'_ self) -> impl ExactSizeIterator<Item = FermionOperatorTermView<'_>> + '_ {
         self.coeffs.iter().enumerate().map(|(i, coeff)| {
             let start = self.boundaries[i];
@@ -296,6 +280,22 @@ impl OperatorTrait for FermionOperator {
             }
         }
         true
+    }
+
+    fn simplify(&self, atol: f64) -> Self {
+        let mut terms = HashMap::new();
+        for term in self.iter() {
+            terms
+                .entry((term.modes, term.actions))
+                .and_modify(|c| *c += term.coeff)
+                .or_insert(term.coeff);
+        }
+        let mut out = Self::zero();
+        terms
+            .iter()
+            .filter(|((_, _), coeff)| coeff.abs() > atol)
+            .for_each(|((modes, actions), coeff)| out._append_term(*coeff, actions, modes));
+        out
     }
 
     fn adjoint(&self) -> Self {

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -60,22 +60,6 @@ impl MajoranaOperator {
         self.boundaries.push(self.modes.len());
     }
 
-    pub fn simplify(&self, atol: f64) -> Self {
-        let mut terms = HashMap::new();
-        for term in self.iter() {
-            terms
-                .entry(term.modes)
-                .and_modify(|c| *c += term.coeff)
-                .or_insert(term.coeff);
-        }
-        let mut out = Self::zero();
-        terms
-            .iter()
-            .filter(|(_, coeff)| coeff.abs() > atol)
-            .for_each(|(modes, coeff)| out._append_term(*coeff, modes));
-        out
-    }
-
     pub fn iter(&'_ self) -> impl ExactSizeIterator<Item = MajoranaOperatorTermView<'_>> + '_ {
         self.coeffs.iter().enumerate().map(|(i, coeff)| {
             let start = self.boundaries[i];
@@ -296,6 +280,22 @@ impl OperatorTrait for MajoranaOperator {
             }
         }
         true
+    }
+
+    fn simplify(&self, atol: f64) -> Self {
+        let mut terms = HashMap::new();
+        for term in self.iter() {
+            terms
+                .entry(term.modes)
+                .and_modify(|c| *c += term.coeff)
+                .or_insert(term.coeff);
+        }
+        let mut out = Self::zero();
+        terms
+            .iter()
+            .filter(|(_, coeff)| coeff.abs() > atol)
+            .for_each(|(modes, coeff)| out._append_term(*coeff, modes));
+        out
     }
 
     fn adjoint(&self) -> Self {

--- a/crates/core/src/operators/mod.rs
+++ b/crates/core/src/operators/mod.rs
@@ -19,6 +19,7 @@ pub trait OperatorTrait {
     fn equiv(&self, other: &Self, atol: f64) -> bool;
 
     fn adjoint(&self) -> Self;
+    fn simplify(&self, atol: f64) -> Self;
 
     fn __iadd__(&mut self, other: &Self);
     fn __imul__(&mut self, other: Complex64);

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -533,7 +533,7 @@ impl PyFermionOperator {
     /// Returns:
     ///     An equivalent but simplified operator.
     #[pyo3(signature = (atol=1e-8))]
-    fn simplify(&mut self, atol: f64) -> Self {
+    fn simplify(&self, atol: f64) -> Self {
         Self {
             inner: self.inner.simplify(atol),
         }

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -515,7 +515,7 @@ impl PyMajoranaOperator {
     /// Returns:
     ///     An equivalent but simplified operator.
     #[pyo3(signature = (atol=1e-8))]
-    fn simplify(&mut self, atol: f64) -> Self {
+    fn simplify(&self, atol: f64) -> Self {
         Self {
             inner: self.inner.simplify(atol),
         }

--- a/python/qiskit_fermions/circuit/library/evolution.py
+++ b/python/qiskit_fermions/circuit/library/evolution.py
@@ -14,21 +14,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from qiskit_fermions.operators.protocol import OperatorTrait
 
 from .. import FermionGate
-
-if TYPE_CHECKING:
-    from qiskit_fermions._lib.operators.fermion_operator import FermionOperator
-    from qiskit_fermions._lib.operators.majorana_operator import MajoranaOperator
 
 
 class Evolution(FermionGate):
     """Implements the time-evolution of an operator."""
 
-    def __init__(
-        self, num_fermions: int, operator: FermionOperator | MajoranaOperator, time: float = 1.0
-    ) -> None:
+    def __init__(self, num_fermions: int, operator: OperatorTrait, time: float = 1.0) -> None:
         """Initializes an Evolution gate.
 
         Args:

--- a/python/qiskit_fermions/operators/__init__.py
+++ b/python/qiskit_fermions/operators/__init__.py
@@ -46,6 +46,21 @@ This operator represents fermionic operators in terms of Majorana fermions.
    MajoranaAction
    MajoranaOperator
    gamma
+
+Protocol
+--------
+
+All operator classes provides by this submodule implement at least those methods specified by the
+protocol below:
+
+.. autoclass:: OperatorTrait
+   :member-order: bysource
+   :show-inheritance:
+   :members:
+   :exclude-members: __init__, __subclasshook__, __weakref__
+   :no-inherited-members:
+   :special-members:
+
 """
 
 from qiskit_fermions._lib.operators.fermion_operator import FermionOperator
@@ -53,12 +68,14 @@ from qiskit_fermions._lib.operators.majorana_operator import MajoranaOperator
 
 from .fermion_action import FermionAction, ann, cre
 from .majorana_action import MajoranaAction, gamma
+from .protocol import OperatorTrait
 
 __all__ = [
     "FermionAction",
     "FermionOperator",
     "MajoranaAction",
     "MajoranaOperator",
+    "OperatorTrait",
     "ann",
     "cre",
     "gamma",

--- a/python/qiskit_fermions/operators/protocol.py
+++ b/python/qiskit_fermions/operators/protocol.py
@@ -1,0 +1,99 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""A protocol for operator types."""
+
+from __future__ import annotations
+
+import sys
+from typing import Protocol
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+
+class OperatorTrait(Protocol):
+    """A protocol indicating all methods implemented by operator classes."""
+
+    @classmethod
+    def zero(cls) -> Self:
+        """Constructs the additive identity operator."""
+
+    @classmethod
+    def one(cls) -> Self:
+        """Constructs the multiplicative identity operator."""
+
+    def __iadd__(self, other: Self):
+        """Adds another operator to this one."""
+
+    def __add__(self, other: Self) -> Self:
+        """Adds two operators."""
+
+    def __isub__(self, other: Self):
+        """Subtracts another operator from this one."""
+
+    def __sub__(self, other: Self) -> Self:
+        """Subtracts two operators."""
+
+    def __imul__(self, other: complex):
+        """Multiplies this operator by a scalar."""
+
+    def __mul__(self, other: complex) -> Self:
+        """Multiplies an operator by a scalar."""
+
+    def __idiv__(self, other: complex):
+        """Divides this operator by a scalar."""
+
+    def __div__(self, other: complex) -> Self:
+        """Divides an operator by a scalar."""
+
+    def __neg__(self) -> Self:
+        """Negates this operator."""
+
+    def __iand__(self, other: Self):
+        """Composes (left-multiplies) another operator onto this one."""
+
+    def __and__(self, other: Self) -> Self:
+        """Composes (left-multiplies) two operators."""
+
+    def __imatmul__(self, other: Self):
+        """Takes the dot-product (right-multiplication) of another operator onto this one."""
+
+    def __matmul__(self, other: Self) -> Self:
+        """Takes the dot-product (right-multiplication) two operators."""
+
+    def __pow__(self, exponent: int, modulo: int | None) -> Self:
+        """Exponentiates this operator by the integer exponent."""
+
+    def __len__(self) -> int:
+        """Returns the length of this operator."""
+
+    def equiv(self, other: Self, atol: float) -> bool:
+        """Checks this operator with another for equivalence up to the specified absolute tolerance."""
+
+    def ichop(self, atol: float):
+        """Trims coefficients below the absolute tolerance from this operator."""
+
+    def simplify(self, atol: float) -> Self:
+        """Simplifies the terms of this operator, discarding those below the absolute tolerance."""
+
+    def adjoint(self) -> Self:
+        """Returns the adjoint of this operator."""
+
+    def normal_ordered(self, *args, **kwargs) -> Self:
+        """Returns the normal-ordered form of this operator.
+
+        .. note::
+           A specific implementation of this method may take additional arguments.
+        """

--- a/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import PauliEvolutionGate
@@ -23,18 +22,12 @@ from qiskit.converters import circuit_to_dag
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode
 from qiskit.quantum_info import SparseObservable
 
+from qiskit_fermions.operators.protocol import OperatorTrait
+
 from ... import F2QLayout
 from ..utils import _parse_node_indices
 
-if TYPE_CHECKING:
-    from qiskit_fermions._lib.operators.fermion_operator import FermionOperator
-    from qiskit_fermions._lib.operators.majorana_operator import MajoranaOperator
-else:
-    from qiskit_fermions.operators import FermionOperator, MajoranaOperator
-
-
-# TODO: add an OperatorProtocol to avoid hard-coding this list of types from our package
-MapperFunction = Callable[[FermionOperator | MajoranaOperator], SparseObservable]
+MapperFunction = Callable[[OperatorTrait], SparseObservable]
 """The function signature for :attr:`mapper_fn`."""
 
 


### PR DESCRIPTION
Closes #50 

For now, I'm not adding a more elaborate `Protocol` to describe mapper functions. Instead, the `MapperFunction` `Callable` alias is sufficient for the case of the `Evolution` gate for the time being. If a scenario arises with a more widespread use of such a type, then we can revisit this question.