### PR TITLE
Rename `Fermion` to `Fermionic` in circuits and transpiler modules

### DIFF
--- a/docs/tutorials/sqdrift.rst
+++ b/docs/tutorials/sqdrift.rst
@@ -28,7 +28,7 @@ documentation as well as :mod:`qiskit_fermions.operators.library`.
        >>> from qiskit_fermions.operators import FermionOperator
        >>>
        >>> fcidump = FCIDump.from_file("docs/tutorials/n2.fcidump")
-       >>> num_fermions = 2 * fcidump.norb
+       >>> num_modes = 2 * fcidump.norb
        >>> hamil = FermionOperator.from_fcidump(fcidump)
 
     .. code-block:: c
@@ -37,7 +37,7 @@ documentation as well as :mod:`qiskit_fermions.operators.library`.
 
        QfFCIDump* fcidump = qf_fcidump_from_file("docs/tutorials/n2.fcidump");
        QfFermionOperator* hamil = qf_ferm_op_from_fcidump(fcidump);
-       uint32_t num_fermions = 2 * qf_fcidump_norb(fcidump);
+       uint32_t num_modes = 2 * qf_fcidump_norb(fcidump);
 
 
 2. Group Hamiltonian terms
@@ -61,12 +61,12 @@ detail in :ref:`this guide <grouping_explanation>`.
 
        >>> from qiskit_fermions.operators.grouping import group_terms_by_electronic_structure
        >>>
-       >>> exit_code = group_terms_by_electronic_structure(hamil, num_fermions)
+       >>> exit_code = group_terms_by_electronic_structure(hamil, num_modes)
        >>> assert exit_code is None
 
     .. code-block:: c
 
-       QfExitCode exit = qf_group_terms_by_electronic_structure(hamil, num_fermions, false);
+       QfExitCode exit = qf_group_terms_by_electronic_structure(hamil, num_modes, false);
 
 3. Prepare the Time-Evolution Circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,13 +80,13 @@ components to do so, in a way that fits naturally with Qiskit's conventions.
 
     .. code-block:: python
 
-       >>> from qiskit_fermions.circuit import FermionCircuit
+       >>> from qiskit_fermions.circuit import FermionicCircuit
        >>> from qiskit_fermions.circuit.library import Evolution
        >>>
        >>> time = 1.0  # you can choose a desired scaling factor here
-       >>> evo_gate = Evolution(num_fermions, hamil, time)
+       >>> evo_gate = Evolution(num_modes, hamil, time)
        >>>
-       >>> circ = FermionCircuit(num_fermions)
+       >>> circ = FermionicCircuit(num_modes)
        >>> circ.append(evo_gate, circ.fermions)
 
     .. code-block:: c
@@ -102,7 +102,7 @@ components to do so, in a way that fits naturally with Qiskit's conventions.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :mod:`qiskit_fermions.transpiler` module integrates directly with Qiskit's
-transpilation pipeline, allowing the :class:`.FermionCircuit` constructed above
+transpilation pipeline, allowing the :class:`.FermionicCircuit` constructed above
 to be directly transpiled to a :external:class:`~qiskit.circuit.QuantumCircuit`.
 
 Here, we are using the :func:`.jordan_wigner` fermion-to-qubit mapping to
@@ -110,7 +110,7 @@ convert the Hamiltonian expressed in terms of fermions to Pauli strings. This
 can be done directly as part of the transpilation process through the use of the
 :class:`.EvolutionSynthesis` transpilation pass plugin. Here, we are using
 :func:`.generate_preset_jw_pass_manager` as a short-hand for building a
-:class:`.FermionStagedPassManager` which ensures the consistent use of the
+:class:`.FermionicStagedPassManager` which ensures the consistent use of the
 Jordan-Wigner encoding for all circuit instructions.
 
 Crucially, we add the :class:`.QDriftTrotterization` transpilation pass to the
@@ -133,7 +133,7 @@ ensemble of circuits to generate:
 
     .. code-block:: python
 
-       >>> from qiskit_fermions.transpiler import FermionPassManager
+       >>> from qiskit_fermions.transpiler import FermionicPassManager
        >>> from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager
        >>> from qiskit_fermions.transpiler.passes import QDriftTrotterization
        >>>
@@ -141,7 +141,7 @@ ensemble of circuits to generate:
        >>> qdrift = QDriftTrotterization(num_groups, rng=42)
        >>>
        >>> pm = generate_preset_jw_pass_manager()
-       >>> pm.optimization = FermionPassManager([qdrift])
+       >>> pm.optimization = FermionicPassManager([qdrift])
        >>>
        >>> num_sqdrift_randomizations = 10
        >>> sqdrift_circuits = [

--- a/docs/tutorials/sqdrift.rst
+++ b/docs/tutorials/sqdrift.rst
@@ -87,7 +87,7 @@ components to do so, in a way that fits naturally with Qiskit's conventions.
        >>> evo_gate = Evolution(num_modes, hamil, time)
        >>>
        >>> circ = FermionicCircuit(num_modes)
-       >>> circ.append(evo_gate, circ.fermions)
+       >>> circ.append(evo_gate, circ.modes)
 
     .. code-block:: c
 

--- a/python/qiskit_fermions/circuit/__init__.py
+++ b/python/qiskit_fermions/circuit/__init__.py
@@ -26,9 +26,9 @@ The following objects are simple type aliases to make this re-interpretation mor
 .. autosummary::
    :toctree: ../stubs/
 
-   Mode
-   ModeRegister
-   ModeSpecifier
+   FermionicMode
+   FermionicRegister
+   FermionicSpecifier
 
 For actually expressing your circuits, you should use the :class:`.FermionCircuit` class along with
 the :mod:`~qiskit_fermions.circuit.library` of :class:`.FermionGate` implementations.
@@ -45,11 +45,13 @@ from typing import TypeAlias
 
 from qiskit.circuit import QuantumRegister, Qubit
 
-Mode: TypeAlias = Qubit
+FermionicMode: TypeAlias = Qubit
 
-ModeRegister: TypeAlias = QuantumRegister
+FermionicRegister: TypeAlias = QuantumRegister
 
-ModeSpecifier: TypeAlias = Mode | ModeRegister | int | slice | Sequence[Mode | int]
+FermionicSpecifier: TypeAlias = (
+    FermionicMode | FermionicRegister | int | slice | Sequence[FermionicMode | int]
+)
 """A type alias equivalent to Qiskit's ``QubitSpecifier`` but for fermionic modes."""
 
 # NOTE: we must explicitly define the type aliases _before_ the following imports to ensure that
@@ -61,7 +63,7 @@ from .fermion_gate import FermionGate
 __all__ = [
     "FermionCircuit",
     "FermionGate",
-    "Mode",
-    "ModeRegister",
-    "ModeSpecifier",
+    "FermionicMode",
+    "FermionicRegister",
+    "FermionicSpecifier",
 ]

--- a/python/qiskit_fermions/circuit/__init__.py
+++ b/python/qiskit_fermions/circuit/__init__.py
@@ -26,9 +26,9 @@ The following objects are simple type aliases to make this re-interpretation mor
 .. autosummary::
    :toctree: ../stubs/
 
-   Fermion
-   FermionRegister
-   FermionSpecifier
+   Mode
+   ModeRegister
+   ModeSpecifier
 
 For actually expressing your circuits, you should use the :class:`.FermionCircuit` class along with
 the :mod:`~qiskit_fermions.circuit.library` of :class:`.FermionGate` implementations.
@@ -45,11 +45,11 @@ from typing import TypeAlias
 
 from qiskit.circuit import QuantumRegister, Qubit
 
-Fermion: TypeAlias = Qubit
+Mode: TypeAlias = Qubit
 
-FermionRegister: TypeAlias = QuantumRegister
+ModeRegister: TypeAlias = QuantumRegister
 
-FermionSpecifier: TypeAlias = Fermion | FermionRegister | int | slice | Sequence[Fermion | int]
+ModeSpecifier: TypeAlias = Mode | ModeRegister | int | slice | Sequence[Mode | int]
 """A type alias equivalent to Qiskit's ``QubitSpecifier`` but for fermionic modes."""
 
 # NOTE: we must explicitly define the type aliases _before_ the following imports to ensure that
@@ -59,9 +59,9 @@ from .fermion_circuit import FermionCircuit
 from .fermion_gate import FermionGate
 
 __all__ = [
-    "Fermion",
     "FermionCircuit",
     "FermionGate",
-    "FermionRegister",
-    "FermionSpecifier",
+    "Mode",
+    "ModeRegister",
+    "ModeSpecifier",
 ]

--- a/python/qiskit_fermions/circuit/__init__.py
+++ b/python/qiskit_fermions/circuit/__init__.py
@@ -31,13 +31,13 @@ The following objects are simple type aliases to make this re-interpretation mor
    FermionicSpecifier
 
 For actually expressing your circuits, you should use the :class:`.FermionicCircuit` class along with
-the :mod:`~qiskit_fermions.circuit.library` of :class:`.FermionGate` implementations.
+the :mod:`~qiskit_fermions.circuit.library` of :class:`.FermionicGate` implementations.
 
 .. autosummary::
    :toctree: ../stubs/
 
    FermionicCircuit
-   FermionGate
+   FermionicGate
 """
 
 from collections.abc import Sequence
@@ -58,11 +58,11 @@ FermionicSpecifier: TypeAlias = (
 # they can actually use those type aliases themselves.
 # ruff: noqa: E402
 from .fermionic_circuit import FermionicCircuit
-from .fermion_gate import FermionGate
+from .fermionic_gate import FermionicGate
 
 __all__ = [
-    "FermionGate",
     "FermionicCircuit",
+    "FermionicGate",
     "FermionicMode",
     "FermionicRegister",
     "FermionicSpecifier",

--- a/python/qiskit_fermions/circuit/__init__.py
+++ b/python/qiskit_fermions/circuit/__init__.py
@@ -30,13 +30,13 @@ The following objects are simple type aliases to make this re-interpretation mor
    FermionicRegister
    FermionicSpecifier
 
-For actually expressing your circuits, you should use the :class:`.FermionCircuit` class along with
+For actually expressing your circuits, you should use the :class:`.FermionicCircuit` class along with
 the :mod:`~qiskit_fermions.circuit.library` of :class:`.FermionGate` implementations.
 
 .. autosummary::
    :toctree: ../stubs/
 
-   FermionCircuit
+   FermionicCircuit
    FermionGate
 """
 
@@ -57,12 +57,12 @@ FermionicSpecifier: TypeAlias = (
 # NOTE: we must explicitly define the type aliases _before_ the following imports to ensure that
 # they can actually use those type aliases themselves.
 # ruff: noqa: E402
-from .fermion_circuit import FermionCircuit
+from .fermionic_circuit import FermionicCircuit
 from .fermion_gate import FermionGate
 
 __all__ = [
-    "FermionCircuit",
     "FermionGate",
+    "FermionicCircuit",
     "FermionicMode",
     "FermionicRegister",
     "FermionicSpecifier",

--- a/python/qiskit_fermions/circuit/fermion_circuit.py
+++ b/python/qiskit_fermions/circuit/fermion_circuit.py
@@ -20,11 +20,11 @@ from typing import TYPE_CHECKING, Any, cast
 
 from qiskit.circuit import Instruction, QuantumCircuit, QuantumRegister
 
-from . import Fermion, FermionSpecifier
+from . import Mode, ModeSpecifier
 from .fermion_gate import FermionGate
 
 if TYPE_CHECKING:
-    from . import FermionRegister
+    from . import ModeRegister
 
 
 class FermionCircuit:
@@ -36,25 +36,25 @@ class FermionCircuit:
     well-defined operation in the general case.
     """
 
-    def __init__(self, num_fermions: int) -> None:
+    def __init__(self, num_modes: int) -> None:
         """Initializes a FermionCircuit instance.
 
         Args:
-            num_fermions: the number of fermionic modes on which this circuit acts.
+            num_modes: the number of fermionic modes on which this circuit acts.
         """
-        self.register: FermionRegister = QuantumRegister(num_fermions, "f")
-        """The inner circuit's :type:`~qiskit_fermions.circuit.FermionRegister`."""
+        self.register: ModeRegister = QuantumRegister(num_modes, "f")
+        """The inner circuit's :type:`~qiskit_fermions.circuit.ModeRegister`."""
         self._inner = QuantumCircuit(self.register)
 
     @property
-    def fermions(self) -> list[Fermion]:
+    def fermions(self) -> list[Mode]:
         """The fermionic mode `bits` that this circuit acts upon."""
-        return cast(list[Fermion], self._inner.qubits)
+        return cast(list[Mode], self._inner.qubits)
 
     def append(
         self,
         gate: FermionGate,
-        fargs: FermionSpecifier,
+        fargs: ModeSpecifier,
         cargs: None = None,
         *,
         copy: bool = True,

--- a/python/qiskit_fermions/circuit/fermion_circuit.py
+++ b/python/qiskit_fermions/circuit/fermion_circuit.py
@@ -20,11 +20,11 @@ from typing import TYPE_CHECKING, Any, cast
 
 from qiskit.circuit import Instruction, QuantumCircuit, QuantumRegister
 
-from . import Mode, ModeSpecifier
+from . import FermionicMode, FermionicSpecifier
 from .fermion_gate import FermionGate
 
 if TYPE_CHECKING:
-    from . import ModeRegister
+    from . import FermionicRegister
 
 
 class FermionCircuit:
@@ -42,19 +42,19 @@ class FermionCircuit:
         Args:
             num_modes: the number of fermionic modes on which this circuit acts.
         """
-        self.register: ModeRegister = QuantumRegister(num_modes, "f")
-        """The inner circuit's :type:`~qiskit_fermions.circuit.ModeRegister`."""
+        self.register: FermionicRegister = QuantumRegister(num_modes, "f")
+        """The inner circuit's :type:`~qiskit_fermions.circuit.FermionicRegister`."""
         self._inner = QuantumCircuit(self.register)
 
     @property
-    def fermions(self) -> list[Mode]:
+    def fermions(self) -> list[FermionicMode]:
         """The fermionic mode `bits` that this circuit acts upon."""
-        return cast(list[Mode], self._inner.qubits)
+        return cast(list[FermionicMode], self._inner.qubits)
 
     def append(
         self,
         gate: FermionGate,
-        fargs: ModeSpecifier,
+        fargs: FermionicSpecifier,
         cargs: None = None,
         *,
         copy: bool = True,

--- a/python/qiskit_fermions/circuit/fermion_gate.py
+++ b/python/qiskit_fermions/circuit/fermion_gate.py
@@ -23,7 +23,7 @@ class FermionGate(Gate):
     """The base class for all fermionic gates.
 
     To ensure consistency only subclasses of this gate class can be added to instances of
-    :class:`.FermionCircuit`. As such, this class (mostly) serves as a type (for the time being).
+    :class:`.FermionicCircuit`. As such, this class (mostly) serves as a type (for the time being).
 
     .. caution::
        Since this is a subclass of :class:`~qiskit.circuit.Gate` the documentation of its methods

--- a/python/qiskit_fermions/circuit/fermion_gate.py
+++ b/python/qiskit_fermions/circuit/fermion_gate.py
@@ -37,7 +37,7 @@ class FermionGate(Gate):
     def __init__(
         self,
         name: str,
-        num_fermions: int,
+        num_modes: int,
         /,
         params: list | None = None,
         *,
@@ -46,9 +46,9 @@ class FermionGate(Gate):
         """Initializes a FermionGate instance."""
         if params is None:
             params = []
-        super().__init__(name, num_fermions, params, label)
+        super().__init__(name, num_modes, params, label)
 
     @property
-    def num_fermions(self) -> int:
+    def num_modes(self) -> int:
         """The number of fermionic modes that this gate acts upon."""
         return cast(int, self._num_qubits)

--- a/python/qiskit_fermions/circuit/fermionic_circuit.py
+++ b/python/qiskit_fermions/circuit/fermionic_circuit.py
@@ -47,8 +47,8 @@ class FermionicCircuit:
         self._inner = QuantumCircuit(self.register)
 
     @property
-    def fermions(self) -> list[FermionicMode]:
-        """The fermionic mode `bits` that this circuit acts upon."""
+    def modes(self) -> list[FermionicMode]:
+        """The fermionic mode ``bits`` that this circuit acts upon."""
         return cast(list[FermionicMode], self._inner.qubits)
 
     def append(

--- a/python/qiskit_fermions/circuit/fermionic_circuit.py
+++ b/python/qiskit_fermions/circuit/fermionic_circuit.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""FermionCircuit."""
+"""FermionicCircuit."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from . import FermionicRegister
 
 
-class FermionCircuit:
+class FermionicCircuit:
     """A wrapper around :class:`~qiskit.circuit.QuantumCircuit` for expressing fermionic circuits.
 
     This class maintains a reduced API compared to the full API of the underlying
@@ -37,7 +37,7 @@ class FermionCircuit:
     """
 
     def __init__(self, num_modes: int) -> None:
-        """Initializes a FermionCircuit instance.
+        """Initializes a FermionicCircuit instance.
 
         Args:
             num_modes: the number of fermionic modes on which this circuit acts.
@@ -88,10 +88,10 @@ class FermionCircuit:
             str | type[Instruction] | Sequence[str | type[Instruction]] | None
         ) = None,
         reps: int = 1,
-    ) -> FermionCircuit:
+    ) -> FermionicCircuit:
         """Re-exposes :external:meth:`~qiskit.circuit.QuantumCircuit.decompose`."""
         inner_decomposed = self._inner.decompose(gates_to_decompose=gates_to_decompose, reps=reps)
-        out = FermionCircuit(len(self.register))
+        out = FermionicCircuit(len(self.register))
         out.register = self.register
         out._inner = inner_decomposed
         return out

--- a/python/qiskit_fermions/circuit/fermionic_circuit.py
+++ b/python/qiskit_fermions/circuit/fermionic_circuit.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, cast
 from qiskit.circuit import Instruction, QuantumCircuit, QuantumRegister
 
 from . import FermionicMode, FermionicSpecifier
-from .fermion_gate import FermionGate
+from .fermionic_gate import FermionicGate
 
 if TYPE_CHECKING:
     from . import FermionicRegister
@@ -53,13 +53,13 @@ class FermionicCircuit:
 
     def append(
         self,
-        gate: FermionGate,
+        gate: FermionicGate,
         fargs: FermionicSpecifier,
         cargs: None = None,
         *,
         copy: bool = True,
     ) -> None:
-        """Appends a :class:`.FermionGate` to this circuit.
+        """Appends a :class:`.FermionicGate` to this circuit.
 
         Args:
             gate: the fermionic gate to apply.
@@ -72,9 +72,9 @@ class FermionicCircuit:
             copy: forwarded to :meth:`~qiskit.circuit.QuantumCircuit.append`.
 
         Raises:
-            ValueError: if the provided ``gate`` is not an instance of :class:`.FermionGate`.
+            ValueError: if the provided ``gate`` is not an instance of :class:`.FermionicGate`.
         """
-        if not isinstance(gate, FermionGate):
+        if not isinstance(gate, FermionicGate):
             raise ValueError("Unsupported instruction type: %s", type(gate))
         self._inner.append(gate, fargs, cargs, copy=copy)
 

--- a/python/qiskit_fermions/circuit/fermionic_gate.py
+++ b/python/qiskit_fermions/circuit/fermionic_gate.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""FermionGate."""
+"""FermionicGate."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ from typing import cast
 from qiskit.circuit import Gate
 
 
-class FermionGate(Gate):
+class FermionicGate(Gate):
     """The base class for all fermionic gates.
 
     To ensure consistency only subclasses of this gate class can be added to instances of
@@ -43,7 +43,7 @@ class FermionGate(Gate):
         *,
         label: str | None = None,
     ) -> None:
-        """Initializes a FermionGate instance."""
+        """Initializes a FermionicGate instance."""
         if params is None:
             params = []
         super().__init__(name, num_modes, params, label)

--- a/python/qiskit_fermions/circuit/library/__init__.py
+++ b/python/qiskit_fermions/circuit/library/__init__.py
@@ -18,7 +18,7 @@ Circuit Library
 
 .. currentmodule:: qiskit_fermions.circuit.library
 
-This module provides a library of :class:`.FermionGate` implementations.
+This module provides a library of :class:`.FermionicGate` implementations.
 
 
 .. autosummary::

--- a/python/qiskit_fermions/circuit/library/evolution.py
+++ b/python/qiskit_fermions/circuit/library/evolution.py
@@ -38,9 +38,9 @@ class Evolution(FermionGate):
         )
 
     def _define(self) -> None:
-        from qiskit_fermions.circuit import FermionCircuit
+        from qiskit_fermions.circuit import FermionicCircuit
 
-        definition = FermionCircuit(self.num_modes)
+        definition = FermionicCircuit(self.num_modes)
 
         # when the operator being evolved has groups use those for the decomposition, otherwise
         # decompose into all individual terms

--- a/python/qiskit_fermions/circuit/library/evolution.py
+++ b/python/qiskit_fermions/circuit/library/evolution.py
@@ -22,11 +22,11 @@ from .. import FermionGate
 class Evolution(FermionGate):
     """Implements the time-evolution of an operator."""
 
-    def __init__(self, num_fermions: int, operator: OperatorTrait, time: float = 1.0) -> None:
+    def __init__(self, num_modes: int, operator: OperatorTrait, time: float = 1.0) -> None:
         """Initializes an Evolution gate.
 
         Args:
-            num_fermions: the number of fermionic modes on which this gate acts.
+            num_modes: the number of fermionic modes on which this gate acts.
             operator: the operator under which to time-evolve the acted-upon fermionic modes.
             time: the evolution time.
         """
@@ -34,13 +34,13 @@ class Evolution(FermionGate):
         """The operator under which to time-evolve the acted-upon fermionic modes."""
 
         super().__init__(
-            "Evolution", num_fermions, [time], label=f"evolve({' '.join(str(operator).split())})"
+            "Evolution", num_modes, [time], label=f"evolve({' '.join(str(operator).split())})"
         )
 
     def _define(self) -> None:
         from qiskit_fermions.circuit import FermionCircuit
 
-        definition = FermionCircuit(self.num_fermions)
+        definition = FermionCircuit(self.num_modes)
 
         # when the operator being evolved has groups use those for the decomposition, otherwise
         # decompose into all individual terms
@@ -59,10 +59,10 @@ class Evolution(FermionGate):
             active = item.get_support()
             num_active = len(active)
             active_idx = iter(range(num_active))
-            idle_idx = iter(range(num_active, self.num_fermions))
+            idle_idx = iter(range(num_active, self.num_modes))
             permutation = [
                 next(active_idx) if idx in active else next(idle_idx)
-                for idx in range(self.num_fermions)
+                for idx in range(self.num_modes)
             ]
             relabeled = item.relabel_modes(permutation)
 

--- a/python/qiskit_fermions/circuit/library/evolution.py
+++ b/python/qiskit_fermions/circuit/library/evolution.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 
 from qiskit_fermions.operators.protocol import OperatorTrait
 
-from .. import FermionGate
+from .. import FermionicGate
 
 
-class Evolution(FermionGate):
+class Evolution(FermionicGate):
     """Implements the time-evolution of an operator."""
 
     def __init__(self, num_modes: int, operator: OperatorTrait, time: float = 1.0) -> None:

--- a/python/qiskit_fermions/circuit/library/evolution.py
+++ b/python/qiskit_fermions/circuit/library/evolution.py
@@ -68,7 +68,7 @@ class Evolution(FermionicGate):
 
             definition.append(
                 Evolution(num_active, relabeled, time=self.params[0]),
-                [definition.fermions[idx] for idx in sorted(active)],
+                [definition.modes[idx] for idx in sorted(active)],
             )
 
         self._definition = definition._inner

--- a/python/qiskit_fermions/circuit/library/initialize_modes.py
+++ b/python/qiskit_fermions/circuit/library/initialize_modes.py
@@ -30,14 +30,14 @@ class InitializeModes(FermionGate):
     """
 
     def __init__(self, occupation: Sequence[bool]) -> None:
-        """Initializes the modes of a :class:`.ModeRegister` with the provided occupation.
+        """Initializes the modes of a :class:`.FermionicRegister` with the provided occupation.
 
         Args:
             occupation: a sequence of booleans indicating the occupation for each mode in the
-                :class:`.ModeRegister` being initialized by this gate.
+                :class:`.FermionicRegister` being initialized by this gate.
         """
         self.occupation = np.asarray(occupation, dtype=bool)
         """The sequence of booleans indicating the occupation for each mode in the
-        :class:`~.ModeRegister` being initialized by this gate."""
+        :class:`~.FermionicRegister` being initialized by this gate."""
 
         super().__init__("InitializeModes", len(self.occupation), [])

--- a/python/qiskit_fermions/circuit/library/initialize_modes.py
+++ b/python/qiskit_fermions/circuit/library/initialize_modes.py
@@ -18,10 +18,10 @@ from collections.abc import Sequence
 
 import numpy as np
 
-from .. import FermionGate
+from .. import FermionicGate
 
 
-class InitializeModes(FermionGate):
+class InitializeModes(FermionicGate):
     """Implements the fermionic mode initialization.
 
     .. caution::

--- a/python/qiskit_fermions/circuit/library/initialize_modes.py
+++ b/python/qiskit_fermions/circuit/library/initialize_modes.py
@@ -30,14 +30,14 @@ class InitializeModes(FermionGate):
     """
 
     def __init__(self, occupation: Sequence[bool]) -> None:
-        """Initializes the modes of a :class:`.FermionRegister` with the provided occupation.
+        """Initializes the modes of a :class:`.ModeRegister` with the provided occupation.
 
         Args:
             occupation: a sequence of booleans indicating the occupation for each mode in the
-                :class:`.FermionRegister` being initialized by this gate.
+                :class:`.ModeRegister` being initialized by this gate.
         """
         self.occupation = np.asarray(occupation, dtype=bool)
         """The sequence of booleans indicating the occupation for each mode in the
-        :class:`~.FermionRegister` being initialized by this gate."""
+        :class:`~.ModeRegister` being initialized by this gate."""
 
         super().__init__("InitializeModes", len(self.occupation), [])

--- a/python/qiskit_fermions/circuit/library/orbital_rotation.py
+++ b/python/qiskit_fermions/circuit/library/orbital_rotation.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 
 import numpy as np
 
-from .. import FermionGate
+from .. import FermionicGate
 
 
-class OrbitalRotation(FermionGate):
+class OrbitalRotation(FermionicGate):
     """Implements an orbital rotation."""
 
     def __init__(self, rotation_unitary: np.ndarray) -> None:

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -67,7 +67,7 @@ qubits, the configured layout must account for that).
 In the general case, fermionic modes are not always encoded with an occupation-basis into the qubit
 register. Consequently, we cannot associate a single fermionic mode with a single qubit.
 Therefore, the user-provided fermion-to-qubit layout (:type:`F2QLayout`) associates
-:type:`~qiskit_fermions.circuit.ModeRegister` instances with
+:type:`~qiskit_fermions.circuit.FermionicRegister` instances with
 :class:`~qiskit.circuit.QuantumRegister` ones.
 
 .. autosummary::
@@ -143,11 +143,11 @@ from typing import TypeAlias
 
 from qiskit.circuit import QuantumRegister
 
-from qiskit_fermions.circuit import ModeRegister
+from qiskit_fermions.circuit import FermionicRegister
 
 from .passmanager import FermionPassManager, FermionStagedPassManager, FermionToQubitConverter
 
-F2QLayout: TypeAlias = dict[ModeRegister, QuantumRegister]
+F2QLayout: TypeAlias = dict[FermionicRegister, QuantumRegister]
 """A mapping of fermionic mode registers to quantum registers.
 
 Users must provide a data structure of this type to the circuit transpiler. In a trivial case, (such

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -126,9 +126,9 @@ its own interfaces of these transpiler pass managers listed below.
 .. autosummary::
    :toctree: ../stubs/
 
-   FermionPassManager
-   FermionStagedPassManager
-   FermionToQubitConverter
+   FermionicPassManager
+   FermionicStagedPassManager
+   FermionicToQubitConverter
 
 Presets
 ^^^^^^^
@@ -145,7 +145,7 @@ from qiskit.circuit import QuantumRegister
 
 from qiskit_fermions.circuit import FermionicRegister
 
-from .passmanager import FermionPassManager, FermionStagedPassManager, FermionToQubitConverter
+from .passmanager import FermionicPassManager, FermionicStagedPassManager, FermionicToQubitConverter
 
 F2QLayout: TypeAlias = dict[FermionicRegister, QuantumRegister]
 """A mapping of fermionic mode registers to quantum registers.
@@ -159,7 +159,7 @@ size of the registers on either side of this mapping may differ.
 
 __all__ = [
     "F2QLayout",
-    "FermionPassManager",
-    "FermionStagedPassManager",
-    "FermionToQubitConverter",
+    "FermionicPassManager",
+    "FermionicStagedPassManager",
+    "FermionicToQubitConverter",
 ]

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -89,7 +89,7 @@ conceptually similar to Qiskit's :class:`~qiskit.transpiler.passes.HighLevelSynt
 uses various `plugins` for transpiling high-level circuit instructions. For more details, refer to
 the documentation of :class:`.F2QSynthesis` directly.
 
-How a given :class:`.FermionGate` can be synthesized in terms of qubit-based operations will depend
+How a given :class:`.FermionicGate` can be synthesized in terms of qubit-based operations will depend
 on the particular gate type as well as the user-chosen fermion-to-qubit mapping. For more details,
 refer to :ref:`qiskit_fermions-transpiler-passes-synthesis-plugins`.
 

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -67,7 +67,7 @@ qubits, the configured layout must account for that).
 In the general case, fermionic modes are not always encoded with an occupation-basis into the qubit
 register. Consequently, we cannot associate a single fermionic mode with a single qubit.
 Therefore, the user-provided fermion-to-qubit layout (:type:`F2QLayout`) associates
-:type:`~qiskit_fermions.circuit.FermionRegister` instances with
+:type:`~qiskit_fermions.circuit.ModeRegister` instances with
 :class:`~qiskit.circuit.QuantumRegister` ones.
 
 .. autosummary::
@@ -143,11 +143,11 @@ from typing import TypeAlias
 
 from qiskit.circuit import QuantumRegister
 
-from qiskit_fermions.circuit import FermionRegister
+from qiskit_fermions.circuit import ModeRegister
 
 from .passmanager import FermionPassManager, FermionStagedPassManager, FermionToQubitConverter
 
-F2QLayout: TypeAlias = dict[FermionRegister, QuantumRegister]
+F2QLayout: TypeAlias = dict[ModeRegister, QuantumRegister]
 """A mapping of fermionic mode registers to quantum registers.
 
 Users must provide a data structure of this type to the circuit transpiler. In a trivial case, (such

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -27,7 +27,7 @@ such as topological and operational constraints of the hardware used to execute 
 We are not going to explain this in more detail here, and instead refer to Qiskit's documentation of
 the :mod:`qiskit.transpiler` module.
 
-The focus here lies on explaining how we achieve the transpilation of a :class:`.FermionCircuit` to
+The focus here lies on explaining how we achieve the transpilation of a :class:`.FermionicCircuit` to
 a :class:`~qiskit.circuit.QuantumCircuit`.
 
 ------
@@ -51,7 +51,7 @@ Optimization
 ^^^^^^^^^^^^
 
 This stage of the transpilation pipeline can implement circuit optimizations while preserving the
-type of circuit to be an instance of :class:`.FermionCircuit`. As such, no qubit information is
+type of circuit to be an instance of :class:`.FermionicCircuit`. As such, no qubit information is
 required (or necessarily available) at this point in the transpilation pipeline.
 
 .. _qiskit_fermions-transpiler-stage-layout:
@@ -103,7 +103,7 @@ instance and can continue to use Qiskit's transpilation pipeline as one would us
 
 .. hint::
    Additional transpiler passes for optimizations on the qubit-level that take into account the
-   knowledge of a circuit originating from a :class:`.FermionCircuit` may be added in the future!
+   knowledge of a circuit originating from a :class:`.FermionicCircuit` may be added in the future!
 
 -------------
 Pass Managers
@@ -113,7 +113,7 @@ Qiskit's transpilation process is orchestrated by a :class:`~qiskit.transpiler.P
 In particular, a :class:`~qiskit.transpiler.StagedPassManager` can be used to orchestrate the
 transpilation into stages as explained above.
 
-Here, we are dealing with a change of circuit representation converting :class:`.FermionCircuit`
+Here, we are dealing with a change of circuit representation converting :class:`.FermionicCircuit`
 instances to :external:class:`~qiskit.circuit.QuantumCircuit` ones. As such, this module provides
 its own interfaces of these transpiler pass managers listed below.
 

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -26,7 +26,7 @@ This module provides various transpiler passes for the stages explained in
 Optimization Passes
 -------------------
 
-These passes provide different kinds of optimization of :class:`.FermionCircuit` instances.
+These passes provide different kinds of optimization of :class:`.FermionicCircuit` instances.
 
 .. autosummary::
    :toctree: ../stubs/
@@ -55,10 +55,10 @@ needs to be placed in the ``f2q_layout`` field of the
 Synthesis Passes
 ----------------
 
-The main logic for mapping a :class:`.FermionCircuit` to a :class:`~qiskit.circuit.QuantumCircuit`
+The main logic for mapping a :class:`.FermionicCircuit` to a :class:`~qiskit.circuit.QuantumCircuit`
 is implemented by a single synthesis pass, namely the :class:`.F2QSynthesis`. It is conceptually
 similar to Qiskit's :class:`~qiskit.transpiler.passes.HighLevelSynthesis` because it simply iterates
-over the :class:`.FermionCircuit` instructions and delegates the mapping to qubit-based instructions
+over the :class:`.FermionicCircuit` instructions and delegates the mapping to qubit-based instructions
 to :ref:`qiskit_fermions-transpiler-passes-synthesis-plugins` for each of the encountered types of
 :class:`.FermionGate`.
 

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -60,7 +60,7 @@ is implemented by a single synthesis pass, namely the :class:`.F2QSynthesis`. It
 similar to Qiskit's :class:`~qiskit.transpiler.passes.HighLevelSynthesis` because it simply iterates
 over the :class:`.FermionicCircuit` instructions and delegates the mapping to qubit-based instructions
 to :ref:`qiskit_fermions-transpiler-passes-synthesis-plugins` for each of the encountered types of
-:class:`.FermionGate`.
+:class:`.FermionicGate`.
 
 .. autosummary::
    :toctree: ../stubs/

--- a/python/qiskit_fermions/transpiler/passes/layout/custom.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/custom.py
@@ -48,6 +48,6 @@ class CustomF2QLayout(AnalysisPass):
         """Runs this analysis pass.
 
         Args:
-            dag: the DAG circuit representation of a :class:`.FermionCircuit`.
+            dag: the DAG circuit representation of a :class:`.FermionicCircuit`.
         """
         self.property_set["f2q_layout"] = self.layout

--- a/python/qiskit_fermions/transpiler/passes/layout/custom.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/custom.py
@@ -41,7 +41,7 @@ class CustomF2QLayout(AnalysisPass):
         super().__init__()
 
         self.layout: F2QLayout = layout
-        """The user-provided mapping of :type:`~qiskit_fermions.circuit.ModeRegister` to
+        """The user-provided mapping of :type:`~qiskit_fermions.circuit.FermionicRegister` to
         :class:`~qiskit.circuit.QuantumRegister`."""
 
     def run(self, dag: DAGCircuit) -> None:

--- a/python/qiskit_fermions/transpiler/passes/layout/custom.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/custom.py
@@ -41,7 +41,7 @@ class CustomF2QLayout(AnalysisPass):
         super().__init__()
 
         self.layout: F2QLayout = layout
-        """The user-provided mapping of :type:`~qiskit_fermions.circuit.FermionRegister` to
+        """The user-provided mapping of :type:`~qiskit_fermions.circuit.ModeRegister` to
         :class:`~qiskit.circuit.QuantumRegister`."""
 
     def run(self, dag: DAGCircuit) -> None:

--- a/python/qiskit_fermions/transpiler/passes/layout/trivial.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/trivial.py
@@ -26,7 +26,7 @@ class TrivialF2QLayout(AnalysisPass):
 
     This pass simply populates the ``f2q_layout`` field of the
     :attr:`~qiskit.passmanager.PassManagerState.property_set`, with a dictionary associating each
-    :type:`~qiskit_fermions.circuit.FermionRegister` with an equally sized
+    :type:`~qiskit_fermions.circuit.ModeRegister` with an equally sized
     :class:`~qiskit.circuit.QuantumRegister`.
     """
 

--- a/python/qiskit_fermions/transpiler/passes/layout/trivial.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/trivial.py
@@ -34,7 +34,7 @@ class TrivialF2QLayout(AnalysisPass):
         """Runs this analysis pass.
 
         Args:
-            dag: the DAG circuit representation of a :class:`.FermionCircuit`.
+            dag: the DAG circuit representation of a :class:`.FermionicCircuit`.
         """
         layout: F2QLayout = {}
         for qreg in dag.qregs.values():

--- a/python/qiskit_fermions/transpiler/passes/layout/trivial.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/trivial.py
@@ -26,7 +26,7 @@ class TrivialF2QLayout(AnalysisPass):
 
     This pass simply populates the ``f2q_layout`` field of the
     :attr:`~qiskit.passmanager.PassManagerState.property_set`, with a dictionary associating each
-    :type:`~qiskit_fermions.circuit.ModeRegister` with an equally sized
+    :type:`~qiskit_fermions.circuit.FermionicRegister` with an equally sized
     :class:`~qiskit.circuit.QuantumRegister`.
     """
 

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -58,7 +58,7 @@ class QDriftTrotterization(TransformationPass):
 
             hamil = node.op.operator
             time = node.op.params[0]
-            num_fermions = len(node.qargs)
+            num_modes = len(node.qargs)
 
             if hamil.groups is not None:
                 terms = hamil.split_out_groups()
@@ -79,7 +79,7 @@ class QDriftTrotterization(TransformationPass):
             for ind in sampled_indices:
                 term = terms[ind]
                 op = hamil.__class__.from_terms([term]) if isinstance(term, tuple) else term
-                evo = Evolution(num_fermions, op, time=delta)
+                evo = Evolution(num_modes, op, time=delta)
                 out_dag.apply_operation_back(evo, qargs=out_dag.qubits)
 
         return out_dag

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -44,7 +44,7 @@ class QDriftTrotterization(TransformationPass):
 
         Args:
             dag: the input circuit with fermion-based instructions. Only
-                :class:`~qiskit.dagcircuit.DAGOpNode` with :class:`.FermionGate` instances as their
+                :class:`~qiskit.dagcircuit.DAGOpNode` with :class:`.FermionicGate` instances as their
                 :attr:`~qiskit.dagcircuit.DAGOpNode.op` are supported.
 
         Returns:

--- a/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
@@ -71,14 +71,14 @@ class EvolutionSynthesis:
 
         Raises:
             NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
-                multiple :type:`~qiskit_fermions.circuit.ModeRegister` instances.
+                multiple :type:`~qiskit_fermions.circuit.FermionicRegister` instances.
         """
         encountered_mode_registers, global_mode_indices = _parse_node_indices(in_node, f2q_layout)
 
         if len(encountered_mode_registers) > 1:
             raise NotImplementedError(
                 "Cannot map an Evolution gate acting on fermionic modes that are spread across "
-                "multiple ModeRegister instances."
+                "multiple FermionicRegister instances."
             )
 
         mreg = encountered_mode_registers.pop()

--- a/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
@@ -73,16 +73,18 @@ class EvolutionSynthesis:
             NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
                 multiple :type:`~qiskit_fermions.circuit.FermionicRegister` instances.
         """
-        encountered_mode_registers, global_mode_indices = _parse_node_indices(in_node, f2q_layout)
+        encountered_fermionic_registers, global_mode_indices = _parse_node_indices(
+            in_node, f2q_layout
+        )
 
-        if len(encountered_mode_registers) > 1:
+        if len(encountered_fermionic_registers) > 1:
             raise NotImplementedError(
                 "Cannot map an Evolution gate acting on fermionic modes that are spread across "
                 "multiple FermionicRegister instances."
             )
 
-        mreg = encountered_mode_registers.pop()
-        qreg = f2q_layout[mreg]
+        freg = encountered_fermionic_registers.pop()
+        qreg = f2q_layout[freg]
 
         local_op = in_node.op.operator
         global_op = local_op.relabel_modes(global_mode_indices)

--- a/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
@@ -71,23 +71,21 @@ class EvolutionSynthesis:
 
         Raises:
             NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
-                multiple :type:`~qiskit_fermions.circuit.FermionRegister` instances.
+                multiple :type:`~qiskit_fermions.circuit.ModeRegister` instances.
         """
-        encountered_fermion_registers, global_fermion_indices = _parse_node_indices(
-            in_node, f2q_layout
-        )
+        encountered_mode_registers, global_mode_indices = _parse_node_indices(in_node, f2q_layout)
 
-        if len(encountered_fermion_registers) > 1:
+        if len(encountered_mode_registers) > 1:
             raise NotImplementedError(
                 "Cannot map an Evolution gate acting on fermionic modes that are spread across "
-                "multiple FermionRegister instances."
+                "multiple ModeRegister instances."
             )
 
-        freg = encountered_fermion_registers.pop()
-        qreg = f2q_layout[freg]
+        mreg = encountered_mode_registers.pop()
+        qreg = f2q_layout[mreg]
 
         local_op = in_node.op.operator
-        global_op = local_op.relabel_modes(global_fermion_indices)
+        global_op = local_op.relabel_modes(global_mode_indices)
         pauli_op = self.mapper_fn(global_op, len(qreg)).simplify()
 
         circ = QuantumCircuit(qreg)

--- a/python/qiskit_fermions/transpiler/passes/synthesis/initialize_modes.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/initialize_modes.py
@@ -54,14 +54,14 @@ class InitializeModesSynthesis:
 
         Raises:
             NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
-                multiple :type:`~qiskit_fermions.circuit.ModeRegister` instances.
+                multiple :type:`~qiskit_fermions.circuit.FermionicRegister` instances.
         """
         encountered_mode_registers, global_mode_indices = _parse_node_indices(in_node, f2q_layout)
 
         if len(encountered_mode_registers) > 1:
             raise NotImplementedError(
                 "Cannot map an InitializeModes gate acting on fermionic modes that are spread "
-                "across multiple ModeRegister instances."
+                "across multiple FermionicRegister instances."
             )
 
         mreg = encountered_mode_registers.pop()

--- a/python/qiskit_fermions/transpiler/passes/synthesis/initialize_modes.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/initialize_modes.py
@@ -56,16 +56,18 @@ class InitializeModesSynthesis:
             NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
                 multiple :type:`~qiskit_fermions.circuit.FermionicRegister` instances.
         """
-        encountered_mode_registers, global_mode_indices = _parse_node_indices(in_node, f2q_layout)
+        encountered_fermionic_registers, global_mode_indices = _parse_node_indices(
+            in_node, f2q_layout
+        )
 
-        if len(encountered_mode_registers) > 1:
+        if len(encountered_fermionic_registers) > 1:
             raise NotImplementedError(
                 "Cannot map an InitializeModes gate acting on fermionic modes that are spread "
                 "across multiple FermionicRegister instances."
             )
 
-        mreg = encountered_mode_registers.pop()
-        qreg = f2q_layout[mreg]
+        freg = encountered_fermionic_registers.pop()
+        qreg = f2q_layout[freg]
 
         circ = QuantumCircuit(qreg)
 

--- a/python/qiskit_fermions/transpiler/passes/synthesis/initialize_modes.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/initialize_modes.py
@@ -54,25 +54,23 @@ class InitializeModesSynthesis:
 
         Raises:
             NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
-                multiple :type:`~qiskit_fermions.circuit.FermionRegister` instances.
+                multiple :type:`~qiskit_fermions.circuit.ModeRegister` instances.
         """
-        encountered_fermion_registers, global_fermion_indices = _parse_node_indices(
-            in_node, f2q_layout
-        )
+        encountered_mode_registers, global_mode_indices = _parse_node_indices(in_node, f2q_layout)
 
-        if len(encountered_fermion_registers) > 1:
+        if len(encountered_mode_registers) > 1:
             raise NotImplementedError(
                 "Cannot map an InitializeModes gate acting on fermionic modes that are spread "
-                "across multiple FermionRegister instances."
+                "across multiple ModeRegister instances."
             )
 
-        freg = encountered_fermion_registers.pop()
-        qreg = f2q_layout[freg]
+        mreg = encountered_mode_registers.pop()
+        qreg = f2q_layout[mreg]
 
         circ = QuantumCircuit(qreg)
 
         local_occupation = in_node.op.occupation
-        global_occupied_indices = np.asarray(global_fermion_indices)[np.nonzero(local_occupation)]
+        global_occupied_indices = np.asarray(global_mode_indices)[np.nonzero(local_occupation)]
         circ.x(global_occupied_indices.tolist())
 
         new_dag = circuit_to_dag(circ)

--- a/python/qiskit_fermions/transpiler/passes/synthesis/orbital_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/orbital_rotation.py
@@ -60,16 +60,18 @@ class OrbitalRotationSynthesis:
             NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
                 multiple :type:`~qiskit_fermions.circuit.FermionicRegister` instances.
         """
-        encountered_mode_registers, global_mode_indices = _parse_node_indices(in_node, f2q_layout)
+        encountered_fermionic_registers, global_mode_indices = _parse_node_indices(
+            in_node, f2q_layout
+        )
 
-        if len(encountered_mode_registers) > 1:
+        if len(encountered_fermionic_registers) > 1:
             raise NotImplementedError(
                 "Cannot map an OrbitalRotation gate acting on fermionic modes that are spread "
                 "across multiple FermionicRegister instances."
             )
 
-        mreg = encountered_mode_registers.pop()
-        qreg = f2q_layout[mreg]
+        freg = encountered_fermionic_registers.pop()
+        qreg = f2q_layout[freg]
 
         circ = QuantumCircuit(qreg)
 

--- a/python/qiskit_fermions/transpiler/passes/synthesis/orbital_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/orbital_rotation.py
@@ -58,20 +58,18 @@ class OrbitalRotationSynthesis:
 
         Raises:
             NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
-                multiple :type:`~qiskit_fermions.circuit.FermionRegister` instances.
+                multiple :type:`~qiskit_fermions.circuit.ModeRegister` instances.
         """
-        encountered_fermion_registers, global_fermion_indices = _parse_node_indices(
-            in_node, f2q_layout
-        )
+        encountered_mode_registers, global_mode_indices = _parse_node_indices(in_node, f2q_layout)
 
-        if len(encountered_fermion_registers) > 1:
+        if len(encountered_mode_registers) > 1:
             raise NotImplementedError(
                 "Cannot map an OrbitalRotation gate acting on fermionic modes that are spread "
-                "across multiple FermionRegister instances."
+                "across multiple ModeRegister instances."
             )
 
-        freg = encountered_fermion_registers.pop()
-        qreg = f2q_layout[freg]
+        mreg = encountered_mode_registers.pop()
+        qreg = f2q_layout[mreg]
 
         circ = QuantumCircuit(qreg)
 
@@ -81,12 +79,12 @@ class OrbitalRotationSynthesis:
             if not np.isclose(c_angle, 0.0):
                 circ.append(
                     XXPlusYYGate(2 * c_angle, np.angle(s) - 0.5 * np.pi),
-                    (global_fermion_indices[i], global_fermion_indices[j]),
+                    (global_mode_indices[i], global_mode_indices[j]),
                 )
         for i, p in enumerate(phase_shifts):
             p_angle = np.angle(p)
             if not np.isclose(p_angle, 0.0):
-                circ.append(PhaseGate(p_angle), (global_fermion_indices[i],))
+                circ.append(PhaseGate(p_angle), (global_mode_indices[i],))
 
         new_dag = circuit_to_dag(circ)
 

--- a/python/qiskit_fermions/transpiler/passes/synthesis/orbital_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/orbital_rotation.py
@@ -58,14 +58,14 @@ class OrbitalRotationSynthesis:
 
         Raises:
             NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
-                multiple :type:`~qiskit_fermions.circuit.ModeRegister` instances.
+                multiple :type:`~qiskit_fermions.circuit.FermionicRegister` instances.
         """
         encountered_mode_registers, global_mode_indices = _parse_node_indices(in_node, f2q_layout)
 
         if len(encountered_mode_registers) > 1:
             raise NotImplementedError(
                 "Cannot map an OrbitalRotation gate acting on fermionic modes that are spread "
-                "across multiple ModeRegister instances."
+                "across multiple FermionicRegister instances."
             )
 
         mreg = encountered_mode_registers.pop()

--- a/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
@@ -93,10 +93,10 @@ class F2QSynthesis(TransformationPass):
 
         out_dag = dag.copy_empty_like()
 
-        for mreg, qreg in f2q_layout.items():
+        for freg, qreg in f2q_layout.items():
             out_dag.add_qreg(qreg)
-            out_dag.remove_qregs(mreg)
-            out_dag.remove_qubits(*mreg)
+            out_dag.remove_qregs(freg)
+            out_dag.remove_qubits(*freg)
 
         for node in dag.op_nodes():
             op_type = type(node.op)

--- a/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
@@ -38,7 +38,7 @@ class F2QSynthesisPlugin(Protocol):
                 must insert the translated circuit instruction.
             f2q_layout: the :type:`~qiskit_fermions.transpiler.F2QLayout` setting that is global to
                 the transpilation process. It is the plugin's responsibility to respect this mapping
-                of :type:`~qiskit_fermions.circuit.ModeRegister` to
+                of :type:`~qiskit_fermions.circuit.FermionicRegister` to
                 :class:`~qiskit.circuit.QuantumRegister`.
         """
         ...

--- a/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
@@ -19,7 +19,7 @@ from typing import Protocol, cast
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode
 from qiskit.transpiler import TransformationPass
 
-from qiskit_fermions.circuit import FermionGate
+from qiskit_fermions.circuit import FermionicGate
 
 from ... import F2QLayout
 
@@ -33,7 +33,7 @@ class F2QSynthesisPlugin(Protocol):
         Args:
             in_node: a fermion-based circuit instruction stored in a
                 :class:`~qiskit.dagcircuit.DAGOpNode`. Specifically, this guarantees that
-                :attr:`~qiskit.dagcircuit.DAGOpNode.op` is of type :class:`.FermionGate`.
+                :attr:`~qiskit.dagcircuit.DAGOpNode.op` is of type :class:`.FermionicGate`.
             out_dag: the qubit-based :class:`~qiskit.dagcircuit.DAGCircuit` into which this plugin
                 must insert the translated circuit instruction.
             f2q_layout: the :type:`~qiskit_fermions.transpiler.F2QLayout` setting that is global to
@@ -49,7 +49,7 @@ class F2QSynthesis(TransformationPass):
 
     This transpilation pass works similarly to Qiskit's
     :class:`~qiskit.transpiler.passes.HighLevelSynthesis` pass; given an input
-    :class:`~qiskit.dagcircuit.DAGCircuit` with :class:`.FermionGate` instructions, it iterates them
+    :class:`~qiskit.dagcircuit.DAGCircuit` with :class:`.FermionicGate` instructions, it iterates them
     and delegates the translation to qubit-based instructions to matching :attr:`plugins`.
     The insertion of the qubit-based circuit instructions into the output
     :class:`~qiskit.dagcircuit.DAGCircuit` is also left to the plugin. This pass will merely have
@@ -77,7 +77,7 @@ class F2QSynthesis(TransformationPass):
 
         Args:
             dag: the input circuit with fermion-based instructions. Only
-                :class:`~qiskit.dagcircuit.DAGOpNode` with :class:`.FermionGate` instances as their
+                :class:`~qiskit.dagcircuit.DAGOpNode` with :class:`.FermionicGate` instances as their
                 :attr:`~qiskit.dagcircuit.DAGOpNode.op` are supported.
 
         Returns:
@@ -85,8 +85,8 @@ class F2QSynthesis(TransformationPass):
 
         Raises:
             ValueError: when a :class:`~qiskit.dagcircuit.DAGOpNode` is encountered whose
-                :attr:`~qiskit.dagcircuit.DAGOpNode.op` is not of type :class:`.FermionGate`.
-            TypeError: when a :class:`.FermionGate` type is encountered for which no translation
+                :attr:`~qiskit.dagcircuit.DAGOpNode.op` is not of type :class:`.FermionicGate`.
+            TypeError: when a :class:`.FermionicGate` type is encountered for which no translation
                 plugin is present in :attr:`plugins`.
         """
         f2q_layout = cast(F2QLayout, self.property_set["f2q_layout"])
@@ -100,7 +100,7 @@ class F2QSynthesis(TransformationPass):
 
         for node in dag.op_nodes():
             op_type = type(node.op)
-            if not isinstance(node.op, FermionGate):
+            if not isinstance(node.op, FermionicGate):
                 raise ValueError("Encountered an unsupported circuit instruction type: {}", op_type)
 
             plugin = self.plugins.get(op_type, None)

--- a/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
@@ -38,7 +38,7 @@ class F2QSynthesisPlugin(Protocol):
                 must insert the translated circuit instruction.
             f2q_layout: the :type:`~qiskit_fermions.transpiler.F2QLayout` setting that is global to
                 the transpilation process. It is the plugin's responsibility to respect this mapping
-                of :type:`~qiskit_fermions.circuit.FermionRegister` to
+                of :type:`~qiskit_fermions.circuit.ModeRegister` to
                 :class:`~qiskit.circuit.QuantumRegister`.
         """
         ...
@@ -93,10 +93,10 @@ class F2QSynthesis(TransformationPass):
 
         out_dag = dag.copy_empty_like()
 
-        for freg, qreg in f2q_layout.items():
+        for mreg, qreg in f2q_layout.items():
             out_dag.add_qreg(qreg)
-            out_dag.remove_qregs(freg)
-            out_dag.remove_qubits(*freg)
+            out_dag.remove_qregs(mreg)
+            out_dag.remove_qubits(*mreg)
 
         for node in dag.op_nodes():
             op_type = type(node.op)

--- a/python/qiskit_fermions/transpiler/passes/utils.py
+++ b/python/qiskit_fermions/transpiler/passes/utils.py
@@ -36,13 +36,13 @@ def _parse_node_indices(
     Returns:
         The set of fermionic mode registers and global mode indices acted upon by ``in_node``.
     """
-    encountered_fermion_registers: set[QuantumRegister] = set()
-    global_fermion_indices = []
+    encountered_mode_registers: set[QuantumRegister] = set()
+    global_mode_indices = []
     for fermion in in_node.qargs:
-        for freg in f2q_layout:
-            if fermion in freg:
-                encountered_fermion_registers.add(freg)
-                global_fermion_indices.append(freg.index(fermion))
+        for mreg in f2q_layout:
+            if fermion in mreg:
+                encountered_mode_registers.add(mreg)
+                global_mode_indices.append(mreg.index(fermion))
                 break
 
-    return encountered_fermion_registers, global_fermion_indices
+    return encountered_mode_registers, global_mode_indices

--- a/python/qiskit_fermions/transpiler/passes/utils.py
+++ b/python/qiskit_fermions/transpiler/passes/utils.py
@@ -36,13 +36,13 @@ def _parse_node_indices(
     Returns:
         The set of fermionic mode registers and global mode indices acted upon by ``in_node``.
     """
-    encountered_mode_registers: set[QuantumRegister] = set()
+    encountered_fermionic_registers: set[QuantumRegister] = set()
     global_mode_indices = []
     for fermion in in_node.qargs:
-        for mreg in f2q_layout:
-            if fermion in mreg:
-                encountered_mode_registers.add(mreg)
-                global_mode_indices.append(mreg.index(fermion))
+        for freg in f2q_layout:
+            if fermion in freg:
+                encountered_fermionic_registers.add(freg)
+                global_mode_indices.append(freg.index(fermion))
                 break
 
-    return encountered_mode_registers, global_mode_indices
+    return encountered_fermionic_registers, global_mode_indices

--- a/python/qiskit_fermions/transpiler/passmanager.py
+++ b/python/qiskit_fermions/transpiler/passmanager.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""PassManager interfaces for FermionCircuits."""
+"""PassManager interfaces for FermionicCircuits."""
 
 from collections.abc import Callable, Iterable
 
@@ -20,11 +20,11 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.passmanager import BasePassManager
 from qiskit.transpiler import StagedPassManager
 
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 
 
 class FermionPassManager(BasePassManager):
-    """A transpiler pass manager converting one :class:`.FermionCircuit` to another.
+    """A transpiler pass manager converting one :class:`.FermionicCircuit` to another.
 
     .. note::
        Qiskit is currently working on native support of transpiler pipelines involving more than a
@@ -33,19 +33,19 @@ class FermionPassManager(BasePassManager):
        <https://github.com/Qiskit/qiskit/issues/16115>`_.
     """
 
-    def _passmanager_frontend(self, input_program: FermionCircuit, **kwargs) -> DAGCircuit:
+    def _passmanager_frontend(self, input_program: FermionicCircuit, **kwargs) -> DAGCircuit:
         return circuit_to_dag(input_program._inner, copy_operations=True)
 
     def _passmanager_backend(
-        self, passmanager_ir: DAGCircuit, in_program: FermionCircuit, **kwargs
-    ) -> FermionCircuit:
-        out = FermionCircuit(passmanager_ir.num_qubits())
+        self, passmanager_ir: DAGCircuit, in_program: FermionicCircuit, **kwargs
+    ) -> FermionicCircuit:
+        out = FermionicCircuit(passmanager_ir.num_qubits())
         out._inner = dag_to_circuit(passmanager_ir, copy_operations=False)
         return out
 
 
 class FermionToQubitConverter(BasePassManager):
-    """A transpiler pass manager converting a :class:`.FermionCircuit` to a :class:`~qiskit.circuit.QuantumCircuit`.
+    """A transpiler pass manager converting a :class:`.FermionicCircuit` to a :class:`~qiskit.circuit.QuantumCircuit`.
 
     .. note::
        Qiskit is currently working on native support of transpiler pipelines involving more than a
@@ -54,11 +54,11 @@ class FermionToQubitConverter(BasePassManager):
        <https://github.com/Qiskit/qiskit/issues/16115>`_.
     """
 
-    def _passmanager_frontend(self, input_program: FermionCircuit, **kwargs) -> DAGCircuit:
+    def _passmanager_frontend(self, input_program: FermionicCircuit, **kwargs) -> DAGCircuit:
         return circuit_to_dag(input_program._inner, copy_operations=True)
 
     def _passmanager_backend(
-        self, passmanager_ir: DAGCircuit, in_program: FermionCircuit, **kwargs
+        self, passmanager_ir: DAGCircuit, in_program: FermionicCircuit, **kwargs
     ) -> QuantumCircuit:
         return dag_to_circuit(passmanager_ir, copy_operations=False)
 
@@ -75,7 +75,7 @@ class FermionStagedPassManager(StagedPassManager):
        <https://github.com/Qiskit/qiskit/issues/16115>`_.
     """
 
-    def _passmanager_frontend(self, input_program: FermionCircuit, **kwargs) -> DAGCircuit:
+    def _passmanager_frontend(self, input_program: FermionicCircuit, **kwargs) -> DAGCircuit:
         return circuit_to_dag(input_program._inner, copy_operations=True)
 
     def __init__(self, stages: Iterable[str] | None = None, **kwargs) -> None:  # noqa: D107
@@ -89,7 +89,7 @@ class FermionStagedPassManager(StagedPassManager):
 
     def run(  # noqa: D102
         self,
-        in_programs: FermionCircuit | list[FermionCircuit],
+        in_programs: FermionicCircuit | list[FermionicCircuit],
         callback: Callable | None = None,
         num_processes: int | None = None,
         *,

--- a/python/qiskit_fermions/transpiler/passmanager.py
+++ b/python/qiskit_fermions/transpiler/passmanager.py
@@ -23,7 +23,7 @@ from qiskit.transpiler import StagedPassManager
 from qiskit_fermions.circuit import FermionicCircuit
 
 
-class FermionPassManager(BasePassManager):
+class FermionicPassManager(BasePassManager):
     """A transpiler pass manager converting one :class:`.FermionicCircuit` to another.
 
     .. note::
@@ -44,7 +44,7 @@ class FermionPassManager(BasePassManager):
         return out
 
 
-class FermionToQubitConverter(BasePassManager):
+class FermionicToQubitConverter(BasePassManager):
     """A transpiler pass manager converting a :class:`.FermionicCircuit` to a :class:`~qiskit.circuit.QuantumCircuit`.
 
     .. note::
@@ -63,7 +63,7 @@ class FermionToQubitConverter(BasePassManager):
         return dag_to_circuit(passmanager_ir, copy_operations=False)
 
 
-class FermionStagedPassManager(StagedPassManager):
+class FermionicStagedPassManager(StagedPassManager):
     """The staged fermion-to-qubit transpilation pipeline.
 
     This

--- a/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
+++ b/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
@@ -17,7 +17,7 @@ from qiskit.transpiler import generate_preset_pass_manager
 from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
 from qiskit_fermions.mappers.library import jordan_wigner
 
-from .. import FermionPassManager, FermionStagedPassManager, FermionToQubitConverter
+from .. import FermionicPassManager, FermionicStagedPassManager, FermionicToQubitConverter
 from ..passes import (
     EvolutionSynthesis,
     F2QSynthesis,
@@ -27,29 +27,29 @@ from ..passes import (
 )
 
 
-def generate_preset_jw_pass_manager(**kwargs) -> FermionStagedPassManager:
+def generate_preset_jw_pass_manager(**kwargs) -> FermionicStagedPassManager:
     """Generates a preset transpiler pipeline based on the :func:`.jordan_wigner` mapping.
 
     Args:
         kwargs: any additional keyword arguments are forwarded to
             :external:func:`~qiskit.transpiler.generate_preset_pass_manager` whose output is used
-            for the ``quantum`` stage of the resulting :class:`.FermionStagedPassManager`.
+            for the ``quantum`` stage of the resulting :class:`.FermionicStagedPassManager`.
 
     Returns:
         The preset staged fermion-to-qubit transpiler pipeline.
     """
-    optimization = FermionPassManager()
+    optimization = FermionicPassManager()
 
-    layout = FermionPassManager(TrivialF2QLayout())
+    layout = FermionicPassManager(TrivialF2QLayout())
 
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)  # type: ignore[arg-type]
     synth.plugins[InitializeModes] = InitializeModesSynthesis()
     synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
 
-    synthesis = FermionToQubitConverter(synth)
+    synthesis = FermionicToQubitConverter(synth)
 
-    pm = FermionStagedPassManager()
+    pm = FermionicStagedPassManager()
     pm.optimization = optimization
     pm.layout = layout
     pm.synthesis = synthesis

--- a/tests/python/circuit/library/test_evolution.py
+++ b/tests/python/circuit/library/test_evolution.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import FermionOperator
 
@@ -30,7 +30,7 @@ def test_evolution_gate():
     )
     time = 1.5
     num_modes = 4
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
@@ -49,7 +49,7 @@ def test_evolution_gate_decompose():
     )
     time = 1.5
     num_modes = 4
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
@@ -76,7 +76,7 @@ def test_evolution_gate_decompose_with_groups():
     hamil.groups = [0, 0, 1, 1]
     time = 1.5
     num_modes = 4
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 

--- a/tests/python/circuit/library/test_evolution.py
+++ b/tests/python/circuit/library/test_evolution.py
@@ -32,7 +32,7 @@ def test_evolution_gate():
     num_modes = 4
     circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
-    circ.append(evo, circ.fermions)
+    circ.append(evo, circ.modes)
 
     ops = circ.count_ops()
     assert ops == {"Evolution": 1}
@@ -51,7 +51,7 @@ def test_evolution_gate_decompose():
     num_modes = 4
     circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
-    circ.append(evo, circ.fermions)
+    circ.append(evo, circ.modes)
 
     decomposed = circ.decompose()
 
@@ -78,7 +78,7 @@ def test_evolution_gate_decompose_with_groups():
     num_modes = 4
     circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
-    circ.append(evo, circ.fermions)
+    circ.append(evo, circ.modes)
 
     decomposed = circ.decompose()
 

--- a/tests/python/circuit/library/test_evolution.py
+++ b/tests/python/circuit/library/test_evolution.py
@@ -29,9 +29,9 @@ def test_evolution_gate():
         }
     )
     time = 1.5
-    num_fermions = 4
-    circ = FermionCircuit(num_fermions)
-    evo = Evolution(num_fermions, hamil, time=time)
+    num_modes = 4
+    circ = FermionCircuit(num_modes)
+    evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
     ops = circ.count_ops()
@@ -48,9 +48,9 @@ def test_evolution_gate_decompose():
         }
     )
     time = 1.5
-    num_fermions = 4
-    circ = FermionCircuit(num_fermions)
-    evo = Evolution(num_fermions, hamil, time=time)
+    num_modes = 4
+    circ = FermionCircuit(num_modes)
+    evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
     decomposed = circ.decompose()
@@ -75,9 +75,9 @@ def test_evolution_gate_decompose_with_groups():
     )
     hamil.groups = [0, 0, 1, 1]
     time = 1.5
-    num_fermions = 4
-    circ = FermionCircuit(num_fermions)
-    evo = Evolution(num_fermions, hamil, time=time)
+    num_modes = 4
+    circ = FermionCircuit(num_modes)
+    evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
     decomposed = circ.decompose()

--- a/tests/python/circuit/library/test_initialize_modes.py
+++ b/tests/python/circuit/library/test_initialize_modes.py
@@ -20,9 +20,9 @@ from qiskit_fermions.circuit.library import InitializeModes
 
 
 def _test_initialize_modes(occupation):
-    num_fermions = len(occupation)
+    num_modes = len(occupation)
     init = InitializeModes(occupation)
-    circ = FermionCircuit(num_fermions)
+    circ = FermionCircuit(num_modes)
     circ.append(init, circ.fermions)
 
     ops = circ.count_ops()

--- a/tests/python/circuit/library/test_initialize_modes.py
+++ b/tests/python/circuit/library/test_initialize_modes.py
@@ -23,7 +23,7 @@ def _test_initialize_modes(occupation):
     num_modes = len(occupation)
     init = InitializeModes(occupation)
     circ = FermionicCircuit(num_modes)
-    circ.append(init, circ.fermions)
+    circ.append(init, circ.modes)
 
     ops = circ.count_ops()
     assert ops == {"InitializeModes": 1}

--- a/tests/python/circuit/library/test_initialize_modes.py
+++ b/tests/python/circuit/library/test_initialize_modes.py
@@ -15,14 +15,14 @@
 from __future__ import annotations
 
 import numpy as np
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import InitializeModes
 
 
 def _test_initialize_modes(occupation):
     num_modes = len(occupation)
     init = InitializeModes(occupation)
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     circ.append(init, circ.fermions)
 
     ops = circ.count_ops()

--- a/tests/python/circuit/test_fermionic_circuit.py
+++ b/tests/python/circuit/test_fermionic_circuit.py
@@ -22,4 +22,4 @@ from qiskit_fermions.circuit import FermionicCircuit
 def test_invalid_gate():
     circ = FermionicCircuit(1)
     with pytest.raises(ValueError):
-        circ.append(XGate(), circ.fermions)
+        circ.append(XGate(), circ.modes)

--- a/tests/python/circuit/test_fermionic_circuit.py
+++ b/tests/python/circuit/test_fermionic_circuit.py
@@ -10,16 +10,16 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""FermionCircuit tests."""
+"""FermionicCircuit tests."""
 
 from __future__ import annotations
 
 import pytest
 from qiskit.circuit.library import XGate
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 
 
 def test_invalid_gate():
-    circ = FermionCircuit(1)
+    circ = FermionicCircuit(1)
     with pytest.raises(ValueError):
         circ.append(XGate(), circ.fermions)

--- a/tests/python/transpiler/passes/test_custom_layout.py
+++ b/tests/python/transpiler/passes/test_custom_layout.py
@@ -19,7 +19,7 @@ from functools import partial
 
 from qiskit.circuit import QuantumRegister
 from qiskit.quantum_info import SparseObservable
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import MajoranaOperator
 from qiskit_fermions.transpiler import FermionStagedPassManager
@@ -323,7 +323,7 @@ def test_custom_layout():
     }
     mapper_fn = partial(derby_klassen, initial_state=initial_state, edge_face_map=edge_face_map)
 
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     circ.append(Evolution(num_modes, hamil), circ.fermions)
 
     layout = CustomF2QLayout({circ.register: QuantumRegister(num_qubits)})

--- a/tests/python/transpiler/passes/test_custom_layout.py
+++ b/tests/python/transpiler/passes/test_custom_layout.py
@@ -298,7 +298,7 @@ def test_custom_layout():
            Phys. Rev. B 104, 035118 (2021),
            `doi:10.1103/PhysRevB.104.035118 <http://dx.doi.org/10.1103/PhysRevB.104.035118>`_.
     """
-    num_fermions = 16
+    num_modes = 16
     num_qubits = 20
     hamil = build_fermi_hubbard_square_lattice(4, 4, 5.0, 5.0)
 
@@ -323,8 +323,8 @@ def test_custom_layout():
     }
     mapper_fn = partial(derby_klassen, initial_state=initial_state, edge_face_map=edge_face_map)
 
-    circ = FermionCircuit(num_fermions)
-    circ.append(Evolution(num_fermions, hamil), circ.fermions)
+    circ = FermionCircuit(num_modes)
+    circ.append(Evolution(num_modes, hamil), circ.fermions)
 
     layout = CustomF2QLayout({circ.register: QuantumRegister(num_qubits)})
 

--- a/tests/python/transpiler/passes/test_custom_layout.py
+++ b/tests/python/transpiler/passes/test_custom_layout.py
@@ -324,7 +324,7 @@ def test_custom_layout():
     mapper_fn = partial(derby_klassen, initial_state=initial_state, edge_face_map=edge_face_map)
 
     circ = FermionicCircuit(num_modes)
-    circ.append(Evolution(num_modes, hamil), circ.fermions)
+    circ.append(Evolution(num_modes, hamil), circ.modes)
 
     layout = CustomF2QLayout({circ.register: QuantumRegister(num_qubits)})
 

--- a/tests/python/transpiler/passes/test_custom_layout.py
+++ b/tests/python/transpiler/passes/test_custom_layout.py
@@ -22,9 +22,9 @@ from qiskit.quantum_info import SparseObservable
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import MajoranaOperator
-from qiskit_fermions.transpiler import FermionStagedPassManager
+from qiskit_fermions.transpiler import FermionicStagedPassManager
 from qiskit_fermions.transpiler.passes import CustomF2QLayout, EvolutionSynthesis, F2QSynthesis
-from qiskit_fermions.transpiler.passmanager import FermionPassManager, FermionToQubitConverter
+from qiskit_fermions.transpiler.passmanager import FermionicPassManager, FermionicToQubitConverter
 
 
 # NOTE: this is a very specific implementation of the Fermi-Hubbard model on a square lattice. It is
@@ -331,9 +331,9 @@ def test_custom_layout():
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(mapper_fn)
 
-    pm = FermionStagedPassManager()
-    pm.layout = FermionPassManager(layout)
-    pm.synthesis = FermionToQubitConverter(synth)
+    pm = FermionicStagedPassManager()
+    pm.layout = FermionicPassManager(layout)
+    pm.synthesis = FermionicToQubitConverter(synth)
 
     qu_circ = pm.run(circ)
     qu_circ_decomp = qu_circ.decompose()

--- a/tests/python/transpiler/passes/test_evolution_synthesis.py
+++ b/tests/python/transpiler/passes/test_evolution_synthesis.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from qiskit.circuit.library import PauliEvolutionGate
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
@@ -38,7 +38,7 @@ def test_evolution_gate_synthesis():
     )
     time = 1.5
     num_modes = 4
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
@@ -70,7 +70,7 @@ def test_custom_qubit_ordering():
     )
     time = 1.5
     num_modes = 4
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 

--- a/tests/python/transpiler/passes/test_evolution_synthesis.py
+++ b/tests/python/transpiler/passes/test_evolution_synthesis.py
@@ -21,9 +21,9 @@ from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.transpiler.passes import EvolutionSynthesis, F2QSynthesis, TrivialF2QLayout
 from qiskit_fermions.transpiler.passmanager import (
-    FermionPassManager,
-    FermionStagedPassManager,
-    FermionToQubitConverter,
+    FermionicPassManager,
+    FermionicStagedPassManager,
+    FermionicToQubitConverter,
 )
 
 
@@ -45,9 +45,9 @@ def test_evolution_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
 
-    pm = FermionStagedPassManager()
-    pm.layout = FermionPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionToQubitConverter(synth)
+    pm = FermionicStagedPassManager()
+    pm.layout = FermionicPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionicToQubitConverter(synth)
 
     qu_circ = pm.run(circ)
 
@@ -83,9 +83,9 @@ def test_custom_qubit_ordering():
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(custom_qubit_ordering_mapper_fn)
 
-    pm = FermionStagedPassManager()
-    pm.layout = FermionPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionToQubitConverter(synth)
+    pm = FermionicStagedPassManager()
+    pm.layout = FermionicPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionicToQubitConverter(synth)
 
     qu_circ = pm.run(circ)
 

--- a/tests/python/transpiler/passes/test_evolution_synthesis.py
+++ b/tests/python/transpiler/passes/test_evolution_synthesis.py
@@ -37,9 +37,9 @@ def test_evolution_gate_synthesis():
         }
     )
     time = 1.5
-    num_fermions = 4
-    circ = FermionCircuit(num_fermions)
-    evo = Evolution(num_fermions, hamil, time=time)
+    num_modes = 4
+    circ = FermionCircuit(num_modes)
+    evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
     synth = F2QSynthesis()
@@ -69,9 +69,9 @@ def test_custom_qubit_ordering():
         }
     )
     time = 1.5
-    num_fermions = 4
-    circ = FermionCircuit(num_fermions)
-    evo = Evolution(num_fermions, hamil, time=time)
+    num_modes = 4
+    circ = FermionCircuit(num_modes)
+    evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
     custom_qubit_ordering = [0, 2, 1, 3]

--- a/tests/python/transpiler/passes/test_evolution_synthesis.py
+++ b/tests/python/transpiler/passes/test_evolution_synthesis.py
@@ -40,7 +40,7 @@ def test_evolution_gate_synthesis():
     num_modes = 4
     circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
-    circ.append(evo, circ.fermions)
+    circ.append(evo, circ.modes)
 
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
@@ -72,7 +72,7 @@ def test_custom_qubit_ordering():
     num_modes = 4
     circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
-    circ.append(evo, circ.fermions)
+    circ.append(evo, circ.modes)
 
     custom_qubit_ordering = [0, 2, 1, 3]
 

--- a/tests/python/transpiler/passes/test_f2q_synthesis.py
+++ b/tests/python/transpiler/passes/test_f2q_synthesis.py
@@ -22,9 +22,9 @@ from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.transpiler.passes import F2QSynthesis, TrivialF2QLayout
 from qiskit_fermions.transpiler.passmanager import (
-    FermionPassManager,
-    FermionStagedPassManager,
-    FermionToQubitConverter,
+    FermionicPassManager,
+    FermionicStagedPassManager,
+    FermionicToQubitConverter,
 )
 
 
@@ -44,9 +44,9 @@ def test_missing_plugin():
     evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
-    pm = FermionStagedPassManager()
-    pm.layout = FermionPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionToQubitConverter(F2QSynthesis())
+    pm = FermionicStagedPassManager()
+    pm.layout = FermionicPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionicToQubitConverter(F2QSynthesis())
 
     with pytest.raises(TypeError, match="No plugin registered"):
         _ = pm.run(circ)

--- a/tests/python/transpiler/passes/test_f2q_synthesis.py
+++ b/tests/python/transpiler/passes/test_f2q_synthesis.py
@@ -39,9 +39,9 @@ def test_missing_plugin():
         }
     )
     time = 1.5
-    num_fermions = 4
-    circ = FermionCircuit(num_fermions)
-    evo = Evolution(num_fermions, hamil, time=time)
+    num_modes = 4
+    circ = FermionCircuit(num_modes)
+    evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
     pm = FermionStagedPassManager()

--- a/tests/python/transpiler/passes/test_f2q_synthesis.py
+++ b/tests/python/transpiler/passes/test_f2q_synthesis.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import pytest
 from qiskit.circuit import QuantumCircuit
 from qiskit.transpiler import PassManager
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.transpiler.passes import F2QSynthesis, TrivialF2QLayout
@@ -40,7 +40,7 @@ def test_missing_plugin():
     )
     time = 1.5
     num_modes = 4
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 

--- a/tests/python/transpiler/passes/test_f2q_synthesis.py
+++ b/tests/python/transpiler/passes/test_f2q_synthesis.py
@@ -42,7 +42,7 @@ def test_missing_plugin():
     num_modes = 4
     circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
-    circ.append(evo, circ.fermions)
+    circ.append(evo, circ.modes)
 
     pm = FermionicStagedPassManager()
     pm.layout = FermionicPassManager(TrivialF2QLayout())

--- a/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
+++ b/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import Statevector
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import InitializeModes
 from qiskit_fermions.transpiler import FermionPassManager, FermionStagedPassManager
 from qiskit_fermions.transpiler.passes import (
@@ -30,7 +30,7 @@ from qiskit_fermions.transpiler.passmanager import FermionToQubitConverter
 def test_initialize_modes_global_gate_synthesis():
     occupation = [True, False, True, False]
     num_modes = len(occupation)
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     init = InitializeModes(occupation)
     circ.append(init, circ.fermions)
 
@@ -53,7 +53,7 @@ def test_initialize_modes_global_gate_synthesis():
 def test_initialize_modes_local_gate_synthesis():
     occupation = [True, False]
     num_modes = 4
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     init = InitializeModes(occupation)
     circ.append(init, circ.fermions[1:3])
 

--- a/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
+++ b/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
@@ -29,8 +29,8 @@ from qiskit_fermions.transpiler.passmanager import FermionToQubitConverter
 
 def test_initialize_modes_global_gate_synthesis():
     occupation = [True, False, True, False]
-    num_fermions = len(occupation)
-    circ = FermionCircuit(num_fermions)
+    num_modes = len(occupation)
+    circ = FermionCircuit(num_modes)
     init = InitializeModes(occupation)
     circ.append(init, circ.fermions)
 
@@ -43,7 +43,7 @@ def test_initialize_modes_global_gate_synthesis():
 
     qu_circ = pm.run(circ)
 
-    expected = QuantumCircuit(num_fermions)
+    expected = QuantumCircuit(num_modes)
     expected.x(0)
     expected.x(2)
 
@@ -52,8 +52,8 @@ def test_initialize_modes_global_gate_synthesis():
 
 def test_initialize_modes_local_gate_synthesis():
     occupation = [True, False]
-    num_fermions = 4
-    circ = FermionCircuit(num_fermions)
+    num_modes = 4
+    circ = FermionCircuit(num_modes)
     init = InitializeModes(occupation)
     circ.append(init, circ.fermions[1:3])
 
@@ -66,7 +66,7 @@ def test_initialize_modes_local_gate_synthesis():
 
     qu_circ = pm.run(circ)
 
-    expected = QuantumCircuit(num_fermions)
+    expected = QuantumCircuit(num_modes)
     expected.x(1)
 
     assert Statevector(qu_circ) == Statevector(expected)

--- a/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
+++ b/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
@@ -18,13 +18,13 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import Statevector
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import InitializeModes
-from qiskit_fermions.transpiler import FermionPassManager, FermionStagedPassManager
+from qiskit_fermions.transpiler import FermionicPassManager, FermionicStagedPassManager
 from qiskit_fermions.transpiler.passes import (
     F2QSynthesis,
     InitializeModesSynthesis,
     TrivialF2QLayout,
 )
-from qiskit_fermions.transpiler.passmanager import FermionToQubitConverter
+from qiskit_fermions.transpiler.passmanager import FermionicToQubitConverter
 
 
 def test_initialize_modes_global_gate_synthesis():
@@ -37,9 +37,9 @@ def test_initialize_modes_global_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[InitializeModes] = InitializeModesSynthesis()
 
-    pm = FermionStagedPassManager()
-    pm.layout = FermionPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionToQubitConverter(synth)
+    pm = FermionicStagedPassManager()
+    pm.layout = FermionicPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionicToQubitConverter(synth)
 
     qu_circ = pm.run(circ)
 
@@ -60,9 +60,9 @@ def test_initialize_modes_local_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[InitializeModes] = InitializeModesSynthesis()
 
-    pm = FermionStagedPassManager()
-    pm.layout = FermionPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionToQubitConverter(synth)
+    pm = FermionicStagedPassManager()
+    pm.layout = FermionicPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionicToQubitConverter(synth)
 
     qu_circ = pm.run(circ)
 

--- a/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
+++ b/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
@@ -32,7 +32,7 @@ def test_initialize_modes_global_gate_synthesis():
     num_modes = len(occupation)
     circ = FermionicCircuit(num_modes)
     init = InitializeModes(occupation)
-    circ.append(init, circ.fermions)
+    circ.append(init, circ.modes)
 
     synth = F2QSynthesis()
     synth.plugins[InitializeModes] = InitializeModesSynthesis()
@@ -55,7 +55,7 @@ def test_initialize_modes_local_gate_synthesis():
     num_modes = 4
     circ = FermionicCircuit(num_modes)
     init = InitializeModes(occupation)
-    circ.append(init, circ.fermions[1:3])
+    circ.append(init, circ.modes[1:3])
 
     synth = F2QSynthesis()
     synth.plugins[InitializeModes] = InitializeModesSynthesis()

--- a/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
+++ b/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import OrbitalRotation
-from qiskit_fermions.transpiler import FermionPassManager, FermionStagedPassManager
+from qiskit_fermions.transpiler import FermionicPassManager, FermionicStagedPassManager
 from qiskit_fermions.transpiler.passes import (
     F2QSynthesis,
     OrbitalRotationSynthesis,
     TrivialF2QLayout,
 )
-from qiskit_fermions.transpiler.passmanager import FermionToQubitConverter
+from qiskit_fermions.transpiler.passmanager import FermionicToQubitConverter
 
 from ...utils import random_unitary
 
@@ -37,9 +37,9 @@ def test_orbital_rotation_global_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
 
-    pm = FermionStagedPassManager()
-    pm.layout = FermionPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionToQubitConverter(synth)
+    pm = FermionicStagedPassManager()
+    pm.layout = FermionicPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionicToQubitConverter(synth)
 
     qu_circ = pm.run(circ)
 
@@ -60,9 +60,9 @@ def test_initialize_modes_local_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
 
-    pm = FermionStagedPassManager()
-    pm.layout = FermionPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionToQubitConverter(synth)
+    pm = FermionicStagedPassManager()
+    pm.layout = FermionicPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionicToQubitConverter(synth)
 
     qu_circ = pm.run(circ)
 

--- a/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
+++ b/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import OrbitalRotation
 from qiskit_fermions.transpiler import FermionPassManager, FermionStagedPassManager
 from qiskit_fermions.transpiler.passes import (
@@ -30,7 +30,7 @@ from ...utils import random_unitary
 def test_orbital_rotation_global_gate_synthesis():
     num_modes = 6
     rotation_unitary = random_unitary(num_modes, seed=42)
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     rot = OrbitalRotation(rotation_unitary)
     circ.append(rot, circ.fermions)
 
@@ -51,7 +51,7 @@ def test_initialize_modes_local_gate_synthesis():
     num_modes = 6
     rotation_unitary_a = random_unitary(num_modes // 2, seed=42)
     rotation_unitary_b = random_unitary(num_modes // 2, seed=43)
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     rot_a = OrbitalRotation(rotation_unitary_a)
     circ.append(rot_a, circ.fermions[:3])
     rot_b = OrbitalRotation(rotation_unitary_b)

--- a/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
+++ b/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
@@ -28,9 +28,9 @@ from ...utils import random_unitary
 
 
 def test_orbital_rotation_global_gate_synthesis():
-    num_fermions = 6
-    rotation_unitary = random_unitary(num_fermions, seed=42)
-    circ = FermionCircuit(num_fermions)
+    num_modes = 6
+    rotation_unitary = random_unitary(num_modes, seed=42)
+    circ = FermionCircuit(num_modes)
     rot = OrbitalRotation(rotation_unitary)
     circ.append(rot, circ.fermions)
 
@@ -48,10 +48,10 @@ def test_orbital_rotation_global_gate_synthesis():
 
 
 def test_initialize_modes_local_gate_synthesis():
-    num_fermions = 6
-    rotation_unitary_a = random_unitary(num_fermions // 2, seed=42)
-    rotation_unitary_b = random_unitary(num_fermions // 2, seed=43)
-    circ = FermionCircuit(num_fermions)
+    num_modes = 6
+    rotation_unitary_a = random_unitary(num_modes // 2, seed=42)
+    rotation_unitary_b = random_unitary(num_modes // 2, seed=43)
+    circ = FermionCircuit(num_modes)
     rot_a = OrbitalRotation(rotation_unitary_a)
     circ.append(rot_a, circ.fermions[:3])
     rot_b = OrbitalRotation(rotation_unitary_b)

--- a/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
+++ b/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
@@ -32,7 +32,7 @@ def test_orbital_rotation_global_gate_synthesis():
     rotation_unitary = random_unitary(num_modes, seed=42)
     circ = FermionicCircuit(num_modes)
     rot = OrbitalRotation(rotation_unitary)
-    circ.append(rot, circ.fermions)
+    circ.append(rot, circ.modes)
 
     synth = F2QSynthesis()
     synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
@@ -53,9 +53,9 @@ def test_initialize_modes_local_gate_synthesis():
     rotation_unitary_b = random_unitary(num_modes // 2, seed=43)
     circ = FermionicCircuit(num_modes)
     rot_a = OrbitalRotation(rotation_unitary_a)
-    circ.append(rot_a, circ.fermions[:3])
+    circ.append(rot_a, circ.modes[:3])
     rot_b = OrbitalRotation(rotation_unitary_b)
-    circ.append(rot_b, circ.fermions[3:])
+    circ.append(rot_b, circ.modes[3:])
 
     synth = F2QSynthesis()
     synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()

--- a/tests/python/transpiler/passes/test_qdrift_optimization.py
+++ b/tests/python/transpiler/passes/test_qdrift_optimization.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.operators.grouping import group_terms_by_electronic_structure
@@ -32,7 +32,7 @@ def test_qdrift_optimization_no_groups(subtests):
     num_modes = 2 * fcidump.norb
     hamil = FermionOperator.from_fcidump(fcidump)
     time = 1.5
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
@@ -116,7 +116,7 @@ def test_qdrift_optimization_with_groups():
     hamil = FermionOperator.from_fcidump(fcidump)
     group_terms_by_electronic_structure(hamil, num_modes)
     time = 1.5
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 

--- a/tests/python/transpiler/passes/test_qdrift_optimization.py
+++ b/tests/python/transpiler/passes/test_qdrift_optimization.py
@@ -29,11 +29,11 @@ from qiskit_fermions.transpiler.passmanager import FermionPassManager
 def test_qdrift_optimization_no_groups(subtests):
     file_path = Path(__file__).parent / "../../../h2.fcidump"
     fcidump = FCIDump.from_file(str(file_path))
-    num_fermions = 2 * fcidump.norb
+    num_modes = 2 * fcidump.norb
     hamil = FermionOperator.from_fcidump(fcidump)
     time = 1.5
-    circ = FermionCircuit(num_fermions)
-    evo = Evolution(num_fermions, hamil, time=time)
+    circ = FermionCircuit(num_modes)
+    evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
     with subtests.test("num_terms=4"):
@@ -62,14 +62,14 @@ def test_qdrift_optimization_no_groups(subtests):
 
         expected_gates = [
             Evolution(
-                num_fermions,
+                num_modes,
                 FermionOperator.from_terms(
                     [(((True, 0), (True, 1), (False, 1), (False, 0)), 0.3322908651276483)]
                 ),
                 time=8.273087572037902,
             ),
             Evolution(
-                num_fermions,
+                num_modes,
                 FermionOperator.from_terms(
                     [(((True, 2), (True, 0), (False, 0), (False, 2)), 0.33785507740175824)]
                 ),
@@ -91,14 +91,14 @@ def test_qdrift_optimization_no_groups(subtests):
 
         expected_gates = [
             Evolution(
-                num_fermions,
+                num_modes,
                 FermionOperator.from_terms(
                     [(((True, 1), (True, 0), (False, 0), (False, 1)), 0.3322908651276483)]
                 ),
                 time=8.273087572037902,
             ),
             Evolution(
-                num_fermions,
+                num_modes,
                 FermionOperator.from_terms([((), 0.7199689944489797)]),
                 time=8.273087572037902,
             ),
@@ -112,12 +112,12 @@ def test_qdrift_optimization_no_groups(subtests):
 def test_qdrift_optimization_with_groups():
     file_path = Path(__file__).parent / "../../../h2.fcidump"
     fcidump = FCIDump.from_file(str(file_path))
-    num_fermions = 2 * fcidump.norb
+    num_modes = 2 * fcidump.norb
     hamil = FermionOperator.from_fcidump(fcidump)
-    group_terms_by_electronic_structure(hamil, num_fermions)
+    group_terms_by_electronic_structure(hamil, num_modes)
     time = 1.5
-    circ = FermionCircuit(num_fermions)
-    evo = Evolution(num_fermions, hamil, time=time)
+    circ = FermionCircuit(num_modes)
+    evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.fermions)
 
     num_terms = 2
@@ -129,7 +129,7 @@ def test_qdrift_optimization_with_groups():
 
     expected_gates = [
         Evolution(
-            num_fermions,
+            num_modes,
             FermionOperator.from_terms(
                 [
                     (((True, 1), (True, 2), (False, 3), (False, 0)), 0.09046559989211567),
@@ -139,7 +139,7 @@ def test_qdrift_optimization_with_groups():
             time=6.036695974299787,
         ),
         Evolution(
-            num_fermions,
+            num_modes,
             FermionOperator.from_terms([(((True, 1), (False, 1)), -0.4718960072811406)]),
             time=6.036695974299787,
         ),

--- a/tests/python/transpiler/passes/test_qdrift_optimization.py
+++ b/tests/python/transpiler/passes/test_qdrift_optimization.py
@@ -23,7 +23,7 @@ from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.operators.grouping import group_terms_by_electronic_structure
 from qiskit_fermions.operators.library import FCIDump
 from qiskit_fermions.transpiler.passes import QDriftTrotterization
-from qiskit_fermions.transpiler.passmanager import FermionPassManager
+from qiskit_fermions.transpiler.passmanager import FermionicPassManager
 
 
 def test_qdrift_optimization_no_groups(subtests):
@@ -39,7 +39,7 @@ def test_qdrift_optimization_no_groups(subtests):
     with subtests.test("num_terms=4"):
         num_terms = 4
         qdrift = QDriftTrotterization(num_terms)
-        pm = FermionPassManager(qdrift)
+        pm = FermionicPassManager(qdrift)
 
         qdrift_circ = pm.run(circ)
         assert qdrift_circ.count_ops() == {"Evolution": num_terms}
@@ -47,7 +47,7 @@ def test_qdrift_optimization_no_groups(subtests):
     with subtests.test("num_terms=6"):
         num_terms = 6
         qdrift = QDriftTrotterization(num_terms)
-        pm = FermionPassManager(qdrift)
+        pm = FermionicPassManager(qdrift)
 
         qdrift_circ = pm.run(circ)
         assert qdrift_circ.count_ops() == {"Evolution": num_terms}
@@ -55,7 +55,7 @@ def test_qdrift_optimization_no_groups(subtests):
     with subtests.test("rng seed"):
         num_terms = 2
         qdrift = QDriftTrotterization(num_terms, rng=42)
-        pm = FermionPassManager(qdrift)
+        pm = FermionicPassManager(qdrift)
 
         qdrift_circ = pm.run(circ)
         assert qdrift_circ.count_ops() == {"Evolution": num_terms}
@@ -84,7 +84,7 @@ def test_qdrift_optimization_no_groups(subtests):
     with subtests.test("rng seed"):
         num_terms = 2
         qdrift = QDriftTrotterization(num_terms, rng=np.random.default_rng(43))
-        pm = FermionPassManager(qdrift)
+        pm = FermionicPassManager(qdrift)
 
         qdrift_circ = pm.run(circ)
         assert qdrift_circ.count_ops() == {"Evolution": num_terms}
@@ -122,7 +122,7 @@ def test_qdrift_optimization_with_groups():
 
     num_terms = 2
     qdrift = QDriftTrotterization(num_terms, rng=42)
-    pm = FermionPassManager(qdrift)
+    pm = FermionicPassManager(qdrift)
 
     qdrift_circ = pm.run(circ)
     assert qdrift_circ.count_ops() == {"Evolution": num_terms}

--- a/tests/python/transpiler/passes/test_qdrift_optimization.py
+++ b/tests/python/transpiler/passes/test_qdrift_optimization.py
@@ -34,7 +34,7 @@ def test_qdrift_optimization_no_groups(subtests):
     time = 1.5
     circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
-    circ.append(evo, circ.fermions)
+    circ.append(evo, circ.modes)
 
     with subtests.test("num_terms=4"):
         num_terms = 4
@@ -118,7 +118,7 @@ def test_qdrift_optimization_with_groups():
     time = 1.5
     circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)
-    circ.append(evo, circ.fermions)
+    circ.append(evo, circ.modes)
 
     num_terms = 2
     qdrift = QDriftTrotterization(num_terms, rng=42)

--- a/tests/python/transpiler/presets/test_jordan_wigner.py
+++ b/tests/python/transpiler/presets/test_jordan_wigner.py
@@ -35,19 +35,19 @@ def test_preset_jordan_wigner():
         }
     )
     time = 1.5
-    num_fermions = 4
-    evo = Evolution(num_fermions, hamil, time=time)
+    num_modes = 4
+    evo = Evolution(num_modes, hamil, time=time)
 
     init = InitializeModes([True, False, True, False])
 
-    rot_mat = np.zeros((num_fermions, num_fermions), dtype=complex)
+    rot_mat = np.zeros((num_modes, num_modes), dtype=complex)
     rot_mat[0, 1] = 1
     rot_mat[1, 0] = 1
     rot_mat[2, 3] = 1
     rot_mat[3, 2] = 1
     orb_rot = OrbitalRotation(rot_mat)
 
-    circ = FermionCircuit(num_fermions)
+    circ = FermionCircuit(num_modes)
     circ.append(init, circ.fermions)
     circ.append(orb_rot, circ.fermions)
     circ.append(evo, circ.fermions)
@@ -56,14 +56,14 @@ def test_preset_jordan_wigner():
 
     qu_circ = pm.run(circ)
 
-    expected = QuantumCircuit(num_fermions)
+    expected = QuantumCircuit(num_modes)
     expected.x((0, 2))
     expected.append(XXPlusYYGate(np.pi, -np.pi / 2), (0, 1))
     expected.append(XXPlusYYGate(np.pi, -np.pi / 2), (2, 3))
     expected.p(np.pi, 0)
     expected.p(np.pi, 2)
     expected.append(
-        PauliEvolutionGate(jordan_wigner(hamil, num_qubits=num_fermions).simplify(), time=time),
+        PauliEvolutionGate(jordan_wigner(hamil, num_qubits=num_modes).simplify(), time=time),
         expected.qubits,
     )
 

--- a/tests/python/transpiler/presets/test_jordan_wigner.py
+++ b/tests/python/transpiler/presets/test_jordan_wigner.py
@@ -48,9 +48,9 @@ def test_preset_jordan_wigner():
     orb_rot = OrbitalRotation(rot_mat)
 
     circ = FermionicCircuit(num_modes)
-    circ.append(init, circ.fermions)
-    circ.append(orb_rot, circ.fermions)
-    circ.append(evo, circ.fermions)
+    circ.append(init, circ.modes)
+    circ.append(orb_rot, circ.modes)
+    circ.append(evo, circ.modes)
 
     pm = generate_preset_jw_pass_manager()
 

--- a/tests/python/transpiler/presets/test_jordan_wigner.py
+++ b/tests/python/transpiler/presets/test_jordan_wigner.py
@@ -18,7 +18,7 @@ import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import PauliEvolutionGate, XXPlusYYGate
 from qiskit.quantum_info import Statevector
-from qiskit_fermions.circuit import FermionCircuit
+from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
 from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
@@ -47,7 +47,7 @@ def test_preset_jordan_wigner():
     rot_mat[3, 2] = 1
     orb_rot = OrbitalRotation(rot_mat)
 
-    circ = FermionCircuit(num_modes)
+    circ = FermionicCircuit(num_modes)
     circ.append(init, circ.fermions)
     circ.append(orb_rot, circ.fermions)
     circ.append(evo, circ.fermions)


### PR DESCRIPTION
Updates for #96. Seemed like an easy way to help out,  changed names of `Fermion` types to `Mode` where appropriate.

# Changed

`Fermion`,`FermionRegister`, `FermionSpecifier`, `num_fermions` `fermion_register`, `fermion_indices`


# Unchanged
`FermionCircuit` and `FermionGate` - (could be `GrassmanCircuit` if you want it to be more general) but changing to `ModeCircuit` might be confusing with some possible future bosonic circuit or when it comes to algorithms involving bosonisation.

`FermionOperator`, `FermionAction` - Independent of mode

`FermionPassManager`, `FermionStagedPassManager`, `FermionToQubitConverter`, - Derive from naming of `FermionCircuit`