### PR TITLE
ci: include --all-targets for clippy linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export BINDGEN_EXTRA_CLANG_ARGS := "-I$(shell python -c "import sysconfig; print
 lint:
 	cargo metadata --format-version=1 --locked >/dev/null
 	cargo fmt --check
-	cargo clippy -- -D warnings
+	cargo clippy --all-targets -- -D warnings
 	tox -e lint
 	clang-format --dry-run -Werror --style="file:.clang-format" -i tests/c/*.c tests/c/*.h
 

--- a/crates/core/src/operators/grouping/electronic_structure.rs
+++ b/crates/core/src/operators/grouping/electronic_structure.rs
@@ -89,120 +89,120 @@ mod tests {
     }
 
     fn build_expected_group_ops() -> Vec<FermionOperator> {
-        let mut expected = Vec::with_capacity(14);
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(0.7199689944489797, 0.0)],
-            actions: vec![],
-            modes: vec![],
-            boundaries: vec![0, 0],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(-1.2563390730032502, 0.0)],
-            actions: vec![true, false],
-            modes: vec![0, 0],
-            boundaries: vec![0, 2],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(-0.4718960072811406, 0.0)],
-            actions: vec![true, false],
-            modes: vec![1, 1],
-            boundaries: vec![0, 2],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(-1.2563390730032502, 0.0)],
-            actions: vec![true, false],
-            modes: vec![2, 2],
-            boundaries: vec![0, 2],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(-0.4718960072811406, 0.0)],
-            actions: vec![true, false],
-            modes: vec![3, 3],
-            boundaries: vec![0, 2],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![
-                Complex64::new(-2.3575299028703285e-16, 0.0),
-                Complex64::new(-2.3575299028703285e-16, 0.0),
-            ],
-            actions: vec![true, false, true, false],
-            modes: vec![0, 1, 1, 0],
-            boundaries: vec![0, 2, 4],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![
-                Complex64::new(-2.3575299028703285e-16, 0.0),
-                Complex64::new(-2.3575299028703285e-16, 0.0),
-            ],
-            actions: vec![true, false, true, false],
-            modes: vec![3, 2, 2, 3],
-            boundaries: vec![0, 2, 4],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(-0.4836505304710653, 0.0)],
-            actions: vec![true, true, false, false],
-            modes: vec![1, 0, 1, 0],
-            boundaries: vec![0, 4],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(-0.6757101548035165, 0.0)],
-            actions: vec![true, true, false, false],
-            modes: vec![2, 0, 2, 0],
-            boundaries: vec![0, 4],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(-0.6645817302552967, 0.0)],
-            actions: vec![true, true, false, false],
-            modes: vec![3, 0, 3, 0],
-            boundaries: vec![0, 4],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(-0.6645817302552967, 0.0)],
-            actions: vec![true, true, false, false],
-            modes: vec![2, 1, 2, 1],
-            boundaries: vec![0, 4],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(-0.6985737227320183, 0.0)],
-            actions: vec![true, true, false, false],
-            modes: vec![3, 1, 3, 1],
-            boundaries: vec![0, 4],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![Complex64::new(-0.4836505304710653, 0.0)],
-            actions: vec![true, true, false, false],
-            modes: vec![3, 2, 3, 2],
-            boundaries: vec![0, 4],
-            groups: None,
-        });
-        expected.push(FermionOperator {
-            coeffs: vec![
-                Complex64::new(-0.18093119978423133, 0.0),
-                Complex64::new(-0.18093119978423133, 0.0),
-                Complex64::new(-0.18093119978423133, 0.0),
-                Complex64::new(-0.18093119978423133, 0.0),
-            ],
-            actions: vec![
-                true, true, false, false, true, true, false, false, true, true, false, false, true,
-                true, false, false,
-            ],
-            modes: vec![2, 0, 3, 1, 2, 1, 3, 0, 3, 1, 2, 0, 3, 0, 2, 1],
-            boundaries: vec![0, 4, 8, 12, 16],
-            groups: None,
-        });
-        expected
+        vec![
+            FermionOperator {
+                coeffs: vec![Complex64::new(0.7199689944489797, 0.0)],
+                actions: vec![],
+                modes: vec![],
+                boundaries: vec![0, 0],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![Complex64::new(-1.2563390730032502, 0.0)],
+                actions: vec![true, false],
+                modes: vec![0, 0],
+                boundaries: vec![0, 2],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![Complex64::new(-0.4718960072811406, 0.0)],
+                actions: vec![true, false],
+                modes: vec![1, 1],
+                boundaries: vec![0, 2],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![Complex64::new(-1.2563390730032502, 0.0)],
+                actions: vec![true, false],
+                modes: vec![2, 2],
+                boundaries: vec![0, 2],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![Complex64::new(-0.4718960072811406, 0.0)],
+                actions: vec![true, false],
+                modes: vec![3, 3],
+                boundaries: vec![0, 2],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![
+                    Complex64::new(-2.3575299028703285e-16, 0.0),
+                    Complex64::new(-2.3575299028703285e-16, 0.0),
+                ],
+                actions: vec![true, false, true, false],
+                modes: vec![0, 1, 1, 0],
+                boundaries: vec![0, 2, 4],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![
+                    Complex64::new(-2.3575299028703285e-16, 0.0),
+                    Complex64::new(-2.3575299028703285e-16, 0.0),
+                ],
+                actions: vec![true, false, true, false],
+                modes: vec![3, 2, 2, 3],
+                boundaries: vec![0, 2, 4],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![Complex64::new(-0.4836505304710653, 0.0)],
+                actions: vec![true, true, false, false],
+                modes: vec![1, 0, 1, 0],
+                boundaries: vec![0, 4],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![Complex64::new(-0.6757101548035165, 0.0)],
+                actions: vec![true, true, false, false],
+                modes: vec![2, 0, 2, 0],
+                boundaries: vec![0, 4],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![Complex64::new(-0.6645817302552967, 0.0)],
+                actions: vec![true, true, false, false],
+                modes: vec![3, 0, 3, 0],
+                boundaries: vec![0, 4],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![Complex64::new(-0.6645817302552967, 0.0)],
+                actions: vec![true, true, false, false],
+                modes: vec![2, 1, 2, 1],
+                boundaries: vec![0, 4],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![Complex64::new(-0.6985737227320183, 0.0)],
+                actions: vec![true, true, false, false],
+                modes: vec![3, 1, 3, 1],
+                boundaries: vec![0, 4],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![Complex64::new(-0.4836505304710653, 0.0)],
+                actions: vec![true, true, false, false],
+                modes: vec![3, 2, 3, 2],
+                boundaries: vec![0, 4],
+                groups: None,
+            },
+            FermionOperator {
+                coeffs: vec![
+                    Complex64::new(-0.18093119978423133, 0.0),
+                    Complex64::new(-0.18093119978423133, 0.0),
+                    Complex64::new(-0.18093119978423133, 0.0),
+                    Complex64::new(-0.18093119978423133, 0.0),
+                ],
+                actions: vec![
+                    true, true, false, false, true, true, false, false, true, true, false, false,
+                    true, true, false, false,
+                ],
+                modes: vec![2, 0, 3, 1, 2, 1, 3, 0, 3, 1, 2, 0, 3, 0, 2, 1],
+                boundaries: vec![0, 4, 8, 12, 16],
+                groups: None,
+            },
+        ]
     }
 
     /// Converts the integral order of 2-body terms from chemist's to physicist's order.
@@ -261,15 +261,12 @@ mod tests {
             if new_len == prior_len {
                 // if we do not remove a group this time, we did not find a matching operator, thus
                 // we must fail the test.
-                assert!(
-                    false,
-                    "Could not find a matching group operator in the expected set!"
-                );
+                panic!("Could not find a matching group operator in the expected set!");
             }
         }
         // if the expected groups are not fully consumed, we also must fail!
         assert!(
-            expected.len() == 0,
+            expected.is_empty(),
             "Did not generate a group operator for all expected groups!"
         );
     }
@@ -309,7 +306,7 @@ mod tests {
         );
 
         let mut expected = build_expected_group_ops();
-        expected.iter_mut().for_each(|op| chem_to_phys(op));
+        expected.iter_mut().for_each(chem_to_phys);
 
         for group in groups.iter() {
             let prior_len = expected.len();
@@ -319,15 +316,12 @@ mod tests {
             if new_len == prior_len {
                 // if we do not remove a group this time, we did not find a matching operator, thus
                 // we must fail the test.
-                assert!(
-                    false,
-                    "Could not find a matching group operator in the expected set!"
-                );
+                panic!("Could not find a matching group operator in the expected set!");
             }
         }
         // if the expected groups are not fully consumed, we also must fail!
         assert!(
-            expected.len() == 0,
+            expected.is_empty(),
             "Did not generate a group operator for all expected groups!"
         );
     }

--- a/crates/core/src/operators/library/commutators.rs
+++ b/crates/core/src/operators/library/commutators.rs
@@ -89,11 +89,11 @@ mod tests {
         let comm = commutator(&op1, &op2);
 
         let expected = FermionOperator {
-            coeffs: vec![1.0, 2.0, 2.0, 4.0, -1.0, -2.0, -2.0, -4.0]
+            coeffs: [1.0, 2.0, 2.0, 4.0, -1.0, -2.0, -2.0, -4.0]
                 .iter()
                 .map(|c| Complex64::new(*c, 0.0))
                 .collect(),
-            actions: vec![true, false].iter().cloned().cycle().take(32).collect(),
+            actions: [true, false].iter().cloned().cycle().take(32).collect(),
             modes: vec![
                 1, 0, 0, 1, 3, 2, 0, 1, 1, 0, 2, 3, 3, 2, 2, 3, 0, 1, 1, 0, 2, 3, 1, 0, 0, 1, 3, 2,
                 2, 3, 3, 2,
@@ -124,11 +124,11 @@ mod tests {
         let comm = anti_commutator(&op1, &op2);
 
         let expected = FermionOperator {
-            coeffs: vec![1.0, 2.0, 2.0, 4.0, 1.0, 2.0, 2.0, 4.0]
+            coeffs: [1.0, 2.0, 2.0, 4.0, 1.0, 2.0, 2.0, 4.0]
                 .iter()
                 .map(|c| Complex64::new(*c, 0.0))
                 .collect(),
-            actions: vec![true, false].iter().cloned().cycle().take(32).collect(),
+            actions: [true, false].iter().cloned().cycle().take(32).collect(),
             modes: vec![
                 1, 0, 0, 1, 3, 2, 0, 1, 1, 0, 2, 3, 3, 2, 2, 3, 0, 1, 1, 0, 2, 3, 1, 0, 0, 1, 3, 2,
                 2, 3, 3, 2,

--- a/crates/core/src/operators/library/electronic_integrals.rs
+++ b/crates/core/src/operators/library/electronic_integrals.rs
@@ -304,16 +304,16 @@ mod tests {
     #[test]
     fn test_1body_tril_spin_sym() {
         let norb = 2;
-        let one_body_a = Array1::from_iter((1..4).map(|i| f64::from(i)));
+        let one_body_a = Array1::from_iter((1..4).map(f64::from));
 
         let op = FermionOperator::from_1body_tril_spin_sym(ArrayView1::from(&one_body_a), norb);
 
         let expected = FermionOperator {
-            coeffs: vec![1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0]
+            coeffs: [1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0, 3.0]
                 .iter()
                 .map(|c| Complex64::new(*c, 0.0))
                 .collect(),
-            actions: vec![true, false].iter().cloned().cycle().take(16).collect(),
+            actions: [true, false].iter().cloned().cycle().take(16).collect(),
             modes: vec![0, 0, 2, 2, 1, 0, 0, 1, 3, 2, 2, 3, 1, 1, 3, 3],
             boundaries: vec![0, 2, 4, 6, 8, 10, 12, 14, 16],
             groups: None,
@@ -325,7 +325,7 @@ mod tests {
     #[test]
     fn test_1body_tril_spin() {
         let norb = 2;
-        let one_body_a = Array1::from_iter((1..4).map(|i| f64::from(i)));
+        let one_body_a = Array1::from_iter((1..4).map(f64::from));
         let one_body_b = Array1::from_iter((1..4).map(|i| f64::from(-i)));
 
         let op = FermionOperator::from_1body_tril_spin(
@@ -335,11 +335,11 @@ mod tests {
         );
 
         let expected = FermionOperator {
-            coeffs: vec![1.0, 2.0, 2.0, 3.0, -1.0, -2.0, -2.0, -3.0]
+            coeffs: [1.0, 2.0, 2.0, 3.0, -1.0, -2.0, -2.0, -3.0]
                 .iter()
                 .map(|c| Complex64::new(*c, 0.0))
                 .collect(),
-            actions: vec![true, false].iter().cloned().cycle().take(16).collect(),
+            actions: [true, false].iter().cloned().cycle().take(16).collect(),
             modes: vec![0, 0, 1, 0, 0, 1, 1, 1, 2, 2, 3, 2, 2, 3, 3, 3],
             boundaries: vec![0, 2, 4, 6, 8, 10, 12, 14, 16],
             groups: None,
@@ -351,7 +351,7 @@ mod tests {
     #[test]
     fn test_2body_tril_spin_sym() {
         let norb = 2;
-        let two_body_aa = Array1::from_iter((1..7).map(|i| f64::from(i)));
+        let two_body_aa = Array1::from_iter((1..7).map(f64::from));
 
         let op = FermionOperator::from_2body_tril_spin_sym(ArrayView1::from(&two_body_aa), norb);
 
@@ -365,7 +365,7 @@ mod tests {
             .iter()
             .map(|c| Complex64::new(*c, 0.0))
             .collect(),
-            actions: vec![true, true, false, false]
+            actions: [true, true, false, false]
                 .iter()
                 .cloned()
                 .cycle()
@@ -393,8 +393,8 @@ mod tests {
     #[test]
     fn test_2body_tril_spin() {
         let norb = 2;
-        let two_body_aa = Array1::from_iter((1..7).map(|i| f64::from(i)));
-        let two_body_ab = Array1::from_iter((11..20).map(|i| f64::from(i)));
+        let two_body_aa = Array1::from_iter((1..7).map(f64::from));
+        let two_body_ab = Array1::from_iter((11..20).map(f64::from));
         let two_body_bb = Array1::from_iter((1..7).map(|i| f64::from(-i)));
 
         let op = FermionOperator::from_2body_tril_spin(
@@ -415,7 +415,7 @@ mod tests {
             .iter()
             .map(|c| Complex64::new(*c, 0.0))
             .collect(),
-            actions: vec![true, true, false, false]
+            actions: [true, true, false, false]
                 .iter()
                 .cloned()
                 .cycle()


### PR DESCRIPTION
This ensures that we also run clippy on test code.