### PR TITLE
feat: allow ascending index order in `MajoranaOperator.normal_ordered`

### DIFF
--- a/crates/cext/src/operators/majorana_operator.rs
+++ b/crates/cext/src/operators/majorana_operator.rs
@@ -854,10 +854,14 @@ pub unsafe extern "C" fn qf_maj_op_simplify(
 ///
 /// @brief Returns an equivalent operator with normal ordered terms.
 ///
-/// The normal order of an operator term is defined such that all actions are ordered by
-/// lexicographically descending indices.
+/// The normal order of an operator term is defined such that all actions are ordered
+/// lexicographically. Whether they ascend or descend depends on the value of the ``ascending``
+/// parameter.
 ///
 /// @param op A pointer to the operator.
+/// @param ascending Whether indices should ascend or descend.
+/// @param reduce Whether to reduce each term to its minimal form by removing actions that square
+/// to the identity.
 ///
 /// @return A pointer to the created operator.
 ///
@@ -874,7 +878,7 @@ pub unsafe extern "C" fn qf_maj_op_simplify(
 ///     QkComplex64 coeff = {1.0, 0.0};
 ///     qf_maj_op_add_term(op, 4, modes, &coeff);
 ///
-///     QfMajoranaOperator *normal_ordered = qf_maj_op_normal_ordered(op, true);
+///     QfMajoranaOperator *normal_ordered = qf_maj_op_normal_ordered(op, false, true);
 ///
 ///     QkComplex64 coeff_minus = {-1.0, 0.0};
 ///     QfMajoranaOperator *expected = qf_maj_op_zero();
@@ -887,12 +891,13 @@ pub unsafe extern "C" fn qf_maj_op_simplify(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qf_maj_op_normal_ordered(
     op: *const MajoranaOperator,
+    ascending: bool,
     reduce: bool,
 ) -> *mut MajoranaOperator {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let op = unsafe { const_ptr_as_ref(op) };
 
-    let result = op.normal_ordered(reduce);
+    let result = op.normal_ordered(ascending, reduce);
     Box::into_raw(Box::new(result))
 }
 

--- a/crates/core/src/mappers/library/majorana_fermion.rs
+++ b/crates/core/src/mappers/library/majorana_fermion.rs
@@ -137,7 +137,7 @@ mod tests {
         };
 
         let maj_op = fermion_to_majorana(&fer_op);
-        let normal = maj_op.normal_ordered(true);
+        let normal = maj_op.normal_ordered(false, true);
         let canon = normal.simplify(1e-8);
 
         let expected = MajoranaOperator {
@@ -161,7 +161,7 @@ mod tests {
         };
 
         let maj_op = fermion_to_majorana(&fer_op);
-        let normal = maj_op.normal_ordered(true);
+        let normal = maj_op.normal_ordered(false, true);
         let canon = normal.simplify(1e-8);
 
         let expected = MajoranaOperator {

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -96,13 +96,13 @@ impl MajoranaOperator {
         Some(groups)
     }
 
-    pub fn normal_ordered(&self, reduce: bool) -> Self {
+    pub fn normal_ordered(&self, ascending: bool, reduce: bool) -> Self {
         let mut coeffs = vec![];
         let mut modes = vec![];
         let mut boundaries = vec![0];
 
         for term in self.iter() {
-            let (mut sorted_term, sign) = sort_and_parity(term.modes);
+            let (mut sorted_term, sign) = sort_and_parity(term.modes, ascending);
             if reduce {
                 sorted_term = reduce_pairs(&sorted_term);
             }
@@ -119,7 +119,7 @@ impl MajoranaOperator {
     }
 
     pub fn is_hermitian(&self, atol: f64) -> bool {
-        let mut diff = (self.__sub__(&self.adjoint())).normal_ordered(true);
+        let mut diff = (self.__sub__(&self.adjoint())).normal_ordered(false, true);
         diff.ichop(atol);
         diff.equiv(&Self::zero(), atol)
     }
@@ -207,15 +207,17 @@ fn permutation_parity(perm: &[usize]) -> i32 {
 ///
 /// Args:
 ///     tpl: tuple of integers to be sorted.
+///     ascending: whether indices should ascend or descend.
 ///
 /// Returns:
 ///     A tuple (sorted_tpl, sign):
 ///     - sorted_tpl: tuple containing the sorted integers.
 ///     - sign: +1 if the sorting permutation is even, -1 if it is odd.
-fn sort_and_parity(tpl: &[u32]) -> (Vec<u32>, i32) {
+fn sort_and_parity(tpl: &[u32], ascending: bool) -> (Vec<u32>, i32) {
     let mut indexed: Vec<(usize, u32)> = tpl.iter().cloned().enumerate().collect();
     // we need stable sort to ensure that the parity is correctly computed
-    indexed.sort_by_key(|&(_, val)| -(val as i32));
+    let sign = if ascending { 1 } else { -1 };
+    indexed.sort_by_key(|&(_, val)| sign * (val as i32));
 
     let perm: Vec<usize> = indexed.iter().map(|&(i, _)| i).collect();
     let sorted_tpl: Vec<u32> = indexed.iter().map(|&(_, val)| val).collect();
@@ -818,7 +820,16 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(false), op);
+        assert_eq!(op.normal_ordered(false, false), op);
+
+        let expected = MajoranaOperator {
+            coeffs: vec![Complex64::new(-1.0, 0.0)],
+            modes: vec![0, 1],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+
+        assert_eq!(op.normal_ordered(true, false), expected);
     }
 
     #[test]
@@ -830,6 +841,8 @@ mod tests {
             groups: None,
         };
 
+        assert_eq!(op.normal_ordered(true, false), op);
+
         let expected = MajoranaOperator {
             coeffs: vec![Complex64::new(-1.0, 0.0)],
             modes: vec![1, 0],
@@ -837,7 +850,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(false), expected);
+        assert_eq!(op.normal_ordered(false, false), expected);
     }
 
     #[test]
@@ -856,7 +869,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(true), expected);
+        assert_eq!(op.normal_ordered(false, true), expected);
     }
 
     #[test]

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -102,7 +102,7 @@ impl MajoranaOperatorDataIter {
 ///    ============== =================================================================================
 ///
 /// The integers in ``modes`` index the Majorana modes, :math:`j`. When using the convenience
-/// function :py:func:`.gamma`, even (odd) indices are used for :math`\gamma` (:math:`\gamma'`).
+/// function :py:func:`.gamma`, even (odd) indices are used for :math:`\gamma` (:math:`\gamma'`).
 ///
 /// .. note::
 ///    You may access **read-only copies** of these internal arrays via their respective methods:
@@ -755,9 +755,10 @@ impl PyMajoranaOperator {
     /// Returns an equivalent operator with normal ordered terms.
     ///
     /// The normal order of an operator term is defined such that all actions are ordered by
-    /// lexicographically descending indices. With the convention set forth by :py:func:`.gamma` to
-    /// place :math:`\gamma` (:math:`\gamma'`) on even (odd) indices, this results in the following
-    /// example:
+    /// lexicographically. Whether they ascend or descend depends on the value of the ``ascending``
+    /// parameter. With the convention set forth by :py:func:`.gamma` to place :math:`\gamma`
+    /// (:math:`\gamma'`) on even (odd) indices, this results in the following example (for the
+    /// default, ``ascending=False``):
     /// ``[\gamma(1, True), \gamma(1, False), \gamma(0, True), \gamma(0, False)] = [3, 2, 1, 0]``.
     ///
     /// .. doctest::
@@ -770,15 +771,16 @@ impl PyMajoranaOperator {
     ///      -1.000000e0 +0.000000e0j * (1)
     ///
     /// Args:
+    ///     ascending: whether indices should ascend or descend.
     ///     reduce: whether to reduce each term to its minimal form by removing actions that square
     ///         to the identity. See also the example above.
     ///
     /// Returns:
     ///     An equivalent but normal-ordered operator.
-    #[pyo3(signature = (reduce=true))]
-    fn normal_ordered(&self, reduce: bool) -> Self {
+    #[pyo3(signature = (ascending=false, reduce=true))]
+    fn normal_ordered(&self, ascending: bool, reduce: bool) -> Self {
         Self {
-            inner: self.inner.normal_ordered(reduce),
+            inner: self.inner.normal_ordered(ascending, reduce),
         }
     }
 

--- a/docs/cdoc/qf-maj-op.rst
+++ b/docs/cdoc/qf-maj-op.rst
@@ -66,7 +66,7 @@ commonly used for sparse matrices. More concretely, a single operator contains 4
    ============== =================================================================================
 
 The integers in ``modes`` index the Majorana modes, :math:`j`. When using the convenience
-function :py:func:`.gamma`, even (odd) indices are used for :math`\gamma` (:math:`\gamma'`).
+function :py:func:`.gamma`, even (odd) indices are used for :math:`\gamma` (:math:`\gamma'`).
 
 .. note::
    You may access **read-only copies** of these internal arrays via their respective functions:

--- a/tests/c/test_majorana_fermion.c
+++ b/tests/c/test_majorana_fermion.c
@@ -24,7 +24,7 @@ static int test_fermion_to_majorana(void) {
     qf_ferm_op_add_term(fer_op, 2, action_fer, indices_fer, &coeff);
 
     QfMajoranaOperator *result = qf_fermion_to_majorana(fer_op);
-    QfMajoranaOperator *canon = qf_maj_op_normal_ordered(result, true);
+    QfMajoranaOperator *canon = qf_maj_op_normal_ordered(result, false, true);
 
     uint64_t num_terms = 2;
     uint64_t num_modes = 2;

--- a/tests/c/test_majorana_operator.c
+++ b/tests/c/test_majorana_operator.c
@@ -337,7 +337,7 @@ static int test_normal_ordered(void) {
     QkComplex64 coeff = {1.0, 0.0};
     qf_maj_op_add_term(op, 4, modes, &coeff);
 
-    QfMajoranaOperator *normal_ordered = qf_maj_op_normal_ordered(op, false);
+    QfMajoranaOperator *normal_ordered = qf_maj_op_normal_ordered(op, false, false);
 
     QkComplex64 coeff_minus = {-1.0, 0.0};
     QfMajoranaOperator *expected = qf_maj_op_zero();

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -242,14 +242,17 @@ class MajoranaOperatorTests(ABC):
     def test_normal_ordered(self, subtests):
         cls = self.get_class()
 
-        with subtests.test("no change"):
+        with subtests.test("descending order"):
             op = cls.from_dict({(gamma(0, True), gamma(0, False)): 1})
-            assert op.normal_ordered().equiv(op)
+            assert op.normal_ordered(ascending=False).equiv(op)
+            expected = cls.from_dict({(gamma(0, False), gamma(0, True)): -1})
+            assert op.normal_ordered(ascending=True).equiv(expected)
 
-        with subtests.test("simple reorder"):
+        with subtests.test("ascending order"):
             op = cls.from_dict({(gamma(0, False), gamma(0, True)): 1})
+            assert op.normal_ordered(ascending=True).equiv(op)
             expected = cls.from_dict({(gamma(0, True), gamma(0, False)): -1})
-            assert op.normal_ordered().equiv(expected)
+            assert op.normal_ordered(ascending=False).equiv(expected)
 
         with subtests.test("reorder with reduction"):
             op = cls.from_dict({(gamma(0, True), gamma(0, False), gamma(0, True)): 1})


### PR DESCRIPTION
In similar vein to #81, this adds an optional argument to `MajoranaOperator.normal_ordered` allowing to customize the index ordering convention.