### PR TITLE
fix: correctly compute mean of absolute coeffs during qDrift

### DIFF
--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -68,7 +68,7 @@ class QDriftTrotterization(TransformationPass):
                 weights = np.zeros(
                     (max_group_idx + 1),
                 )
-                weights[groups] += np.abs(all_coeffs)
+                np.add.at(weights, groups, np.abs(all_coeffs))
                 weights /= np.unique(groups, return_counts=True)[1]
             else:
                 terms = list(hamil.iter_terms())


### PR DESCRIPTION
It was pointed out that the in-place addition with clever numpy indexing was not implementing the correct mathematical operation. Instead of accumulating the values with duplicate indices, the last write operation would win, resulting in a wrong mean. Using `np.add.at` resolves this problem.

Closes #140