### PR TITLE
Rename `many_body_order` to `max_rank`

### DIFF
--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -1042,16 +1042,17 @@ pub unsafe extern "C" fn qf_ferm_op_is_hermitian(op: *const FermionOperator, ato
 
 /// @ingroup qf_ferm_op
 ///
-/// @brief Checks the many-body order of an operator.
+/// @brief Checks the maximum rank of an operator.
 ///
 /// @param op A pointer to the fermionic operator to be checked.
 ///
-/// @return The many-body order of the operator.
+/// @return The maximum rank of the operator.
 ///
 /// @rst
 ///
 /// .. note::
-///    The many-body order is defined as the length of the longest term contained in the operator.
+///    The length of the longest term can depend on the operator's form which means that (for
+///    example) operator simplification or normal-ordering can result in a different maximum rank.
 ///
 /// Example
 /// -------
@@ -1065,15 +1066,15 @@ pub unsafe extern "C" fn qf_ferm_op_is_hermitian(op: *const FermionOperator, ato
 ///     QkComplex64 coeff = {1.0, 0.0};
 ///     qf_ferm_op_add_term(op, 4, actions, modes, &coeff);
 ///
-///     assert(qf_ferm_op_many_body_order(op, 4));
+///     assert(qf_ferm_op_max_rank(op, 4));
 ///
 /// @endrst
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qf_ferm_op_many_body_order(op: *const FermionOperator) -> u32 {
+pub unsafe extern "C" fn qf_ferm_op_max_rank(op: *const FermionOperator) -> u32 {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let op = unsafe { const_ptr_as_ref(op) };
 
-    op.many_body_order()
+    op.max_rank()
 }
 
 /// @ingroup qf_ferm_op

--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -1066,7 +1066,7 @@ pub unsafe extern "C" fn qf_ferm_op_is_hermitian(op: *const FermionOperator, ato
 ///     QkComplex64 coeff = {1.0, 0.0};
 ///     qf_ferm_op_add_term(op, 4, actions, modes, &coeff);
 ///
-///     assert(qf_ferm_op_max_rank(op, 4));
+///     assert(qf_ferm_op_max_rank(op), 4);
 ///
 /// @endrst
 #[unsafe(no_mangle)]

--- a/crates/cext/src/operators/majorana_operator.rs
+++ b/crates/cext/src/operators/majorana_operator.rs
@@ -945,16 +945,17 @@ pub unsafe extern "C" fn qf_maj_op_is_hermitian(op: *const MajoranaOperator, ato
 
 /// @ingroup qf_maj_op
 ///
-/// @brief Checks the many-body order of an operator.
+/// @brief Checks the maximum rank of an operator.
 ///
 /// @param op A pointer to the Majorana operator to be checked.
 ///
-/// @return The many-body order of the operator.
+/// @return The maximum rank of the operator.
 ///
 /// @rst
 ///
 /// .. note::
-///    The many-body order is defined as the length of the longest term contained in the operator.
+///    The length of the longest term can depend on the operator's form which means that (for
+///    example) operator simplification or normal-ordering can result in a different maximum rank.
 ///
 /// Example
 /// -------
@@ -967,15 +968,15 @@ pub unsafe extern "C" fn qf_maj_op_is_hermitian(op: *const MajoranaOperator, ato
 ///     QkComplex64 coeff = {1.0, 0.0};
 ///     qf_maj_op_add_term(op, 4, modes, &coeff);
 ///
-///     assert(qf_maj_op_many_body_order(op, 4));
+///     assert(qf_maj_op_max_rank(op, 4));
 ///
 /// @endrst
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qf_maj_op_many_body_order(op: *const MajoranaOperator) -> u32 {
+pub unsafe extern "C" fn qf_maj_op_max_rank(op: *const MajoranaOperator) -> u32 {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let op = unsafe { const_ptr_as_ref(op) };
 
-    op.many_body_order()
+    op.max_rank()
 }
 
 /// @ingroup qf_maj_op

--- a/crates/cext/src/operators/majorana_operator.rs
+++ b/crates/cext/src/operators/majorana_operator.rs
@@ -968,7 +968,7 @@ pub unsafe extern "C" fn qf_maj_op_is_hermitian(op: *const MajoranaOperator, ato
 ///     QkComplex64 coeff = {1.0, 0.0};
 ///     qf_maj_op_add_term(op, 4, modes, &coeff);
 ///
-///     assert(qf_maj_op_max_rank(op, 4));
+///     assert(qf_maj_op_max_rank(op), 4);
 ///
 /// @endrst
 #[unsafe(no_mangle)]

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -119,7 +119,7 @@ impl FermionOperator {
         diff.equiv(&Self::zero(), atol)
     }
 
-    pub fn many_body_order(&self) -> u32 {
+    pub fn max_rank(&self) -> u32 {
         let mut max = 0;
         let mut prev_b = 0;
         // TODO: refactor this
@@ -1004,8 +1004,8 @@ mod tests {
     }
 
     #[test]
-    fn test_many_body_order() {
-        assert_eq!(FermionOperator::one().many_body_order(), 0);
+    fn test_max_rank() {
+        assert_eq!(FermionOperator::one().max_rank(), 0);
 
         assert_eq!(
             FermionOperator {
@@ -1015,7 +1015,7 @@ mod tests {
                 boundaries: vec![0, 1],
                 groups: None,
             }
-            .many_body_order(),
+            .max_rank(),
             1
         );
 
@@ -1027,7 +1027,7 @@ mod tests {
                 boundaries: vec![0, 2],
                 groups: None,
             }
-            .many_body_order(),
+            .max_rank(),
             2
         );
     }

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -120,17 +120,11 @@ impl FermionOperator {
     }
 
     pub fn max_rank(&self) -> u32 {
-        let mut max = 0;
-        let mut prev_b = 0;
-        // TODO: refactor this
-        self.boundaries[1..].iter().for_each(|b| {
-            let d = b - prev_b;
-            if d > max {
-                max = d;
-            }
-            prev_b = *b;
-        });
-        max as u32
+        self.boundaries
+            .windows(2)
+            .map(|p| p[1] - p[0])
+            .max()
+            .unwrap_or(0) as u32
     }
 
     pub fn conserves_particle_number(&self) -> bool {
@@ -1005,6 +999,8 @@ mod tests {
 
     #[test]
     fn test_max_rank() {
+        assert_eq!(FermionOperator::zero().max_rank(), 0);
+
         assert_eq!(FermionOperator::one().max_rank(), 0);
 
         assert_eq!(

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -124,7 +124,7 @@ impl MajoranaOperator {
         diff.equiv(&Self::zero(), atol)
     }
 
-    pub fn many_body_order(&self) -> u32 {
+    pub fn max_rank(&self) -> u32 {
         let mut max = 0;
         let mut prev_b = 0;
         // TODO: refactor this
@@ -889,8 +889,8 @@ mod tests {
     }
 
     #[test]
-    fn test_many_body_order() {
-        assert_eq!(MajoranaOperator::one().many_body_order(), 0);
+    fn test_max_rank() {
+        assert_eq!(MajoranaOperator::one().max_rank(), 0);
 
         assert_eq!(
             MajoranaOperator {
@@ -899,7 +899,7 @@ mod tests {
                 boundaries: vec![0, 1],
                 groups: None,
             }
-            .many_body_order(),
+            .max_rank(),
             1
         );
 
@@ -910,7 +910,7 @@ mod tests {
                 boundaries: vec![0, 2],
                 groups: None,
             }
-            .many_body_order(),
+            .max_rank(),
             2
         );
     }

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -125,17 +125,11 @@ impl MajoranaOperator {
     }
 
     pub fn max_rank(&self) -> u32 {
-        let mut max = 0;
-        let mut prev_b = 0;
-        // TODO: refactor this
-        self.boundaries[1..].iter().for_each(|b| {
-            let d = b - prev_b;
-            if d > max {
-                max = d;
-            }
-            prev_b = *b;
-        });
-        max as u32
+        self.boundaries
+            .windows(2)
+            .map(|p| p[1] - p[0])
+            .max()
+            .unwrap_or(0) as u32
     }
 
     pub fn is_even(&self) -> bool {
@@ -890,6 +884,8 @@ mod tests {
 
     #[test]
     fn test_max_rank() {
+        assert_eq!(MajoranaOperator::zero().max_rank(), 0);
+
         assert_eq!(MajoranaOperator::one().max_rank(), 0);
 
         assert_eq!(

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -326,7 +326,7 @@ impl FermionOperatorDataIter {
 /// .. autosummary::
 ///
 ///    is_hermitian
-///    many_body_order
+///    max_rank
 ///    conserves_particle_number
 ///
 /// ----
@@ -965,11 +965,12 @@ impl PyFermionOperator {
         self.inner.is_hermitian(atol)
     }
 
-    /// Returns the many-body order of this operator.
+    /// Returns the maximum rank of the terms in this operator.
     ///
     /// .. note::
-    ///    The many-body order is defined as the length of the longest term contained in the
-    ///    operator.
+    ///    The length of the longest term can depend on the operator's form which means that (for
+    ///    example) operator simplification or normal-ordering can result in a different maximum
+    ///    rank.
     ///
     /// .. doctest::
     ///
@@ -977,13 +978,13 @@ impl PyFermionOperator {
     ///     >>> op = FermionOperator.from_dict({
     ///     ...     ((True, 0), (False, 1), (True, 2), (False, 3)): 1,
     ///     ... })
-    ///     >>> op.many_body_order()
+    ///     >>> op.max_rank()
     ///     4
     ///
     /// Returns:
-    ///     The many-body order of this operator.
-    fn many_body_order(&self) -> u32 {
-        self.inner.many_body_order()
+    ///     The maximum rank of this operator.
+    fn max_rank(&self) -> u32 {
+        self.inner.max_rank()
     }
 
     /// Returns whether this operator is particle-number conserving.

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -326,7 +326,7 @@ impl MajoranaOperatorDataIter {
 /// .. autosummary::
 ///
 ///    is_hermitian
-///    many_body_order
+///    max_rank
 ///    is_even
 ///
 /// ----
@@ -904,23 +904,24 @@ impl PyMajoranaOperator {
         self.inner.is_hermitian(atol)
     }
 
-    /// Returns the many-body order of this operator.
+    /// Returns the maximum rank of the terms in this operator.
     ///
     /// .. note::
-    ///    The many-body order is defined as the length of the longest term contained in the
-    ///    operator.
+    ///    The length of the longest term can depend on the operator's form which means that (for
+    ///    example) operator simplification or normal-ordering can result in a different maximum
+    ///    rank.
     ///
     /// .. doctest::
     ///
     ///     >>> from qiskit_fermions.operators import MajoranaOperator
     ///     >>> op = MajoranaOperator.from_dict({(0, 1, 2, 3): 1})
-    ///     >>> op.many_body_order()
+    ///     >>> op.max_rank()
     ///     4
     ///
     /// Returns:
-    ///     The many-body order of this operator.
-    fn many_body_order(&self) -> u32 {
-        self.inner.many_body_order()
+    ///     The maximum rank of this operator.
+    fn max_rank(&self) -> u32 {
+        self.inner.max_rank()
     }
 
     /// Returns whether this operator is even.

--- a/docs/cdoc/qf-ferm-op.rst
+++ b/docs/cdoc/qf-ferm-op.rst
@@ -136,7 +136,7 @@ The following functions exist to check certain properties of an operator.
 
   ==============================================  ==========================================================
   :c:func:`qf_ferm_op_is_hermitian`               Returns whether an operator is Hermitian.
-  :c:func:`qf_ferm_op_many_body_order`            Returns the many-body order of an operator.
+  :c:func:`qf_ferm_op_max_rank`                   Returns the maximum rank of the terms in this operator.
   :c:func:`qf_ferm_op_conserves_particle_number`  Returns whether an operator is particle-number conserving.
   ==============================================  ==========================================================
 

--- a/docs/cdoc/qf-maj-op.rst
+++ b/docs/cdoc/qf-maj-op.rst
@@ -139,11 +139,11 @@ The following functions exist to check certain properties of an operator.
 
 .. table::
 
-  ==================================== ===========================================
+  ==================================== =======================================================
   :c:func:`qf_maj_op_is_hermitian`     Returns whether an operator is Hermitian.
-  :c:func:`qf_maj_op_many_body_order`  Returns the many-body order of an operator.
+  :c:func:`qf_maj_op_max_rank`         Returns the maximum rank of the terms in this operator.
   :c:func:`qf_maj_op_is_even`          Returns whether an operator is even.
-  ==================================== ===========================================
+  ==================================== =======================================================
 
 ----
 

--- a/tests/c/test_fermion_operator.c
+++ b/tests/c/test_fermion_operator.c
@@ -459,16 +459,16 @@ static int test_is_hermitian(void) {
     return Ok;
 }
 
-static int test_many_body_order(void) {
+static int test_max_rank(void) {
     QfFermionOperator *op = qf_ferm_op_zero();
     bool action[4] = {true, false, true, false};
     uint32_t modes[4] = {0, 1, 2, 3};
     QkComplex64 coeff = {1.0, 0.0};
     qf_ferm_op_add_term(op, 4, action, modes, &coeff);
 
-    uint32_t many_body_order = qf_ferm_op_many_body_order(op);
+    uint32_t max_rank = qf_ferm_op_max_rank(op);
 
-    bool correct = many_body_order == 4;
+    bool correct = max_rank == 4;
 
     qf_ferm_op_free(op);
 
@@ -686,7 +686,7 @@ int test_fermion_operator(void) {
     num_failed += RUN_TEST(test_sandwich_ordered_true);
     num_failed += RUN_TEST(test_sandwich_ordered_false);
     num_failed += RUN_TEST(test_is_hermitian);
-    num_failed += RUN_TEST(test_many_body_order);
+    num_failed += RUN_TEST(test_max_rank);
     num_failed += RUN_TEST(test_conserves_particle_number);
     num_failed += RUN_TEST(test_len);
     num_failed += RUN_TEST(test_relabel_modes);

--- a/tests/c/test_majorana_operator.c
+++ b/tests/c/test_majorana_operator.c
@@ -379,15 +379,15 @@ static int test_is_hermitian(void) {
     return Ok;
 }
 
-static int test_many_body_order(void) {
+static int test_max_rank(void) {
     QfMajoranaOperator *op = qf_maj_op_zero();
     uint32_t modes[4] = {0, 1, 2, 3};
     QkComplex64 coeff = {1.0, 0.0};
     qf_maj_op_add_term(op, 4, modes, &coeff);
 
-    uint32_t many_body_order = qf_maj_op_many_body_order(op);
+    uint32_t max_rank = qf_maj_op_max_rank(op);
 
-    bool correct = many_body_order == 4;
+    bool correct = max_rank == 4;
 
     qf_maj_op_free(op);
 
@@ -588,7 +588,7 @@ int test_majorana_operator(void) {
     num_failed += RUN_TEST(test_adjoint);
     num_failed += RUN_TEST(test_normal_ordered);
     num_failed += RUN_TEST(test_is_hermitian);
-    num_failed += RUN_TEST(test_many_body_order);
+    num_failed += RUN_TEST(test_max_rank);
     num_failed += RUN_TEST(test_is_even);
     num_failed += RUN_TEST(test_len);
     num_failed += RUN_TEST(test_relabel_modes);

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -324,23 +324,23 @@ class TestFermionOperator:
         assert not op.is_hermitian()
         assert op.is_hermitian(1e-4)
 
-    def test_many_body_order(self, subtests):
+    def test_max_rank(self, subtests):
         cls = self.get_class()
 
         op = cls.one()
 
         with subtests.test("0"):
-            assert op.many_body_order() == 0
+            assert op.max_rank() == 0
 
         op += cls.from_dict({((True, 0), (False, 1)): 1})
 
         with subtests.test("2"):
-            assert op.many_body_order() == 2
+            assert op.max_rank() == 2
 
         op += cls.from_dict({((True, 0), (False, 1), (True, 2), (False, 3)): 1})
 
         with subtests.test("4"):
-            assert op.many_body_order() == 4
+            assert op.max_rank() == 4
 
     def test_conserves_particle_number(self, subtests):
         cls = self.get_class()

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -327,9 +327,14 @@ class TestFermionOperator:
     def test_max_rank(self, subtests):
         cls = self.get_class()
 
-        op = cls.one()
+        op = cls.zero()
 
-        with subtests.test("0"):
+        with subtests.test("0 for additive identity"):
+            assert op.max_rank() == 0
+
+        op += cls.one()
+
+        with subtests.test("0 for multiplicative identity"):
             assert op.max_rank() == 0
 
         op += cls.from_dict({((True, 0), (False, 1)): 1})

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -304,9 +304,14 @@ class TestMajoranaOperator:
     def test_max_rank(self, subtests):
         cls = self.get_class()
 
-        op = cls.one()
+        op = cls.zero()
 
-        with subtests.test("0"):
+        with subtests.test("0 for additive identity"):
+            assert op.max_rank() == 0
+
+        op += cls.one()
+
+        with subtests.test("0 for multiplicative identity"):
             assert op.max_rank() == 0
 
         op += cls.from_dict({(0, 1): 1})

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -301,23 +301,23 @@ class TestMajoranaOperator:
         assert not op.is_hermitian()
         assert op.is_hermitian(1e-4)
 
-    def test_many_body_order(self, subtests):
+    def test_max_rank(self, subtests):
         cls = self.get_class()
 
         op = cls.one()
 
         with subtests.test("0"):
-            assert op.many_body_order() == 0
+            assert op.max_rank() == 0
 
         op += cls.from_dict({(0, 1): 1})
 
         with subtests.test("2"):
-            assert op.many_body_order() == 2
+            assert op.max_rank() == 2
 
         op += cls.from_dict({(0, 1, 2, 3): 1})
 
         with subtests.test("4"):
-            assert op.many_body_order() == 4
+            assert op.max_rank() == 4
 
     def test_is_even(self, subtests):
         cls = self.get_class()


### PR DESCRIPTION
This addresses the main concern raised in #122.

While working on this PR I was contemplating adding a revised version of the `many_body_order` method with a definition along the lines of:

- the many-body-order being only defined when a `FermionOperator` (`MajoranaOperator`) is particle-number conserving (even)
- if it is not, return `None`, else return `max_rank // 2`

While starting to implement that, it felt unnecessary to add a method to just do these checks which are easy enough for a user to call directly, too. So I opted for not adding this as part of this PR. But I'm happy to hear arguments about pros/cons of doing so.

One problem that I was already made aware of by @timmintam is that the requirement is not mathematically identical between `FermionOperator` and `MajoranaOperator`. I would have considered this "fine" as long as it is well documented, but am still questioning the usefulness of adding this function as such, given that it may even cause more confusion when implemented like so.