### PR TITLE
test: remove unnecessary subclass pattern

### DIFF
--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -10,18 +10,16 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from abc import ABC, abstractmethod
-
 import numpy as np
 import pytest
 from qiskit_fermions.operators import FermionOperator, ann, cre
 from qiskit_fermions.operators.library import anti_commutator, commutator
 
 
-class FermionOperatorTests(ABC):
+class TestFermionOperator:
     @staticmethod
-    @abstractmethod
-    def get_class() -> type[FermionOperator]: ...
+    def get_class() -> type[FermionOperator]:
+        return FermionOperator
 
     def test_getters(self, subtests):
         cls = self.get_class()
@@ -424,9 +422,3 @@ class FermionOperatorTests(ABC):
             {(cre(0), ann(1)): 1, (cre(1), ann(0)): 1, (cre(0), cre(0), ann(1), ann(1)): 2}
         )
         assert op.split_out_groups() is None
-
-
-class TestFermionOperator(FermionOperatorTests):
-    @staticmethod
-    def get_class() -> type[FermionOperator]:
-        return FermionOperator

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -10,18 +10,16 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from abc import ABC, abstractmethod
-
 import numpy as np
 import pytest
 from qiskit_fermions.operators import MajoranaOperator, gamma
 from qiskit_fermions.operators.library import anti_commutator, commutator
 
 
-class MajoranaOperatorTests(ABC):
+class TestMajoranaOperator:
     @staticmethod
-    @abstractmethod
-    def get_class() -> type[MajoranaOperator]: ...
+    def get_class() -> type[MajoranaOperator]:
+        return MajoranaOperator
 
     def test_getters(self, subtests):
         cls = self.get_class()
@@ -396,9 +394,3 @@ class MajoranaOperatorTests(ABC):
 
         op = cls.from_dict({(0, 1): 1, (1, 0): 1, (0, 0, 1, 1): 2})
         assert op.split_out_groups() is None
-
-
-class TestMajoranaOperator(MajoranaOperatorTests):
-    @staticmethod
-    def get_class() -> type[MajoranaOperator]:
-        return MajoranaOperator


### PR DESCRIPTION
In the past, we had Rust- and Python-based implementations of the same operator data structures. Our unittest suite was designed to enforce a matching API for both implementations. We no longer have this dual implementation, rendering the class design in the unittest suite unnecessary and confusing. Thus, this commit removes this outdated design pattern.