### PR TITLE
fix: formatting of doctest

### DIFF
--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -967,6 +967,7 @@ impl PyFermionOperator {
     /// Returns a new operator with relabeled modes.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import FermionOperator
     ///     >>> op = FermionOperator.from_dict({
     ///     ...     ((True, 0), (False, 1)): 1,

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -908,6 +908,7 @@ impl PyMajoranaOperator {
     /// Returns a new operator with relabeled modes.
     ///
     /// .. doctest::
+    ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({
     ///     ...     (0, 1): 1,


### PR DESCRIPTION
Without these new lines, the doctest output did not get rendered correctly in the Sphinx docs.