### PR TITLE
refactor: make `num_qubits` in EvolutionSynthesis flexible

### DIFF
--- a/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
@@ -27,7 +27,7 @@ from qiskit_fermions.operators.protocol import OperatorTrait
 from ... import F2QLayout
 from ..utils import _parse_node_indices
 
-MapperFunction = Callable[[OperatorTrait], SparseObservable]
+MapperFunction = Callable[[OperatorTrait, int], SparseObservable]
 """The function signature for :attr:`mapper_fn`."""
 
 
@@ -44,6 +44,11 @@ class EvolutionSynthesis:
 
         self.mapper_fn: MapperFunction = mapper_fn
         """The fermion-to-qubit operator mapping function.
+
+        The two input arguments should be the following:
+
+        1. the operator to be mapped.
+        2. the number of qubits that the resulting operator should be defined on.
 
         .. note::
            It is the user's responsibility to ensure that this function is in-sync with the global
@@ -83,7 +88,7 @@ class EvolutionSynthesis:
 
         local_op = in_node.op.operator
         global_op = local_op.relabel_modes(global_fermion_indices)
-        pauli_op = self.mapper_fn(global_op).simplify()
+        pauli_op = self.mapper_fn(global_op, len(qreg)).simplify()
 
         circ = QuantumCircuit(qreg)
         circ.append(PauliEvolutionGate(pauli_op, time=in_node.op.params[0]), qreg)

--- a/tests/python/transpiler/passes/test_custom_layout.py
+++ b/tests/python/transpiler/passes/test_custom_layout.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from functools import partial
 
 from qiskit.circuit import QuantumRegister
 from qiskit.quantum_info import SparseObservable
@@ -88,17 +89,17 @@ def build_fermi_hubbard_square_lattice(
 # general and only implemented for the purposes of this test.
 def derby_klassen(
     op: MajoranaOperator,
+    num_qubits: int,
     initial_state: list[bool],
     edge_face_map: dict[tuple[int, int], int],
-    num_qubits: int,
 ) -> SparseObservable:
     """Implements the Derby-Klassen fermion-to-qubit encoding. [1]_
 
     Args:
         op: the operator to encode.
+        num_qubits: the total number of qubits in the resulting operator.
         initial_state: the initial occupation state of the fermionic modes.
         edge_face_map: a mapping of fermionic lattice edges to auxiliary qubit indices.
-        num_qubits: the total number of qubits in the resulting operator.
 
     Returns:
         The mapped operator.
@@ -186,7 +187,7 @@ def test_derby_klassen():
         (14, 10): 19,
         (14, 13): 19,
     }
-    qop = derby_klassen(hamil, initial_state, edge_face_map, num_qubits)
+    qop = derby_klassen(hamil, num_qubits, initial_state, edge_face_map)
 
     expected = SparseObservable.from_list(
         [
@@ -300,27 +301,26 @@ def test_custom_layout():
     num_qubits = 20
     hamil = build_fermi_hubbard_square_lattice(4, 4, 5.0, 5.0)
 
-    def mapper_fn(op):
-        initial_state = [bool(int(c)) for c in "1010010110100101"]
-        edge_face_map = {
-            (1, 2): 16,
-            (1, 5): 16,
-            (6, 2): 16,
-            (6, 5): 16,
-            (6, 7): 18,
-            (6, 10): 18,
-            (11, 7): 18,
-            (11, 10): 18,
-            (4, 5): 17,
-            (4, 8): 17,
-            (9, 5): 17,
-            (9, 8): 17,
-            (9, 10): 19,
-            (9, 13): 19,
-            (14, 10): 19,
-            (14, 13): 19,
-        }
-        return derby_klassen(op, initial_state, edge_face_map, num_qubits)
+    initial_state = [bool(int(c)) for c in "1010010110100101"]
+    edge_face_map = {
+        (1, 2): 16,
+        (1, 5): 16,
+        (6, 2): 16,
+        (6, 5): 16,
+        (6, 7): 18,
+        (6, 10): 18,
+        (11, 7): 18,
+        (11, 10): 18,
+        (4, 5): 17,
+        (4, 8): 17,
+        (9, 5): 17,
+        (9, 8): 17,
+        (9, 10): 19,
+        (9, 13): 19,
+        (14, 10): 19,
+        (14, 13): 19,
+    }
+    mapper_fn = partial(derby_klassen, initial_state=initial_state, edge_face_map=edge_face_map)
 
     circ = FermionCircuit(num_fermions)
     circ.append(Evolution(num_fermions, hamil), circ.fermions)

--- a/tests/python/transpiler/passes/test_evolution_synthesis.py
+++ b/tests/python/transpiler/passes/test_evolution_synthesis.py
@@ -14,8 +14,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-
 from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.transpiler import PassManager
 from qiskit_fermions.circuit import FermionCircuit
@@ -41,10 +39,8 @@ def test_evolution_gate_synthesis():
     evo = Evolution(num_fermions, hamil, time=time)
     circ.append(evo, circ.fermions)
 
-    mapper_fn = partial(jordan_wigner, num_qubits=num_fermions)
-
     synth = F2QSynthesis()
-    synth.plugins[Evolution] = EvolutionSynthesis(mapper_fn)
+    synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
 
     pm = PassManager([TrivialF2QLayout(), synth])
 
@@ -76,9 +72,9 @@ def test_custom_qubit_ordering():
 
     custom_qubit_ordering = [0, 2, 1, 3]
 
-    def custom_qubit_ordering_mapper_fn(op):
+    def custom_qubit_ordering_mapper_fn(op, num_qubits):
         relabeled = op.relabel_modes(custom_qubit_ordering)
-        return jordan_wigner(relabeled, num_fermions)
+        return jordan_wigner(relabeled, num_qubits)
 
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(custom_qubit_ordering_mapper_fn)


### PR DESCRIPTION
Rather than force a fixed number of qubits be hard-coded inside the fermion-to-qubit mapper function inside the `EvolutionSynthesis` transpiler pass plugin, this relaxes the design and instead makes this a required input argument to the mapper function. This allows for much more flexibility in building preset transpiler passes down the line. It also means that the `jordan_wigner` function can be used directly without having to be wrapped by `functools.partial`. The downside is obviously that user-provided mapper functions need to be adjusted, but they are most likely determining this input argument in some form or another anyways.