### PR TITLE
Implement a decomposition for the `Evolution` gate

### DIFF
--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -150,25 +150,6 @@ impl FermionOperator {
         }
         true
     }
-
-    pub fn relabel_modes(&self, permutation: Vec<u32>) -> Result<Self, CoherenceError> {
-        if permutation.iter().collect::<HashSet<_>>().len() != permutation.len() {
-            return Err(CoherenceError::DuplicateIndices);
-        }
-        let mut out = self.clone();
-        let new_modes: Result<Vec<u32>, CoherenceError> = self
-            .modes
-            .iter()
-            .map(|&idx| {
-                permutation
-                    .get(idx as usize)
-                    .cloned()
-                    .ok_or(CoherenceError::IndexMapTooSmall)
-            })
-            .collect();
-        out.modes = new_modes?;
-        Ok(out)
-    }
 }
 
 fn _normal_ordered_term(
@@ -386,6 +367,25 @@ impl OperatorTrait for FermionOperator {
 
     fn get_support(&self) -> HashSet<u32> {
         HashSet::from_iter(self.modes.clone())
+    }
+
+    fn relabel_modes(&self, permutation: Vec<u32>) -> Result<Self, CoherenceError> {
+        if permutation.iter().collect::<HashSet<_>>().len() != permutation.len() {
+            return Err(CoherenceError::DuplicateIndices);
+        }
+        let mut out = self.clone();
+        let new_modes: Result<Vec<u32>, CoherenceError> = self
+            .modes
+            .iter()
+            .map(|&idx| {
+                permutation
+                    .get(idx as usize)
+                    .cloned()
+                    .ok_or(CoherenceError::IndexMapTooSmall)
+            })
+            .collect();
+        out.modes = new_modes?;
+        Ok(out)
     }
 }
 

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -383,6 +383,10 @@ impl OperatorTrait for FermionOperator {
         self.boundaries = boundaries;
         self.groups = None;
     }
+
+    fn get_support(&self) -> HashSet<u32> {
+        HashSet::from_iter(self.modes.clone())
+    }
 }
 
 #[cfg(test)]
@@ -1049,6 +1053,19 @@ mod tests {
         };
 
         assert!(!op2.conserves_particle_number());
+    }
+
+    #[test]
+    fn test_get_support() {
+        let op = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(1.0, 0.0)],
+            actions: vec![true, false, true, true, false, false],
+            modes: vec![0, 4, 1, 3, 4, 7],
+            boundaries: vec![0, 2, 4],
+            groups: None,
+        };
+
+        assert_eq!(op.get_support(), HashSet::from([0, 1, 3, 4, 7]));
     }
 
     #[test]

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -148,25 +148,6 @@ impl MajoranaOperator {
         }
         true
     }
-
-    pub fn relabel_modes(&self, permutation: Vec<u32>) -> Result<Self, CoherenceError> {
-        if permutation.iter().collect::<HashSet<_>>().len() != permutation.len() {
-            return Err(CoherenceError::DuplicateIndices);
-        }
-        let mut out = self.clone();
-        let new_modes: Result<Vec<u32>, CoherenceError> = self
-            .modes
-            .iter()
-            .map(|&idx| {
-                permutation
-                    .get(idx as usize)
-                    .cloned()
-                    .ok_or(CoherenceError::IndexMapTooSmall)
-            })
-            .collect();
-        out.modes = new_modes?;
-        Ok(out)
-    }
 }
 
 /// FIXME: follow rustdoc standards
@@ -376,6 +357,25 @@ impl OperatorTrait for MajoranaOperator {
 
     fn get_support(&self) -> HashSet<u32> {
         HashSet::from_iter(self.modes.clone())
+    }
+
+    fn relabel_modes(&self, permutation: Vec<u32>) -> Result<Self, CoherenceError> {
+        if permutation.iter().collect::<HashSet<_>>().len() != permutation.len() {
+            return Err(CoherenceError::DuplicateIndices);
+        }
+        let mut out = self.clone();
+        let new_modes: Result<Vec<u32>, CoherenceError> = self
+            .modes
+            .iter()
+            .map(|&idx| {
+                permutation
+                    .get(idx as usize)
+                    .cloned()
+                    .ok_or(CoherenceError::IndexMapTooSmall)
+            })
+            .collect();
+        out.modes = new_modes?;
+        Ok(out)
     }
 }
 

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -373,6 +373,10 @@ impl OperatorTrait for MajoranaOperator {
         self.boundaries = boundaries;
         self.groups = None;
     }
+
+    fn get_support(&self) -> HashSet<u32> {
+        HashSet::from_iter(self.modes.clone())
+    }
 }
 
 #[cfg(test)]
@@ -933,6 +937,18 @@ mod tests {
             }
             .is_even()
         );
+    }
+
+    #[test]
+    fn test_get_support() {
+        let op = MajoranaOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(1.0, 0.0)],
+            modes: vec![0, 4, 1, 3, 4, 7],
+            boundaries: vec![0, 2, 4],
+            groups: None,
+        };
+
+        assert_eq!(op.get_support(), HashSet::from([0, 1, 3, 4, 7]));
     }
 
     #[test]

--- a/crates/core/src/operators/mod.rs
+++ b/crates/core/src/operators/mod.rs
@@ -15,6 +15,16 @@ use std::collections::HashSet;
 use num_complex::Complex64;
 use thiserror::Error;
 
+/// Error cases stemming from data coherence at the point of entry into `OperatorTrait` from
+/// user-provided arrays.
+#[derive(Error, Debug)]
+pub enum CoherenceError {
+    #[error("the input contains duplicate indices")]
+    DuplicateIndices,
+    #[error("the provided index mapping does not account for the entire length of the operator")]
+    IndexMapTooSmall,
+}
+
 pub trait OperatorTrait {
     fn zero() -> Self;
     fn one() -> Self;
@@ -30,6 +40,9 @@ pub trait OperatorTrait {
     fn ichop(&mut self, atol: f64);
 
     fn get_support(&self) -> HashSet<u32>;
+    fn relabel_modes(&self, permutation: Vec<u32>) -> Result<Self, CoherenceError>
+    where
+        Self: Sized;
 }
 
 pub trait OperatorMacro {
@@ -224,16 +237,6 @@ macro_rules! impl_operator_macro {
             }
         }
     };
-}
-
-/// Error cases stemming from data coherence at the point of entry into `OperatorTrait` from
-/// user-provided arrays.
-#[derive(Error, Debug)]
-pub enum CoherenceError {
-    #[error("the input contains duplicate indices")]
-    DuplicateIndices,
-    #[error("the provided index mapping does not account for the entire length of the operator")]
-    IndexMapTooSmall,
 }
 
 pub mod fermion_operator;

--- a/crates/core/src/operators/mod.rs
+++ b/crates/core/src/operators/mod.rs
@@ -10,6 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::collections::HashSet;
+
 use num_complex::Complex64;
 use thiserror::Error;
 
@@ -26,6 +28,8 @@ pub trait OperatorTrait {
     fn __iand__(&mut self, other: &Self);
     fn __imatmul__(&mut self, other: &Self);
     fn ichop(&mut self, atol: f64);
+
+    fn get_support(&self) -> HashSet<u32>;
 }
 
 pub trait OperatorMacro {

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -10,6 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::collections::HashSet;
+
 use num_complex::Complex64;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -465,6 +467,25 @@ impl PyFermionOperator {
     ///     A list of the operator's terms boundaries.
     fn get_boundaries(&self) -> Vec<usize> {
         self.inner.boundaries().to_vec()
+    }
+
+    /// Returns the set of mode indices which this operator acts upon.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator.from_dict(
+    ///     ...     {
+    ///     ...         ((True, 0), (False, 4)): 1,
+    ///     ...         ((True, 1), (True, 3), (False, 4), (False, 7)): 1,
+    ///     ...     }
+    ///     ... )
+    ///     >>> assert op.get_support() == {0, 1, 3, 4, 7}
+    ///
+    /// Returns:
+    ///     The set of mode indices which this operator acts upon.
+    fn get_support(&self) -> HashSet<u32> {
+        self.inner.get_support()
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, _py: Python<'_>) -> PyResult<bool> {

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -691,6 +691,36 @@ impl PyFermionOperator {
         Py::new(slf.py(), iter)
     }
 
+    /// Constructs a new operator from an iterator of terms (see also :meth:`.iter_terms`).
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator.from_dict({(): 2.0, ((True, 0),): 1.0, ((False, 1),): -1.0j})
+    ///     >>> op.equiv(FermionOperator.from_terms(op.iter_terms()))
+    ///     True
+    ///
+    /// Args:
+    ///     terms: an iterator of terms as produced by :meth:`.iter_terms`.
+    ///
+    /// Returns:
+    ///     A new operator.
+    #[classmethod]
+    fn from_terms(_cls: &Bound<'_, PyType>, terms: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let mut inner = FermionOperator::zero();
+        terms.try_iter()?.try_for_each(|item| -> PyResult<()> {
+            let (term, coeff) = item?.extract::<(Vec<PyFermionAction>, Complex64)>()?;
+            inner.coeffs.push(coeff);
+            term.iter().for_each(|(a, m)| {
+                inner.actions.push(*a);
+                inner.modes.push(*m);
+            });
+            inner.boundaries.push(inner.modes.len());
+            Ok(())
+        })?;
+        Ok(Self { inner })
+    }
+
     /// An optional vector of `group indices` for each term.
     ///
     /// For more information refer to the :mod:`~qiskit_fermions.operators.grouping` module.

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -158,6 +158,7 @@ impl FermionOperatorDataIter {
 ///
 ///    zero
 ///    one
+///    from_terms
 ///
 /// Iteration
 /// ---------

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -159,6 +159,7 @@ impl MajoranaOperatorDataIter {
 ///
 ///    zero
 ///    one
+///    from_terms
 ///
 /// Iteration
 /// ---------

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -650,6 +650,33 @@ impl PyMajoranaOperator {
         Py::new(slf.py(), iter)
     }
 
+    /// Constructs a new operator from an iterator of terms (see also :meth:`.iter_terms`).
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import MajoranaOperator
+    ///     >>> op = MajoranaOperator.from_dict({(): 2.0, (0,): 1.0, (1,): -1.0j})
+    ///     >>> op.equiv(MajoranaOperator.from_terms(op.iter_terms()))
+    ///     True
+    ///
+    /// Args:
+    ///     terms: an iterator of terms as produced by :meth:`.iter_terms`.
+    ///
+    /// Returns:
+    ///     A new operator.
+    #[classmethod]
+    fn from_terms(_cls: &Bound<'_, PyType>, terms: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let mut inner = MajoranaOperator::zero();
+        terms.try_iter()?.try_for_each(|item| -> PyResult<()> {
+            let (term, coeff) = item?.extract::<(Vec<PyMajoranaAction>, Complex64)>()?;
+            inner.coeffs.push(coeff);
+            inner.modes.extend_from_slice(&term);
+            inner.boundaries.push(inner.modes.len());
+            Ok(())
+        })?;
+        Ok(Self { inner })
+    }
+
     /// An optional vector of `group indices` for each term.
     ///
     /// For more information refer to the :mod:`~qiskit_fermions.operators.grouping` module.

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -10,6 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::collections::HashSet;
+
 use num_complex::Complex64;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -435,6 +437,25 @@ impl PyMajoranaOperator {
     ///     A list of the operator's terms boundaries.
     fn get_boundaries(&self) -> Vec<usize> {
         self.inner.boundaries().to_vec()
+    }
+
+    /// Returns the set of mode indices which this operator acts upon.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import MajoranaOperator
+    ///     >>> op = MajoranaOperator.from_dict(
+    ///     ...     {
+    ///     ...         (0, 4): 1,
+    ///     ...         (1, 3, 4, 7): 1,
+    ///     ...     }
+    ///     ... )
+    ///     >>> assert op.get_support() == {0, 1, 3, 4, 7}
+    ///
+    /// Returns:
+    ///     The set of mode indices which this operator acts upon.
+    fn get_support(&self) -> HashSet<u32> {
+        self.inner.get_support()
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, _py: Python<'_>) -> PyResult<bool> {

--- a/python/qiskit_fermions/circuit/fermion_circuit.py
+++ b/python/qiskit_fermions/circuit/fermion_circuit.py
@@ -14,9 +14,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, cast
 
-from qiskit.circuit import QuantumCircuit, QuantumRegister
+from qiskit.circuit import Instruction, QuantumCircuit, QuantumRegister
 
 from . import Fermion, FermionSpecifier
 from .fermion_gate import FermionGate
@@ -76,6 +77,20 @@ class FermionCircuit:
             raise ValueError("Unsupported instruction type: %s", type(gate))
 
         self._inner.append(gate, fargs, cargs, copy=copy)
+
+    def decompose(
+        self,
+        gates_to_decompose: (
+            str | type[Instruction] | Sequence[str | type[Instruction]] | None
+        ) = None,
+        reps: int = 1,
+    ) -> FermionCircuit:
+        """Re-exposes :external:meth:`~qiskit.circuit.QuantumCircuit.decompose`."""
+        inner_decomposed = self._inner.decompose(gates_to_decompose=gates_to_decompose, reps=reps)
+        out = FermionCircuit(len(self.register))
+        out.register = self.register
+        out._inner = inner_decomposed
+        return out
 
     def draw(self, *args, **kwargs) -> Any:
         """Directly exposes the inner circuit's :meth:`~qiskit.circuit.QuantumCircuit.draw` method."""

--- a/python/qiskit_fermions/circuit/library/evolution.py
+++ b/python/qiskit_fermions/circuit/library/evolution.py
@@ -33,4 +33,42 @@ class Evolution(FermionGate):
         self.operator = operator
         """The operator under which to time-evolve the acted-upon fermionic modes."""
 
-        super().__init__("Evolution", num_fermions, [time])
+        super().__init__(
+            "Evolution", num_fermions, [time], label=f"evolve({' '.join(str(operator).split())})"
+        )
+
+    def _define(self) -> None:
+        from qiskit_fermions.circuit import FermionCircuit
+
+        definition = FermionCircuit(self.num_fermions)
+
+        # when the operator being evolved has groups use those for the decomposition, otherwise
+        # decompose into all individual terms
+        iterator = (
+            self.operator.iter_terms
+            if self.operator.groups is None
+            else self.operator.split_out_groups
+        )
+
+        for item in iterator():
+            if isinstance(item, tuple):
+                # iterating over terms rather than operator groups
+                item = self.operator.__class__.from_terms([item])
+
+            # reduce each operator to act only on the non-idle part of the register
+            active = item.get_support()
+            num_active = len(active)
+            active_idx = iter(range(num_active))
+            idle_idx = iter(range(num_active, self.num_fermions))
+            permutation = [
+                next(active_idx) if idx in active else next(idle_idx)
+                for idx in range(self.num_fermions)
+            ]
+            relabeled = item.relabel_modes(permutation)
+
+            definition.append(
+                Evolution(num_active, relabeled, time=self.params[0]),
+                [definition.fermions[idx] for idx in sorted(active)],
+            )
+
+        self._definition = definition._inner

--- a/python/qiskit_fermions/operators/protocol.py
+++ b/python/qiskit_fermions/operators/protocol.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterable, Iterator
 from typing import Protocol
 
 if sys.version_info >= (3, 11):
@@ -78,6 +79,13 @@ class OperatorTrait(Protocol):
 
     def __len__(self) -> int:
         """Returns the length of this operator."""
+
+    def iter_terms(self) -> Iterator:
+        """Iterates over the terms of this operator."""
+
+    @classmethod
+    def from_terms(cls, terms: Iterable) -> Self:
+        """Constructs a new operator from an iterator (see also :meth:`.iter_terms`)."""
 
     def equiv(self, other: Self, atol: float) -> bool:
         """Checks this operator with another for equivalence up to the specified absolute tolerance."""

--- a/python/qiskit_fermions/operators/protocol.py
+++ b/python/qiskit_fermions/operators/protocol.py
@@ -99,6 +99,9 @@ class OperatorTrait(Protocol):
     def adjoint(self) -> Self:
         """Returns the adjoint of this operator."""
 
+    def get_support(self) -> frozenset[int]:
+        """Returns the set of mode indices which this operator acts upon."""
+
     def normal_ordered(self, *args, **kwargs) -> Self:
         """Returns the normal-ordered form of this operator.
 

--- a/python/qiskit_fermions/operators/protocol.py
+++ b/python/qiskit_fermions/operators/protocol.py
@@ -111,3 +111,14 @@ class OperatorTrait(Protocol):
         .. note::
            A specific implementation of this method may take additional arguments.
         """
+
+    @property
+    def groups(self) -> list[int] | None:
+        """Returns the groups indices."""
+
+    @groups.setter
+    def groups(self, groups: list[int] | None) -> None:
+        """Sets the groups indices."""
+
+    def split_out_groups(self) -> list[Self]:
+        """Splits this operator into an optional list of new operators based on its :attr:`.groups`."""

--- a/python/qiskit_fermions/operators/protocol.py
+++ b/python/qiskit_fermions/operators/protocol.py
@@ -102,6 +102,9 @@ class OperatorTrait(Protocol):
     def get_support(self) -> frozenset[int]:
         """Returns the set of mode indices which this operator acts upon."""
 
+    def relabel_modes(self, permutation: list[int]) -> Self:
+        """Relabels the modes of the operator."""
+
     def normal_ordered(self, *args, **kwargs) -> Self:
         """Returns the normal-ordered form of this operator.
 

--- a/tests/python/circuit/library/test_evolution.py
+++ b/tests/python/circuit/library/test_evolution.py
@@ -42,3 +42,63 @@ def test_evolution_gate():
     assert len(gates) == 1
     assert isinstance(gates[0].operation, Evolution)
     assert gates[0].operation.operator == hamil
+
+
+def test_evolution_gate_decompose():
+    hamil = FermionOperator.from_dict(
+        {
+            ((True, 0), (False, 1)): 2.0,
+            ((True, 1), (False, 0)): 2.0,
+            ((True, 2), (False, 3)): -2.0,
+            ((True, 3), (False, 2)): -2.0,
+        }
+    )
+    time = 1.5
+    num_fermions = 4
+    circ = FermionCircuit(num_fermions)
+    evo = Evolution(num_fermions, hamil, time=time)
+    circ.append(evo, circ.fermions)
+
+    decomposed = circ.decompose()
+
+    # TODO: perform a better assertion instead of accessing an internal attribute here
+    # NOTE: for example, we should be able to perform a statevector-like check that the evolution is
+    # implemented physically correct
+    gates = decomposed._inner.data
+
+    expected_num_gates = 4
+    assert len(gates) == expected_num_gates
+    assert all(isinstance(gates[i].operation, Evolution) for i in range(expected_num_gates))
+
+
+def test_evolution_gate_decompose_with_groups():
+    hamil = FermionOperator.zero()
+    hamil += FermionOperator.from_dict(
+        {
+            ((True, 0), (False, 1)): 2.0,
+            ((True, 1), (False, 0)): 2.0,
+        }
+    )
+    hamil += FermionOperator.from_dict(
+        {
+            ((True, 2), (False, 3)): -2.0,
+            ((True, 3), (False, 2)): -2.0,
+        }
+    )
+    hamil.groups = [0, 0, 1, 1]
+    time = 1.5
+    num_fermions = 4
+    circ = FermionCircuit(num_fermions)
+    evo = Evolution(num_fermions, hamil, time=time)
+    circ.append(evo, circ.fermions)
+
+    decomposed = circ.decompose()
+
+    # TODO: perform a better assertion instead of accessing an internal attribute here
+    # NOTE: for example, we should be able to perform a statevector-like check that the evolution is
+    # implemented physically correct
+    gates = decomposed._inner.data
+
+    expected_num_gates = 2
+    assert len(gates) == expected_num_gates
+    assert all(isinstance(gates[i].operation, Evolution) for i in range(expected_num_gates))

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -42,6 +42,13 @@ class FermionOperatorTests(ABC):
         with subtests.test("boundaries"):
             assert np.all(op.get_boundaries() == boundaries)
 
+    def test_get_support(self):
+        cls = self.get_class()
+        op = cls.from_dict(
+            {((True, 0), (False, 4)): 1, ((True, 1), (True, 3), (False, 4), (False, 7)): 1}
+        )
+        assert op.get_support() == {0, 1, 3, 4, 7}
+
     def test_zero(self):
         cls = self.get_class()
         op = cls.zero()

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -83,6 +83,22 @@ class FermionOperatorTests(ABC):
         op = cls.one()
         assert list(op.iter_terms()) == [([], 1)]
 
+    def test_from_terms(self, subtests):
+        cls = self.get_class()
+        op = cls.from_dict(
+            {
+                (): 2,
+                (cre(1), ann(2)): 1,
+                (cre(2), ann(1)): 0.5,
+                (cre(3), ann(4)): -0.5j,
+                (cre(4), ann(3)): 1 - 0.5j,
+            }
+        )
+        with subtests.test("iterator"):
+            assert op.equiv(cls.from_terms(op.iter_terms()))
+        with subtests.test("list"):
+            assert op.equiv(cls.from_terms(list(op.iter_terms())))
+
     def test_ichop(self):
         cls = self.get_class()
         op = cls.from_dict({(): 1e-4, ((True, 0),): 1e-6, ((False, 0),): 1e-10})

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -39,6 +39,11 @@ class MajoranaOperatorTests(ABC):
         with subtests.test("boundaries"):
             assert np.all(op.get_boundaries() == boundaries)
 
+    def test_get_support(self):
+        cls = self.get_class()
+        op = cls.from_dict({(0, 4): 1, (1, 3, 4, 7): 1})
+        assert op.get_support() == {0, 1, 3, 4, 7}
+
     def test_zero(self):
         cls = self.get_class()
         op = cls.zero()

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -80,6 +80,22 @@ class MajoranaOperatorTests(ABC):
         op = cls.one()
         assert list(op.iter_terms()) == [([], 1)]
 
+    def test_from_terms(self, subtests):
+        cls = self.get_class()
+        op = cls.from_dict(
+            {
+                (): 2,
+                (gamma(0, False),): 1,
+                (gamma(0, False), gamma(0, True)): 0.5,
+                (gamma(1, False), gamma(0, True)): -0.5j,
+                (gamma(1, True), gamma(1, False)): 1 - 0.5j,
+            }
+        )
+        with subtests.test("iterator"):
+            assert op.equiv(cls.from_terms(op.iter_terms()))
+        with subtests.test("list"):
+            assert op.equiv(cls.from_terms(list(op.iter_terms())))
+
     def test_ichop(self):
         cls = self.get_class()
         op = cls.from_dict({(): 1e-4, (0,): 1e-6, (1,): 1e-10})


### PR DESCRIPTION
Although not strictly required right now, implementing this simple decomposition of the `Evolution` gate helped me understand and address some limitations in the `OperatorTrait` protocol and add some useful convenience methods to the relevant operator classes.

This also lays the foundation for the soon-to-follow work on the transpiler pipeline.