### PR TITLE
`RelabelModes` optimization pass

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -14,11 +14,12 @@ from doctest import ELLIPSIS, NORMALIZE_WHITESPACE
 
 from sybil import Sybil
 from sybil.evaluators.doctest import NUMBER
-from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import DocTestParser, SkipParser
 
 pytest_collect_file = Sybil(
     parsers=[
         DocTestParser(optionflags=ELLIPSIS | NORMALIZE_WHITESPACE | NUMBER),
+        SkipParser(),
     ],
     patterns=["*.rst"],
 ).pytest()

--- a/docs/tutorials/sqdrift.rst
+++ b/docs/tutorials/sqdrift.rst
@@ -159,6 +159,51 @@ ensemble of circuits to generate:
    generator used inside of the :class:`.QDriftTrotterization` transpilation
    pass.
 
+(Optional) Optimize the fermionic mode indexing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+One can add an additional optimization step to the transpilation pipeline which
+minimizes the distance of the fermionic excitation spans by relabeling the
+fermionic mode indices. This optimization was introduced in the `SqDRIFT`_ paper
+and is implemented by :func:`.build_excitation_span_minimization_model`. It can
+be easily inserted into the transpiler pipeline via the :class:`.RelabelModes`
+pass:
+
+.. invisible-code-block: python
+
+   >>> from qiskit_fermions.utils.optionals import HAS_PYOMO
+
+.. skip: start if(not HAS_PYOMO)
+
+.. tab-set-code::
+
+    .. code-block:: python
+
+       >>> from pyomo.environ import SolverFactory
+       >>> from qiskit_fermions.transpiler.passes import RelabelModes
+       >>>
+       >>> solver = SolverFactory("appsi_highs")
+       >>> solver.options["time_limit"] = 60
+       >>>
+       >>> qdrift = QDriftTrotterization(5, rng=42)
+       >>> relabel = RelabelModes(solver=solver)
+       >>>
+       >>> pm.optimization = FermionicPassManager([qdrift, relabel])
+       >>>
+       >>> relabeled_circ = pm.run(circ)
+       >>> assert "permutation" in relabeled_circ.metadata
+
+    .. code-block:: c
+
+       // WARNING: This feature is not available via the C API.
+
+.. skip: end
+
+.. note::
+   Using the automatic optimization inside :class:`.RelabelModes` (which
+   leverages :func:`.build_excitation_span_minimization_model`) requires the
+   optional dependency managed by :data:`.HAS_PYOMO`.
+
 Next steps
 ^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ doctest = [
 test = [
     {include-group = "basetest"},
     {include-group = "doctest"},
+    "highspy>=1.7.1",
 ]
 coverage = [
     {include-group = "test"},

--- a/python/qiskit_fermions/circuit/fermionic_circuit.py
+++ b/python/qiskit_fermions/circuit/fermionic_circuit.py
@@ -47,6 +47,15 @@ class FermionicCircuit:
         self._inner = QuantumCircuit(self.register)
 
     @property
+    def metadata(self) -> dict:
+        """Re-exposes :external:attr:`~qiskit.circuit.QuantumCircuit.metadata`."""
+        return cast(dict, self._inner.metadata)
+
+    @metadata.setter
+    def metadata(self, metadata: dict) -> None:
+        self._inner.metadata = metadata
+
+    @property
     def modes(self) -> list[FermionicMode]:
         """The fermionic mode ``bits`` that this circuit acts upon."""
         return cast(list[FermionicMode], self._inner.qubits)

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -32,6 +32,7 @@ These passes provide different kinds of optimization of :class:`.FermionicCircui
    :toctree: ../stubs/
 
    QDriftTrotterization
+   RelabelModes
 
 .. _qiskit_fermions-transpiler-passes-layout:
 
@@ -88,7 +89,7 @@ provides builtin plugins:
 """
 
 from .layout import CustomF2QLayout, TrivialF2QLayout
-from .optimization import QDriftTrotterization
+from .optimization import QDriftTrotterization, RelabelModes
 from .synthesis import (
     EvolutionSynthesis,
     F2QSynthesis,
@@ -105,5 +106,6 @@ __all__ = [
     "InitializeModesSynthesis",
     "OrbitalRotationSynthesis",
     "QDriftTrotterization",
+    "RelabelModes",
     "TrivialF2QLayout",
 ]

--- a/python/qiskit_fermions/transpiler/passes/optimization/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/__init__.py
@@ -13,7 +13,9 @@
 """Optimization passes."""
 
 from .qdrift import QDriftTrotterization
+from .relabel_modes import RelabelModes
 
 __all__ = [
     "QDriftTrotterization",
+    "RelabelModes",
 ]

--- a/python/qiskit_fermions/transpiler/passes/optimization/relabel_modes.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/relabel_modes.py
@@ -1,0 +1,226 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""An optimization pass to relabel fermionic modes."""
+
+from __future__ import annotations
+
+import warnings
+from collections import deque
+from collections.abc import Generator, Iterable
+from itertools import islice
+from typing import TYPE_CHECKING, Any
+
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.transpiler import TransformationPass
+
+from qiskit_fermions._lib.operators.fermion_operator import FermionOperator
+from qiskit_fermions.circuit.library import Evolution
+from qiskit_fermions.mappers.optimization import build_excitation_span_minimization_model
+from qiskit_fermions.utils.optionals import HAS_PYOMO
+
+if TYPE_CHECKING:
+    import pyomo
+
+
+def _sliding_window(iterable: Iterable[Any], n: int) -> Generator[tuple[Any, ...], None, None]:
+    """Collect data into overlapping fixed-length chunks or blocks.
+
+    Adapted from https://docs.python.org/3/library/itertools.html#itertools-recipes
+
+    Example: sliding_window('ABCDEFG', 3) → ABC BCD CDE DEF EFG
+    """
+    iterator = iter(iterable)
+    window = deque(islice(iterator, n - 1), maxlen=n)
+    for x in iterator:
+        window.append(x)
+        yield tuple(window)
+
+
+class RelabelModes(TransformationPass):
+    """A transpilation pass to relabel the fermionic modes.
+
+    .. caution::
+       This transpiler pass is known to have the following limitations:
+
+       - handling of gates other than :class:`.Evolution` is currently not implemented
+       - handling of gates acting on a local subset of fermionic modes is not implemented
+    """
+
+    def __init__(
+        self,
+        permutation: list[int] | None = None,
+        *,
+        solver: pyomo.opt.SolverFactory | None = None,
+        **kwargs,
+    ) -> None:
+        """Initializes the transpiler pass.
+
+        Args:
+            permutation: the index permutation used to relabel the fermionic mode indices. When this
+                is ``None``, a permutation will be determined automatically based on
+                :func:`.build_excitation_span_minimization_model`. See also :attr:`.permutation` for
+                more details.
+            solver: the optimization problem solver instance used to solve the
+                :func:`.build_excitation_span_minimization_model` problem. When this is ``None``, no
+                ``permutation`` can be determined automatically. See also :attr:`.solver` for more
+                details.
+            kwargs: any additional keyword arguments will be forward to
+                :func:`.build_excitation_span_minimization_model`.
+        """
+        super().__init__()
+
+        self.permutation = permutation
+        """The index permutation used to relabel the fermionic mode indices.
+
+        This may either be a ``list[int]`` in which case its length has to match the number of
+        fermionic modes of the circuit being transpiled. This scenario therefore requires the
+        transpiler pass to be tailored quite specifically to the user's circuit.
+
+        Being a permutation, each index in this list has to appear exactly once.
+
+        Or it may be ``None``, in which case the :func:`.build_excitation_span_minimization_model`
+        function is used to define an optimization problem which tries to minimize the span of all
+        occurring fermionic excitations.
+
+        .. note::
+           The use of this optimization model is only implemented for time-evolution gates
+           containing a :class:`.FermionOperator` instance.
+        """
+
+        self.solver = solver
+        """The optimization problem solver instance to automatically find :attr:`.permutation`.
+
+        When :attr:`.permutation` is ``None``, the optimization problem defined by
+        :func:`.build_excitation_span_minimization_model` is used to automatically find a good
+        permutation of mode indices. In such a case, the user must provide an optimizer to solve
+        this model.
+        """
+
+        self._model_kwargs = kwargs
+
+    def find_permutation(
+        self, dag: DAGCircuit
+    ) -> tuple[list[int] | None, pyomo.opt.results.results_.SolverResults | None]:
+        """Finds a mode index :attr:`.permutation` when not specified by the user.
+
+        This function only gets called when :attr:`.permutation` is not specified by the user (i.e.
+        it is ``None``). When that is the case, it does the following:
+
+        1. ensure that the optional `pyomo <https://pypi.org/project/pyomo/>`_ dependency is
+           installed. Otherwise, no optimization can be performed and this transpiler pass has no
+           effect.
+        2. ensure that a :attr:`.solver` is specified. Otherwise, no optimization can be performed
+           and this transpiler pass has no effect.
+        3. gather all the fermionic excitations from any :class:`.Evolution` gates containing a
+           :class:`.FermionOperator` instance.
+        4. build the optimization problem using :func:`.build_excitation_span_minimization_model`,
+           forwarding any additional keyword arguments (``kwargs``) from when this transpiler pass
+           was constructed.
+        5. solve the optimization problem using :attr:`.solver` and extract the final permutation.
+
+        Args:
+            dag: the circuit to be transpiled.
+
+        Returns:
+            The permutation to use. When ``None``, this transpiler pass will have no effect.
+
+        Raises:
+            NotImplementedError: when encountering an :class:`.Evolution` gate containing an
+                operator that is not a :class:`.FermionOperator` instance.
+        """
+        if not HAS_PYOMO:
+            warnings.warn(
+                "Finding the optimal mode index permutation requires the optional 'pyomo' "
+                "dependency to be installed.",
+                category=UserWarning,
+                stacklevel=1,
+            )
+            return (None, None)
+
+        if self.solver is None:
+            warnings.warn(
+                "Finding the optimal mode index permutation requires the `RelabelModes.solver` "
+                "attribute to be defined.",
+                category=UserWarning,
+                stacklevel=1,
+            )
+            return (None, None)
+
+        gathered_excitations: list[tuple[int, ...]] = []
+        for node in dag.op_nodes():
+            if not isinstance(node.op, Evolution):
+                continue
+
+            hamil = node.op.operator
+            if not isinstance(hamil, FermionOperator):
+                raise NotImplementedError(
+                    "The optimization model defined by build_excitation_span_minimization_model "
+                    "assumes fermionic mode excitations defined in terms of `FermionOperator` "
+                    "instances. Handling time-evolution gates of operators of type {} is not "
+                    "implemented.",
+                    type(hamil),
+                )
+
+            modes = hamil.get_modes()
+            boundaries = hamil.get_boundaries()
+            for start, stop in _sliding_window(boundaries, 2):
+                gathered_excitations.append(tuple(modes[start:stop]))
+
+        num_modes = dag.num_qubits()
+        model = build_excitation_span_minimization_model(
+            gathered_excitations, num_modes, **self._model_kwargs
+        )
+
+        result = self.solver.solve(model)
+
+        from pyomo.environ import value
+
+        permutation = [round(value(model.y[i])) for i in range(num_modes)]
+        return permutation, result
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Runs this transpilation pass.
+
+        Args:
+            dag: the input circuit with fermion-based instructions. Only
+                :class:`~qiskit.dagcircuit.DAGOpNode` with :class:`.FermionicGate` instances as their
+                :attr:`~qiskit.dagcircuit.DAGOpNode.op` are supported.
+
+        Returns:
+            The output circuit which is still acting on a fermionic register.
+        """
+        permutation, opt_result = (
+            self.find_permutation(dag) if self.permutation is None else (self.permutation, None)
+        )
+
+        if permutation is None:
+            return dag
+
+        out_dag = dag.copy_empty_like()
+        out_dag.metadata["permutation"] = permutation.copy()
+        if opt_result is not None:
+            out_dag.metadata["permutation.opt_result"] = opt_result
+
+        for node in dag.op_nodes():
+            if not isinstance(node.op, Evolution):
+                continue
+
+            hamil = node.op.operator
+            time = node.op.params[0]
+            num_modes = len(node.qargs)
+
+            relabeled = hamil.relabel_modes(permutation)
+            evo = Evolution(num_modes, relabeled, time=time)
+            out_dag.apply_operation_back(evo, qargs=out_dag.qubits)
+
+        return out_dag

--- a/python/qiskit_fermions/transpiler/passes/optimization/relabel_modes.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/relabel_modes.py
@@ -1,0 +1,219 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""An optimization pass to relabel fermionic modes."""
+
+from __future__ import annotations
+
+import warnings
+from collections import deque
+from collections.abc import Generator, Iterable
+from itertools import islice
+from typing import TYPE_CHECKING, Any
+
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.transpiler import TransformationPass
+
+from qiskit_fermions._lib.operators.fermion_operator import FermionOperator
+from qiskit_fermions.circuit.library import Evolution
+from qiskit_fermions.mappers.optimization import build_excitation_span_minimization_model
+from qiskit_fermions.utils.optionals import HAS_PYOMO
+
+if TYPE_CHECKING:
+    import pyomo
+
+
+def _sliding_window(iterable: Iterable[Any], n: int) -> Generator[tuple[Any, ...], None, None]:
+    """Collect data into overlapping fixed-length chunks or blocks.
+
+    Adapted from https://docs.python.org/3/library/itertools.html#itertools-recipes
+
+    Example: sliding_window('ABCDEFG', 3) → ABC BCD CDE DEF EFG
+    """
+    iterator = iter(iterable)
+    window = deque(islice(iterator, n - 1), maxlen=n)
+    for x in iterator:
+        window.append(x)
+        yield tuple(window)
+
+
+class RelabelModes(TransformationPass):
+    """A transpilation pass to relabel the fermionic modes."""
+
+    def __init__(
+        self,
+        permutation: list[int] | None = None,
+        *,
+        solver: pyomo.opt.SolverFactory | None = None,
+        **kwargs,
+    ) -> None:
+        """Initializes the transpiler pass.
+
+        Args:
+            permutation: the index permutation used to relabel the fermionic mode indices. When this
+                is ``None``, a permutation will be determined automatically based on
+                :func:`.build_excitation_span_minimization_model`. See also :attr:`.permutation` for
+                more details.
+            solver: the optimization problem solver instance used to solve the
+                :func:`.build_excitation_span_minimization_model` problem. When this is ``None``, no
+                ``permutation`` can be determined automatically. See also :attr:`.solver` for more
+                details.
+            kwargs: any additional keyword arguments will be forward to
+                :func:`.build_excitation_span_minimization_model`.
+        """
+        super().__init__()
+
+        self.permutation = permutation
+        """The index permutation used to relabel the fermionic mode indices.
+
+        This may either be a ``list[int]`` in which case its length has to match the number of
+        fermionic modes of the circuit being transpiled. This scenario therefore requires the
+        transpiler pass to be tailored quite specifically to the user's circuit.
+
+        Being a permutation, each index in this list has to appear exactly once.
+
+        Or it may be ``None``, in which case the :func:`.build_excitation_span_minimization_model`
+        function is used to define an optimization problem which tries to minimize the span of all
+        occurring fermionic excitations.
+
+        .. note::
+           The use of this optimization model is only implemented for time-evolution gates
+           containing a :class:`.FermionOperator` instance.
+        """
+
+        self.solver = solver
+        """The optimization problem solver instance to automatically find :attr:`.permutation`.
+
+        When :attr:`.permutation` is ``None``, the optimization problem defined by
+        :func:`.build_excitation_span_minimization_model` is used to automatically find a good
+        permutation of mode indices. In such a case, the user must provide an optimizer to solve
+        this model.
+        """
+
+        self._model_kwargs = kwargs
+
+    def find_permutation(
+        self, dag: DAGCircuit
+    ) -> tuple[list[int] | None, pyomo.opt.results.results_.SolverResults | None]:
+        """Finds a mode index :attr:`.permutation` when not specified by the user.
+
+        This function only gets called when :attr:`.permutation` is not specified by the user (i.e.
+        it is ``None``). When that is the case, it does the following:
+
+        1. ensure that the optional `pyomo <https://pypi.org/project/pyomo/>`_ dependency is
+           installed. Otherwise, no optimization can be performed and this transpiler pass has no
+           effect.
+        2. ensure that a :attr:`.solver` is specified. Otherwise, no optimization can be performed
+           and this transpiler pass has no effect.
+        3. gather all the fermionic excitations from any :class:`.Evolution` gates containing a
+           :class:`.FermionOperator` instance.
+        4. build the optimization problem using :func:`.build_excitation_span_minimization_model`,
+           forwarding any additional keyword arguments (``kwargs``) from when this transpiler pass
+           was constructed.
+        5. solve the optimization problem using :attr:`.solver` and extract the final permutation.
+
+        Args:
+            dag: the circuit to be transpiled.
+
+        Returns:
+            The permutation to use. When ``None``, this transpiler pass will have no effect.
+
+        Raises:
+            NotImplementedError: when encountering an :class:`.Evolution` gate containing an
+                operator that is not a :class:`.FermionOperator` instance.
+        """
+        if not HAS_PYOMO:
+            warnings.warn(
+                "Finding the optimal mode index permutation requires the optional 'pyomo' "
+                "dependency to be installed.",
+                category=UserWarning,
+                stacklevel=1,
+            )
+            return (None, None)
+
+        if self.solver is None:
+            warnings.warn(
+                "Finding the optimal mode index permutation requires the `RelabelModes.solver` "
+                "attribute to be defined.",
+                category=UserWarning,
+                stacklevel=1,
+            )
+            return (None, None)
+
+        gathered_excitations: list[tuple[int, ...]] = []
+        for node in dag.op_nodes():
+            if not isinstance(node.op, Evolution):
+                continue
+
+            hamil = node.op.operator
+            if not isinstance(hamil, FermionOperator):
+                raise NotImplementedError(
+                    "The optimization model defined by build_excitation_span_minimization_model "
+                    "assumes fermionic mode excitations defined in terms of `FermionOperator` "
+                    "instances. Handling time-evolution gates of operators of type {} is not "
+                    "implemented.",
+                    type(hamil),
+                )
+
+            modes = hamil.get_modes()
+            boundaries = hamil.get_boundaries()
+            for start, stop in _sliding_window(boundaries, 2):
+                gathered_excitations.append(tuple(modes[start:stop]))
+
+        num_modes = dag.num_qubits()
+        model = build_excitation_span_minimization_model(
+            gathered_excitations, num_modes, **self._model_kwargs
+        )
+
+        result = self.solver.solve(model)
+
+        from pyomo.environ import value
+
+        permutation = [round(value(model.y[i])) for i in range(num_modes)]
+        return permutation, result
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        """Runs this transpilation pass.
+
+        Args:
+            dag: the input circuit with fermion-based instructions. Only
+                :class:`~qiskit.dagcircuit.DAGOpNode` with :class:`.FermionicGate` instances as their
+                :attr:`~qiskit.dagcircuit.DAGOpNode.op` are supported.
+
+        Returns:
+            The output circuit which is still acting on a fermionic register.
+        """
+        permutation, opt_result = (
+            self.find_permutation(dag) if self.permutation is None else (self.permutation, None)
+        )
+
+        if permutation is None:
+            return dag
+
+        out_dag = dag.copy_empty_like()
+        out_dag.metadata["permutation"] = permutation.copy()
+        if opt_result is not None:
+            out_dag.metadata["permutation.opt_result"] = opt_result
+
+        for node in dag.op_nodes():
+            if not isinstance(node.op, Evolution):
+                continue
+
+            hamil = node.op.operator
+            time = node.op.params[0]
+            num_modes = len(node.qargs)
+
+            relabeled = hamil.relabel_modes(permutation)
+            evo = Evolution(num_modes, relabeled, time=time)
+            out_dag.apply_operation_back(evo, qargs=out_dag.qubits)
+
+        return out_dag

--- a/tests/python/transpiler/passes/test_relabel_modes.py
+++ b/tests/python/transpiler/passes/test_relabel_modes.py
@@ -1,0 +1,111 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Mode relabeling optimization tests."""
+
+from __future__ import annotations
+
+import pytest
+from qiskit.circuit.library import PauliEvolutionGate
+from qiskit_fermions.circuit import FermionicCircuit
+from qiskit_fermions.circuit.library import Evolution
+from qiskit_fermions.mappers.library import jordan_wigner
+from qiskit_fermions.operators import FermionOperator
+from qiskit_fermions.transpiler.passes import (
+    EvolutionSynthesis,
+    F2QSynthesis,
+    RelabelModes,
+    TrivialF2QLayout,
+)
+from qiskit_fermions.transpiler.passmanager import (
+    FermionicPassManager,
+    FermionicStagedPassManager,
+    FermionicToQubitConverter,
+)
+from qiskit_fermions.utils.optionals import HAS_PYOMO
+
+if HAS_PYOMO:
+    from pyomo.environ import SolverFactory
+
+
+def test_relabel_modes_fixed_permutation():
+    hamil = FermionOperator.from_dict(
+        {
+            ((True, 0), (False, 2)): 2.0,
+            ((True, 2), (False, 0)): 2.0,
+            ((True, 1), (False, 3)): -2.0,
+            ((True, 3), (False, 1)): -2.0,
+        }
+    )
+    time = 1.5
+    num_modes = 4
+    circ = FermionicCircuit(num_modes)
+    evo = Evolution(num_modes, hamil, time=time)
+    circ.append(evo, circ.modes)
+
+    synth = F2QSynthesis()
+    synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
+
+    permutation = [0, 2, 1, 3]
+    relabel = RelabelModes(permutation)
+
+    pm = FermionicStagedPassManager()
+    pm.optimization = FermionicPassManager(relabel)
+    pm.layout = FermionicPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionicToQubitConverter(synth)
+
+    qu_circ = pm.run(circ)
+
+    gates = qu_circ.data
+    assert len(gates) == 1
+    assert isinstance(gates[0].operation, PauliEvolutionGate)
+
+    qu_circ_decomp = qu_circ.decompose(reps=2)
+    assert qu_circ_decomp.depth(lambda instr: len(instr.qubits) == 2) == 4
+
+
+@pytest.mark.skipif(not HAS_PYOMO, reason="Pyomo is required")
+def test_relabel_modes_pyomo_optimization():
+    hamil = FermionOperator.from_dict(
+        {
+            ((True, 0), (False, 2)): 2.0,
+            ((True, 2), (False, 0)): 2.0,
+            ((True, 1), (False, 3)): -2.0,
+            ((True, 3), (False, 1)): -2.0,
+        }
+    )
+    time = 1.5
+    num_modes = 4
+    circ = FermionicCircuit(num_modes)
+    evo = Evolution(num_modes, hamil, time=time)
+    circ.append(evo, circ.modes)
+
+    synth = F2QSynthesis()
+    synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
+
+    solver = SolverFactory("appsi_highs")
+    solver.options["time_limit"] = 60
+    relabel = RelabelModes(solver=solver)
+
+    pm = FermionicStagedPassManager()
+    pm.optimization = FermionicPassManager(relabel)
+    pm.layout = FermionicPassManager(TrivialF2QLayout())
+    pm.synthesis = FermionicToQubitConverter(synth)
+
+    qu_circ = pm.run(circ)
+
+    gates = qu_circ.data
+    assert len(gates) == 1
+    assert isinstance(gates[0].operation, PauliEvolutionGate)
+
+    qu_circ_decomp = qu_circ.decompose(reps=2)
+    assert qu_circ_decomp.depth(lambda instr: len(instr.qubits) == 2) == 4


### PR DESCRIPTION
This adds a new transpiler pass for the `optimization` stage of the `FermionicStagedPassManager` which can be used to relabel the fermionic mode indices. This builds on top of #29, allowing the optimization of the fermion-to-qubit routing to be automatized as part of the transpiler pipeline.

This closes #6 as finally complete.

----

Open tasks:
- [x] add a unittest
- [ ] ~handle index relabeling on gates other than `Evolution` (where applicable)~ postponed for the time being (see #104)
- [x] rebase on `main` after merging #29 