### PR TITLE
feat: QDrift Trotterization optimization

### DIFF
--- a/python/qiskit_fermions/operators/protocol.py
+++ b/python/qiskit_fermions/operators/protocol.py
@@ -112,6 +112,9 @@ class OperatorTrait(Protocol):
            A specific implementation of this method may take additional arguments.
         """
 
+    def get_coeffs(self) -> list[complex]:
+        """Returns the term coefficients."""
+
     @property
     def groups(self) -> list[int] | None:
         """Returns the groups indices."""

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -50,8 +50,9 @@ Stage                                                Description
 Optimization
 ^^^^^^^^^^^^
 
-.. hint::
-   Coming soon!
+This stage of the transpilation pipeline can implement circuit optimizations while preserving the
+type of circuit to be an instance of :class:`.FermionCircuit`. As such, no qubit information is
+required (or necessarily available) at this point in the transpilation pipeline.
 
 .. _qiskit_fermions-transpiler-stage-layout:
 

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -26,8 +26,12 @@ This module provides various transpiler passes for the stages explained in
 Optimization Passes
 -------------------
 
-.. hint::
-   Coming soon!
+These passes provide different kinds of optimization of :class:`.FermionCircuit` instances.
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   QDriftTrotterization
 
 .. _qiskit_fermions-transpiler-passes-layout:
 
@@ -84,6 +88,7 @@ provides builtin plugins:
 """
 
 from .layout import CustomF2QLayout, TrivialF2QLayout
+from .optimization import QDriftTrotterization
 from .synthesis import (
     EvolutionSynthesis,
     F2QSynthesis,
@@ -99,5 +104,6 @@ __all__ = [
     "F2QSynthesisPlugin",
     "InitializeModesSynthesis",
     "OrbitalRotationSynthesis",
+    "QDriftTrotterization",
     "TrivialF2QLayout",
 ]

--- a/python/qiskit_fermions/transpiler/passes/optimization/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/__init__.py
@@ -1,0 +1,19 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Optimization passes."""
+
+from .qdrift import QDriftTrotterization
+
+__all__ = [
+    "QDriftTrotterization",
+]

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -1,0 +1,85 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""A QDrift Trotterization optimization pass."""
+
+from __future__ import annotations
+
+import numpy as np
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.transpiler import TransformationPass
+
+from qiskit_fermions.circuit.library import Evolution
+
+
+class QDriftTrotterization(TransformationPass):
+    """A transpilation pass to Trotterize :class:`.Evolution` gates via the qDRIFT protocol."""
+
+    def __init__(self, num_terms: int, *, rng: np.random.Generator | int | None = None) -> None:
+        """Initializes the transpiler pass.
+
+        Args:
+            num_terms: the number of terms to include in the qDRIFT Trotterization.
+            rng: the random number generator (rng) to be used. When this is an ``int``, the internal
+                rng will be initialized with ``np.random.default_rng(seed=rng)``.
+        """
+        super().__init__()
+
+        self.num_terms = num_terms
+        """The number of terms to include in the qDRIFT Trotterization."""
+
+        self._rng = rng if isinstance(rng, np.random.Generator) else np.random.default_rng(rng)
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Runs this transpilation pass.
+
+        Args:
+            dag: the input circuit with fermion-based instructions. Only
+                :class:`~qiskit.dagcircuit.DAGOpNode` with :class:`.FermionGate` instances as their
+                :attr:`~qiskit.dagcircuit.DAGOpNode.op` are supported.
+
+        Returns:
+            The output circuit which is still acting on a fermionic register.
+        """
+        out_dag = dag.copy_empty_like()
+
+        for node in dag.op_nodes():
+            if not isinstance(node.op, Evolution):
+                continue
+
+            hamil = node.op.operator
+            time = node.op.params[0]
+            num_fermions = len(node.qargs)
+
+            if hamil.groups is not None:
+                terms = hamil.split_out_groups()
+                weights = [np.abs(np.mean(g.get_coeffs())) for g in terms]
+            else:
+                terms = list(hamil.iter_terms())
+                weights = np.abs(hamil.get_coeffs())
+
+            lambd = np.sum(weights)
+            delta = (lambd * time) / self.num_terms
+
+            sampled_indices = self._rng.choice(
+                np.arange(len(weights)),
+                size=self.num_terms,
+                p=weights / lambd,
+            )
+
+            for ind in sampled_indices:
+                term = terms[ind]
+                op = hamil.__class__.from_terms([term]) if isinstance(term, tuple) else term
+                evo = Evolution(num_fermions, op, time=delta)
+                out_dag.apply_operation_back(evo, qargs=out_dag.qubits)
+
+        return out_dag

--- a/python/qiskit_fermions/transpiler/passmanager.py
+++ b/python/qiskit_fermions/transpiler/passmanager.py
@@ -39,7 +39,7 @@ class FermionPassManager(BasePassManager):
     def _passmanager_backend(
         self, passmanager_ir: DAGCircuit, in_program: FermionCircuit, **kwargs
     ) -> FermionCircuit:
-        out = FermionCircuit(passmanager_ir.num_qubits)
+        out = FermionCircuit(passmanager_ir.num_qubits())
         out._inner = dag_to_circuit(passmanager_ir, copy_operations=False)
         return out
 

--- a/tests/python/transpiler/passes/test_qdrift_optimization.py
+++ b/tests/python/transpiler/passes/test_qdrift_optimization.py
@@ -1,0 +1,150 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""QDrift optimization tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit.library import Evolution
+from qiskit_fermions.operators import FermionOperator
+from qiskit_fermions.operators.grouping import group_terms_by_electronic_structure
+from qiskit_fermions.operators.library import FCIDump
+from qiskit_fermions.transpiler.passes import QDriftTrotterization
+from qiskit_fermions.transpiler.passmanager import FermionPassManager
+
+
+def test_qdrift_optimization_no_groups(subtests):
+    file_path = Path(__file__).parent / "../../../h2.fcidump"
+    fcidump = FCIDump.from_file(str(file_path))
+    num_fermions = 2 * fcidump.norb
+    hamil = FermionOperator.from_fcidump(fcidump)
+    time = 1.5
+    circ = FermionCircuit(num_fermions)
+    evo = Evolution(num_fermions, hamil, time=time)
+    circ.append(evo, circ.fermions)
+
+    with subtests.test("num_terms=4"):
+        num_terms = 4
+        qdrift = QDriftTrotterization(num_terms)
+        pm = FermionPassManager(qdrift)
+
+        qdrift_circ = pm.run(circ)
+        assert qdrift_circ.count_ops() == {"Evolution": num_terms}
+
+    with subtests.test("num_terms=6"):
+        num_terms = 6
+        qdrift = QDriftTrotterization(num_terms)
+        pm = FermionPassManager(qdrift)
+
+        qdrift_circ = pm.run(circ)
+        assert qdrift_circ.count_ops() == {"Evolution": num_terms}
+
+    with subtests.test("rng seed"):
+        num_terms = 2
+        qdrift = QDriftTrotterization(num_terms, rng=42)
+        pm = FermionPassManager(qdrift)
+
+        qdrift_circ = pm.run(circ)
+        assert qdrift_circ.count_ops() == {"Evolution": num_terms}
+
+        expected_gates = [
+            Evolution(
+                num_fermions,
+                FermionOperator.from_terms(
+                    [(((True, 0), (True, 1), (False, 1), (False, 0)), 0.3322908651276483)]
+                ),
+                time=8.273087572037902,
+            ),
+            Evolution(
+                num_fermions,
+                FermionOperator.from_terms(
+                    [(((True, 2), (True, 0), (False, 0), (False, 2)), 0.33785507740175824)]
+                ),
+                time=8.273087572037902,
+            ),
+        ]
+
+        for actual, expected in zip(qdrift_circ._inner.data, expected_gates, strict=True):
+            assert actual.operation.operator.equiv(expected.operator)
+            assert np.isclose(actual.params[0], expected.params[0])
+
+    with subtests.test("rng seed"):
+        num_terms = 2
+        qdrift = QDriftTrotterization(num_terms, rng=np.random.default_rng(43))
+        pm = FermionPassManager(qdrift)
+
+        qdrift_circ = pm.run(circ)
+        assert qdrift_circ.count_ops() == {"Evolution": num_terms}
+
+        expected_gates = [
+            Evolution(
+                num_fermions,
+                FermionOperator.from_terms(
+                    [(((True, 1), (True, 0), (False, 0), (False, 1)), 0.3322908651276483)]
+                ),
+                time=8.273087572037902,
+            ),
+            Evolution(
+                num_fermions,
+                FermionOperator.from_terms([((), 0.7199689944489797)]),
+                time=8.273087572037902,
+            ),
+        ]
+
+        for actual, expected in zip(qdrift_circ._inner.data, expected_gates, strict=True):
+            assert actual.operation.operator.equiv(expected.operator)
+            assert np.isclose(actual.params[0], expected.params[0])
+
+
+def test_qdrift_optimization_with_groups():
+    file_path = Path(__file__).parent / "../../../h2.fcidump"
+    fcidump = FCIDump.from_file(str(file_path))
+    num_fermions = 2 * fcidump.norb
+    hamil = FermionOperator.from_fcidump(fcidump)
+    group_terms_by_electronic_structure(hamil, num_fermions)
+    time = 1.5
+    circ = FermionCircuit(num_fermions)
+    evo = Evolution(num_fermions, hamil, time=time)
+    circ.append(evo, circ.fermions)
+
+    num_terms = 2
+    qdrift = QDriftTrotterization(num_terms, rng=42)
+    pm = FermionPassManager(qdrift)
+
+    qdrift_circ = pm.run(circ)
+    assert qdrift_circ.count_ops() == {"Evolution": num_terms}
+
+    expected_gates = [
+        Evolution(
+            num_fermions,
+            FermionOperator.from_terms(
+                [
+                    (((True, 1), (True, 2), (False, 3), (False, 0)), 0.09046559989211567),
+                    (((True, 3), (True, 0), (False, 1), (False, 2)), 0.09046559989211567),
+                ]
+            ),
+            time=6.036695974299787,
+        ),
+        Evolution(
+            num_fermions,
+            FermionOperator.from_terms([(((True, 1), (False, 1)), -0.4718960072811406)]),
+            time=6.036695974299787,
+        ),
+    ]
+
+    for actual, expected in zip(qdrift_circ._inner.data, expected_gates, strict=True):
+        assert actual.operation.operator.equiv(expected.operator)
+        assert np.isclose(actual.params[0], expected.params[0])


### PR DESCRIPTION
This adds a first transpilation pass for the `optimization` stage of the transpilation pipeline. As such, it transpiles one `FermionCircuit` to another. In particular, the pass implemented by this PR implements the qDrift Trotterization protocol on the fermionic level.

Closes #57 

In a follow-up to this PR, I am going to update the SqDRIFT tutorial to reflect all the recent improvements to this package.