### PR TITLE
ci: generate pystubs before running Python testsuite

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Python tests
         shell: bash
         run: |
-          make testpython
+          make pystubs testpython
 
       - name: Optional tests
         shell: bash

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -117,7 +117,7 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         shell: bash
         run: |
-          make testpython
+          make pystubs testpython
 
       - name: Optional tests
         if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Python tests
         shell: bash
         run: |
-          make testpython
+          make pystubs testpython
 
       - name: Optional tests
         shell: bash


### PR DESCRIPTION
Without the pystubs being generated, not all code examples from the docstrings can be picked up correctly. This commit ensures this happens before the Python test suite gets run.