### PR TITLE
feat: formalize the staged pass manager

### DIFF
--- a/docs/pydoc/index.rst
+++ b/docs/pydoc/index.rst
@@ -47,6 +47,7 @@ Transpiler
 
    qiskit_fermions.transpiler
    qiskit_fermions.transpiler.passes
+   qiskit_fermions.transpiler.presets
 
 
 **************

--- a/docs/pydoc/qiskit_fermions.transpiler.presets.rst
+++ b/docs/pydoc/qiskit_fermions.transpiler.presets.rst
@@ -1,0 +1,4 @@
+.. automodule:: qiskit_fermions.transpiler.presets
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/python/qiskit_fermions/circuit/fermion_circuit.py
+++ b/python/qiskit_fermions/circuit/fermion_circuit.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, cast
 
@@ -75,8 +76,11 @@ class FermionCircuit:
         """
         if not isinstance(gate, FermionGate):
             raise ValueError("Unsupported instruction type: %s", type(gate))
-
         self._inner.append(gate, fargs, cargs, copy=copy)
+
+    def count_ops(self) -> OrderedDict[str, int]:
+        """Re-exposes :external:meth:`~qiskit.circuit.QuantumCircuit.count_ops`."""
+        return cast(OrderedDict[str, int], self._inner.count_ops())
 
     def decompose(
         self,

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -112,9 +112,28 @@ Qiskit's transpilation process is orchestrated by a :class:`~qiskit.transpiler.P
 In particular, a :class:`~qiskit.transpiler.StagedPassManager` can be used to orchestrate the
 transpilation into stages as explained above.
 
-.. important::
-   The ``qiskit_fermions`` package does not (yet) provide transpilation presets. These will be added
-   in the future and this section will be expanded upon then.
+Here, we are dealing with a change of circuit representation converting :class:`.FermionCircuit`
+instances to :external:class:`~qiskit.circuit.QuantumCircuit` ones. As such, this module provides
+its own interfaces of these transpiler pass managers listed below.
+
+.. note::
+   Qiskit is currently working on native support of transpiler pipelines involving more than a
+   single intermediate representation. Once that gets more formalized, the implementation here
+   will be aligned with the resulting interfaces. See also `this tracking issue
+   <https://github.com/Qiskit/qiskit/issues/16115>`_.
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   FermionPassManager
+   FermionStagedPassManager
+   FermionToQubitConverter
+
+Presets
+^^^^^^^
+
+For user convenience, the :mod:`qiskit_fermions.transpiler.presets` module provides a number of
+functions for quickly building pre-defined transpilation pipelines.
 """
 
 from __future__ import annotations
@@ -124,6 +143,8 @@ from typing import TypeAlias
 from qiskit.circuit import QuantumRegister
 
 from qiskit_fermions.circuit import FermionRegister
+
+from .passmanager import FermionPassManager, FermionStagedPassManager, FermionToQubitConverter
 
 F2QLayout: TypeAlias = dict[FermionRegister, QuantumRegister]
 """A mapping of fermionic mode registers to quantum registers.
@@ -137,4 +158,7 @@ size of the registers on either side of this mapping may differ.
 
 __all__ = [
     "F2QLayout",
+    "FermionPassManager",
+    "FermionStagedPassManager",
+    "FermionToQubitConverter",
 ]

--- a/python/qiskit_fermions/transpiler/passmanager.py
+++ b/python/qiskit_fermions/transpiler/passmanager.py
@@ -1,0 +1,106 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""PassManager interfaces for FermionCircuits."""
+
+from collections.abc import Callable, Iterable
+
+from qiskit import QuantumCircuit
+from qiskit.converters import circuit_to_dag, dag_to_circuit
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.passmanager import BasePassManager
+from qiskit.transpiler import StagedPassManager
+
+from qiskit_fermions.circuit import FermionCircuit
+
+
+class FermionPassManager(BasePassManager):
+    """A transpiler pass manager converting one :class:`.FermionCircuit` to another.
+
+    .. note::
+       Qiskit is currently working on native support of transpiler pipelines involving more than a
+       single intermediate representation. Once that gets more formalized, the implementation here
+       will be aligned with the resulting interfaces. See also `this tracking issue
+       <https://github.com/Qiskit/qiskit/issues/16115>`_.
+    """
+
+    def _passmanager_frontend(self, input_program: FermionCircuit, **kwargs) -> DAGCircuit:
+        return circuit_to_dag(input_program._inner, copy_operations=True)
+
+    def _passmanager_backend(
+        self, passmanager_ir: DAGCircuit, in_program: FermionCircuit, **kwargs
+    ) -> FermionCircuit:
+        out = FermionCircuit(passmanager_ir.num_qubits)
+        out._inner = dag_to_circuit(passmanager_ir, copy_operations=False)
+        return out
+
+
+class FermionToQubitConverter(BasePassManager):
+    """A transpiler pass manager converting a :class:`.FermionCircuit` to a :class:`~qiskit.circuit.QuantumCircuit`.
+
+    .. note::
+       Qiskit is currently working on native support of transpiler pipelines involving more than a
+       single intermediate representation. Once that gets more formalized, the implementation here
+       will be aligned with the resulting interfaces. See also `this tracking issue
+       <https://github.com/Qiskit/qiskit/issues/16115>`_.
+    """
+
+    def _passmanager_frontend(self, input_program: FermionCircuit, **kwargs) -> DAGCircuit:
+        return circuit_to_dag(input_program._inner, copy_operations=True)
+
+    def _passmanager_backend(
+        self, passmanager_ir: DAGCircuit, in_program: FermionCircuit, **kwargs
+    ) -> QuantumCircuit:
+        return dag_to_circuit(passmanager_ir, copy_operations=False)
+
+
+class FermionStagedPassManager(StagedPassManager):
+    """The staged fermion-to-qubit transpilation pipeline.
+
+    This
+
+    .. note::
+       Qiskit is currently working on native support of transpiler pipelines involving more than a
+       single intermediate representation. Once that gets more formalized, the implementation here
+       will be aligned with the resulting interfaces. See also `this tracking issue
+       <https://github.com/Qiskit/qiskit/issues/16115>`_.
+    """
+
+    def _passmanager_frontend(self, input_program: FermionCircuit, **kwargs) -> DAGCircuit:
+        return circuit_to_dag(input_program._inner, copy_operations=True)
+
+    def __init__(self, stages: Iterable[str] | None = None, **kwargs) -> None:  # noqa: D107
+        stages = stages or [
+            "optimization",
+            "layout",
+            "synthesis",
+            "quantum",
+        ]
+        super().__init__(stages, **kwargs)
+
+    def run(  # noqa: D102
+        self,
+        in_programs: FermionCircuit | list[FermionCircuit],
+        callback: Callable | None = None,
+        num_processes: int | None = None,
+        *,
+        property_set: dict[str, object] | None = None,
+        **kwargs,
+    ) -> QuantumCircuit:
+        self._update_passmanager()
+        return super().run(
+            in_programs,
+            callback,
+            num_processes=num_processes,
+            property_set=property_set,
+            **kwargs,
+        )

--- a/python/qiskit_fermions/transpiler/presets/__init__.py
+++ b/python/qiskit_fermions/transpiler/presets/__init__.py
@@ -1,0 +1,35 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+# ruff: noqa: D205,D212,D415
+"""
+==================
+Transpiler Presets
+==================
+
+.. currentmodule:: qiskit_fermions.transpiler.presets
+
+This module provides various functions for generating pre-defined transpiler pipelines. All
+available ones are listed in the table below.
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   generate_preset_jw_pass_manager
+"""
+
+from .jordan_wigner import generate_preset_jw_pass_manager
+
+__all__ = [
+    "generate_preset_jw_pass_manager",
+]

--- a/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
+++ b/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
@@ -1,0 +1,58 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The preset transpiler pipeline based on the Jordan-Wigner fermion-to-qubit mapping."""
+
+from qiskit.transpiler import generate_preset_pass_manager
+
+from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
+from qiskit_fermions.mappers.library import jordan_wigner
+
+from .. import FermionPassManager, FermionStagedPassManager, FermionToQubitConverter
+from ..passes import (
+    EvolutionSynthesis,
+    F2QSynthesis,
+    InitializeModesSynthesis,
+    OrbitalRotationSynthesis,
+    TrivialF2QLayout,
+)
+
+
+def generate_preset_jw_pass_manager(**kwargs) -> FermionStagedPassManager:
+    """Generates a preset transpiler pipeline based on the :func:`.jordan_wigner` mapping.
+
+    Args:
+        kwargs: any additional keyword arguments are forwarded to
+            :external:func:`~qiskit.transpiler.generate_preset_pass_manager` whose output is used
+            for the ``quantum`` stage of the resulting :class:`.FermionStagedPassManager`.
+
+    Returns:
+        The preset staged fermion-to-qubit transpiler pipeline.
+    """
+    optimization = FermionPassManager()
+
+    layout = FermionPassManager(TrivialF2QLayout())
+
+    synth = F2QSynthesis()
+    synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)  # type: ignore[arg-type]
+    synth.plugins[InitializeModes] = InitializeModesSynthesis()
+    synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
+
+    synthesis = FermionToQubitConverter(synth)
+
+    pm = FermionStagedPassManager()
+    pm.optimization = optimization
+    pm.layout = layout
+    pm.synthesis = synthesis
+    pm.quantum = generate_preset_pass_manager(**kwargs)
+
+    return pm

--- a/tests/python/circuit/library/test_evolution.py
+++ b/tests/python/circuit/library/test_evolution.py
@@ -34,14 +34,8 @@ def test_evolution_gate():
     evo = Evolution(num_fermions, hamil, time=time)
     circ.append(evo, circ.fermions)
 
-    # TODO: perform a better assertion instead of accessing an internal attribute here
-    # NOTE: for example, we should be able to perform a statevector-like check that the evolution is
-    # implemented physically correct
-    gates = circ._inner.data
-
-    assert len(gates) == 1
-    assert isinstance(gates[0].operation, Evolution)
-    assert gates[0].operation.operator == hamil
+    ops = circ.count_ops()
+    assert ops == {"Evolution": 1}
 
 
 def test_evolution_gate_decompose():
@@ -61,14 +55,8 @@ def test_evolution_gate_decompose():
 
     decomposed = circ.decompose()
 
-    # TODO: perform a better assertion instead of accessing an internal attribute here
-    # NOTE: for example, we should be able to perform a statevector-like check that the evolution is
-    # implemented physically correct
-    gates = decomposed._inner.data
-
-    expected_num_gates = 4
-    assert len(gates) == expected_num_gates
-    assert all(isinstance(gates[i].operation, Evolution) for i in range(expected_num_gates))
+    ops = decomposed.count_ops()
+    assert ops == {"Evolution": 4}
 
 
 def test_evolution_gate_decompose_with_groups():
@@ -94,11 +82,5 @@ def test_evolution_gate_decompose_with_groups():
 
     decomposed = circ.decompose()
 
-    # TODO: perform a better assertion instead of accessing an internal attribute here
-    # NOTE: for example, we should be able to perform a statevector-like check that the evolution is
-    # implemented physically correct
-    gates = decomposed._inner.data
-
-    expected_num_gates = 2
-    assert len(gates) == expected_num_gates
-    assert all(isinstance(gates[i].operation, Evolution) for i in range(expected_num_gates))
+    ops = decomposed.count_ops()
+    assert ops == {"Evolution": 2}

--- a/tests/python/circuit/library/test_initialize_modes.py
+++ b/tests/python/circuit/library/test_initialize_modes.py
@@ -25,13 +25,8 @@ def _test_initialize_modes(occupation):
     circ = FermionCircuit(num_fermions)
     circ.append(init, circ.fermions)
 
-    # TODO: perform a better assertion instead of accessing an internal attribute here
-    gates = circ._inner.data
-
-    assert len(gates) == 1
-    assert isinstance(gates[0].operation, InitializeModes)
-    assert gates[0].operation.occupation.shape == (num_fermions,)
-    assert np.allclose(gates[0].operation.occupation, occupation)
+    ops = circ.count_ops()
+    assert ops == {"InitializeModes": 1}
 
 
 def test_initialize_modes_gate(subtests):

--- a/tests/python/transpiler/passes/test_custom_layout.py
+++ b/tests/python/transpiler/passes/test_custom_layout.py
@@ -19,11 +19,12 @@ from functools import partial
 
 from qiskit.circuit import QuantumRegister
 from qiskit.quantum_info import SparseObservable
-from qiskit.transpiler import PassManager
 from qiskit_fermions.circuit import FermionCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import MajoranaOperator
+from qiskit_fermions.transpiler import FermionStagedPassManager
 from qiskit_fermions.transpiler.passes import CustomF2QLayout, EvolutionSynthesis, F2QSynthesis
+from qiskit_fermions.transpiler.passmanager import FermionPassManager, FermionToQubitConverter
 
 
 # NOTE: this is a very specific implementation of the Fermi-Hubbard model on a square lattice. It is
@@ -330,8 +331,10 @@ def test_custom_layout():
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(mapper_fn)
 
-    pm = PassManager([layout, synth])
+    pm = FermionStagedPassManager()
+    pm.layout = FermionPassManager(layout)
+    pm.synthesis = FermionToQubitConverter(synth)
 
-    qu_circ = pm.run(circ._inner)
+    qu_circ = pm.run(circ)
     qu_circ_decomp = qu_circ.decompose()
     assert qu_circ_decomp.depth(lambda instr: len(instr.qubits) == 2) == 93

--- a/tests/python/transpiler/passes/test_evolution_synthesis.py
+++ b/tests/python/transpiler/passes/test_evolution_synthesis.py
@@ -15,13 +15,16 @@
 from __future__ import annotations
 
 from qiskit.circuit.library import PauliEvolutionGate
-from qiskit.transpiler import PassManager
 from qiskit_fermions.circuit import FermionCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
-from qiskit_fermions.transpiler.passes.layout import TrivialF2QLayout
-from qiskit_fermions.transpiler.passes.synthesis import EvolutionSynthesis, F2QSynthesis
+from qiskit_fermions.transpiler.passes import EvolutionSynthesis, F2QSynthesis, TrivialF2QLayout
+from qiskit_fermions.transpiler.passmanager import (
+    FermionPassManager,
+    FermionStagedPassManager,
+    FermionToQubitConverter,
+)
 
 
 def test_evolution_gate_synthesis():
@@ -42,10 +45,11 @@ def test_evolution_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
 
-    pm = PassManager([TrivialF2QLayout(), synth])
+    pm = FermionStagedPassManager()
+    pm.layout = FermionPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionToQubitConverter(synth)
 
-    # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
-    qu_circ = pm.run(circ._inner)
+    qu_circ = pm.run(circ)
 
     gates = qu_circ.data
     assert len(gates) == 1
@@ -79,10 +83,11 @@ def test_custom_qubit_ordering():
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(custom_qubit_ordering_mapper_fn)
 
-    pm = PassManager([TrivialF2QLayout(), synth])
+    pm = FermionStagedPassManager()
+    pm.layout = FermionPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionToQubitConverter(synth)
 
-    # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
-    qu_circ = pm.run(circ._inner)
+    qu_circ = pm.run(circ)
 
     gates = qu_circ.data
     assert len(gates) == 1

--- a/tests/python/transpiler/passes/test_f2q_synthesis.py
+++ b/tests/python/transpiler/passes/test_f2q_synthesis.py
@@ -20,8 +20,12 @@ from qiskit.transpiler import PassManager
 from qiskit_fermions.circuit import FermionCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import FermionOperator
-from qiskit_fermions.transpiler.passes.layout import TrivialF2QLayout
-from qiskit_fermions.transpiler.passes.synthesis import F2QSynthesis
+from qiskit_fermions.transpiler.passes import F2QSynthesis, TrivialF2QLayout
+from qiskit_fermions.transpiler.passmanager import (
+    FermionPassManager,
+    FermionStagedPassManager,
+    FermionToQubitConverter,
+)
 
 
 def test_missing_plugin():
@@ -40,11 +44,12 @@ def test_missing_plugin():
     evo = Evolution(num_fermions, hamil, time=time)
     circ.append(evo, circ.fermions)
 
-    pm = PassManager([TrivialF2QLayout(), F2QSynthesis()])
+    pm = FermionStagedPassManager()
+    pm.layout = FermionPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionToQubitConverter(F2QSynthesis())
 
     with pytest.raises(TypeError, match="No plugin registered"):
-        # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
-        _ = pm.run(circ._inner)
+        _ = pm.run(circ)
 
 
 def test_unsupported_gate():

--- a/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
+++ b/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
@@ -16,11 +16,15 @@ from __future__ import annotations
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import Statevector
-from qiskit.transpiler import PassManager
 from qiskit_fermions.circuit import FermionCircuit
 from qiskit_fermions.circuit.library import InitializeModes
-from qiskit_fermions.transpiler.passes.layout import TrivialF2QLayout
-from qiskit_fermions.transpiler.passes.synthesis import F2QSynthesis, InitializeModesSynthesis
+from qiskit_fermions.transpiler import FermionPassManager, FermionStagedPassManager
+from qiskit_fermions.transpiler.passes import (
+    F2QSynthesis,
+    InitializeModesSynthesis,
+    TrivialF2QLayout,
+)
+from qiskit_fermions.transpiler.passmanager import FermionToQubitConverter
 
 
 def test_initialize_modes_global_gate_synthesis():
@@ -33,10 +37,11 @@ def test_initialize_modes_global_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[InitializeModes] = InitializeModesSynthesis()
 
-    pm = PassManager([TrivialF2QLayout(), synth])
+    pm = FermionStagedPassManager()
+    pm.layout = FermionPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionToQubitConverter(synth)
 
-    # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
-    qu_circ = pm.run(circ._inner)
+    qu_circ = pm.run(circ)
 
     expected = QuantumCircuit(num_fermions)
     expected.x(0)
@@ -55,10 +60,11 @@ def test_initialize_modes_local_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[InitializeModes] = InitializeModesSynthesis()
 
-    pm = PassManager([TrivialF2QLayout(), synth])
+    pm = FermionStagedPassManager()
+    pm.layout = FermionPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionToQubitConverter(synth)
 
-    # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
-    qu_circ = pm.run(circ._inner)
+    qu_circ = pm.run(circ)
 
     expected = QuantumCircuit(num_fermions)
     expected.x(1)

--- a/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
+++ b/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
@@ -14,11 +14,15 @@
 
 from __future__ import annotations
 
-from qiskit.transpiler import PassManager
 from qiskit_fermions.circuit import FermionCircuit
 from qiskit_fermions.circuit.library import OrbitalRotation
-from qiskit_fermions.transpiler.passes.layout import TrivialF2QLayout
-from qiskit_fermions.transpiler.passes.synthesis import F2QSynthesis, OrbitalRotationSynthesis
+from qiskit_fermions.transpiler import FermionPassManager, FermionStagedPassManager
+from qiskit_fermions.transpiler.passes import (
+    F2QSynthesis,
+    OrbitalRotationSynthesis,
+    TrivialF2QLayout,
+)
+from qiskit_fermions.transpiler.passmanager import FermionToQubitConverter
 
 from ...utils import random_unitary
 
@@ -33,10 +37,11 @@ def test_orbital_rotation_global_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
 
-    pm = PassManager([TrivialF2QLayout(), synth])
+    pm = FermionStagedPassManager()
+    pm.layout = FermionPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionToQubitConverter(synth)
 
-    # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
-    qu_circ = pm.run(circ._inner)
+    qu_circ = pm.run(circ)
 
     ops = qu_circ.count_ops()
     assert ops == {"xx_plus_yy": 15, "p": 6}
@@ -55,10 +60,11 @@ def test_initialize_modes_local_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
 
-    pm = PassManager([TrivialF2QLayout(), synth])
+    pm = FermionStagedPassManager()
+    pm.layout = FermionPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionToQubitConverter(synth)
 
-    # TODO: update API of FermionCircuit to not require access to `_inner` QuantumCircuit here
-    qu_circ = pm.run(circ._inner)
+    qu_circ = pm.run(circ)
 
     ops = qu_circ.count_ops()
     assert ops == {"xx_plus_yy": 6, "p": 6}

--- a/tests/python/transpiler/presets/__init__.py
+++ b/tests/python/transpiler/presets/__init__.py
@@ -1,0 +1,13 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Preset transpiler tests."""

--- a/tests/python/transpiler/presets/test_jordan_wigner.py
+++ b/tests/python/transpiler/presets/test_jordan_wigner.py
@@ -1,0 +1,70 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Preset Jordan-Wigner transpiler test."""
+
+from __future__ import annotations
+
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.circuit.library import PauliEvolutionGate, XXPlusYYGate
+from qiskit.quantum_info import Statevector
+from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
+from qiskit_fermions.mappers.library import jordan_wigner
+from qiskit_fermions.operators import FermionOperator
+from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager
+
+
+def test_preset_jordan_wigner():
+    hamil = FermionOperator.from_dict(
+        {
+            ((True, 0), (False, 2)): 2.0,
+            ((True, 2), (False, 0)): 2.0,
+            ((True, 1), (False, 3)): -2.0,
+            ((True, 3), (False, 1)): -2.0,
+        }
+    )
+    time = 1.5
+    num_fermions = 4
+    evo = Evolution(num_fermions, hamil, time=time)
+
+    init = InitializeModes([True, False, True, False])
+
+    rot_mat = np.zeros((num_fermions, num_fermions), dtype=complex)
+    rot_mat[0, 1] = 1
+    rot_mat[1, 0] = 1
+    rot_mat[2, 3] = 1
+    rot_mat[3, 2] = 1
+    orb_rot = OrbitalRotation(rot_mat)
+
+    circ = FermionCircuit(num_fermions)
+    circ.append(init, circ.fermions)
+    circ.append(orb_rot, circ.fermions)
+    circ.append(evo, circ.fermions)
+
+    pm = generate_preset_jw_pass_manager()
+
+    qu_circ = pm.run(circ)
+
+    expected = QuantumCircuit(num_fermions)
+    expected.x((0, 2))
+    expected.append(XXPlusYYGate(np.pi, -np.pi / 2), (0, 1))
+    expected.append(XXPlusYYGate(np.pi, -np.pi / 2), (2, 3))
+    expected.p(np.pi, 0)
+    expected.p(np.pi, 2)
+    expected.append(
+        PauliEvolutionGate(jordan_wigner(hamil, num_qubits=num_fermions).simplify(), time=time),
+        expected.qubits,
+    )
+
+    assert Statevector(qu_circ) == Statevector(expected)


### PR DESCRIPTION
This introduces proper `FermionPassManager` and
`FermionStagedPassManager` interfaces along with a first convenience function for generating a common preset pass manager pipeline.

Closes #56
Closes #61 

---

The documentation is being updated quite minimally in this PR. I plan to do a more thorough pass over it when tackling #59 