### PR TITLE
Double factorization

### DIFF
--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -68,26 +68,44 @@ fn nalgebra_to_ndarray<T: nalgebra::Scalar + Copy>(mat: &DMatrix<T>) -> Array2<T
 ///
 /// Returns eigenvalues sorted in ascending order (matching numpy's `eigh`) together with the
 /// corresponding eigenvectors as the columns of the returned matrix.
-fn hermitian_eigh(mat: &Array2<Complex64>) -> (Array1<f64>, Array2<Complex64>) {
+///
+/// This function optionally truncates the returned eigenpairs by sorting them by descending
+/// absolute eigenvalue, then discards the smallest-magnitude eigenpairs whose cumulative absolute
+/// sum stays below `tol`, capping the number of retained vectors at `max_vecs` (default: all).
+fn hermitian_eigh(
+    mat: &Array2<Complex64>,
+    tol: Option<f64>,
+    max_vecs: Option<usize>,
+) -> (Array1<f64>, Array2<Complex64>) {
     let nalg = ndarray_to_nalgebra(mat);
     let eigen = nalg.symmetric_eigen();
-    sort_eigen_ascending(&eigen.eigenvalues, &eigen.eigenvectors)
-}
 
-/// Sorts eigenpairs in ascending order of eigenvalue and converts them to ndarray types.
-fn sort_eigen_ascending<T: nalgebra::Scalar + Copy>(
-    eigenvalues: &nalgebra::DVector<f64>,
-    eigenvectors: &DMatrix<T>,
-) -> (Array1<f64>, Array2<T>) {
-    let dim = eigenvalues.len();
+    let eigs = &eigen.eigenvalues;
+    let vecs = &eigen.eigenvectors;
+    let dim = eigs.len();
+    let mut n_keep = dim;
+
     let mut order: Vec<usize> = (0..dim).collect();
-    order.sort_by(|&a, &b| eigenvalues[a].partial_cmp(&eigenvalues[b]).unwrap());
+    // When we want to truncate the eigenpairs, we must order the eigenvalues by their |eigs|,
+    // otherwise we order them by their non-absolute values.
+    if tol.is_none() {
+        // Order by ascending eigenvalue.
+        order.sort_by(|&a, &b| eigs[a].partial_cmp(&eigs[b]).unwrap());
+    } else {
+        // Order by descending |eigenvalue|.
+        order.sort_by(|&a, &b| eigs[b].abs().partial_cmp(&eigs[a].abs()).unwrap());
 
-    let sorted_vals = Array1::from_shape_fn(dim, |i| eigenvalues[order[i]]);
-    let sorted_vecs = Array2::from_shape_fn((eigenvectors.nrows(), dim), |(row, col)| {
-        eigenvectors[(row, order[col])]
-    });
-    (sorted_vals, sorted_vecs)
+        // The reversed (ascending-magnitude) tail used for the cumulative discard count.
+        let ascending_abs = order.iter().rev().map(|&i| eigs[i].abs());
+        let n_discard = cumulative_discard_count(ascending_abs, tol.unwrap());
+
+        n_keep = max_vecs.unwrap_or(dim).min(dim - n_discard);
+    }
+
+    let kept_vals = Array1::from_shape_fn(n_keep, |i| eigs[order[i]]);
+    let kept_vecs =
+        Array2::from_shape_fn((vecs.nrows(), n_keep), |(row, col)| vecs[(row, order[col])]);
+    (kept_vals, kept_vecs)
 }
 
 /// Thin SVD of a complex matrix.
@@ -132,35 +150,6 @@ fn cumulative_discard_count(ascending_abs_tail: impl Iterator<Item = f64>, tol: 
         }
     }
     discard
-}
-
-/// Truncated Hermitian eigendecomposition.
-///
-/// Sorts eigenpairs by descending absolute eigenvalue, then discards the smallest-magnitude
-/// eigenpairs whose cumulative absolute sum stays below `tol`, capping the number of retained
-/// vectors at `max_vecs` (default: all).
-fn truncated_eigh(
-    mat: &Array2<Complex64>,
-    tol: f64,
-    max_vecs: Option<usize>,
-) -> (Array1<f64>, Array2<Complex64>) {
-    let (eigs, vecs) = hermitian_eigh(mat);
-    let dim = eigs.len();
-
-    // Order by descending |eigenvalue|.
-    let mut order: Vec<usize> = (0..dim).collect();
-    order.sort_by(|&a, &b| eigs[b].abs().partial_cmp(&eigs[a].abs()).unwrap());
-
-    // The reversed (ascending-magnitude) tail used for the cumulative discard count.
-    let ascending_abs = order.iter().rev().map(|&i| eigs[i].abs());
-    let n_discard = cumulative_discard_count(ascending_abs, tol);
-
-    let n_vecs = max_vecs.unwrap_or(dim).min(dim - n_discard);
-
-    let kept_eigs = Array1::from_shape_fn(n_vecs, |i| eigs[order[i]]);
-    let kept_vecs =
-        Array2::from_shape_fn((vecs.nrows(), n_vecs), |(row, col)| vecs[[row, order[col]]]);
-    (kept_eigs, kept_vecs)
 }
 
 /// Truncated thin SVD.
@@ -291,7 +280,7 @@ pub fn double_factorized(
         let n_vecs = cholesky_vecs.ncols();
         (cholesky_vecs, vec![1.0; n_vecs])
     } else {
-        let (outer_eigs, outer_vecs) = truncated_eigh(&reshaped, tol, Some(max_vecs));
+        let (outer_eigs, outer_vecs) = hermitian_eigh(&reshaped, Some(tol), Some(max_vecs));
         let coeffs = outer_eigs.to_vec();
         (outer_vecs, coeffs)
     };
@@ -335,7 +324,7 @@ fn terms_from_outer_matrices(
         .iter()
         .zip(outer_coeffs.iter())
         .map(|(mat, &coeff)| {
-            let (eigs, rotation) = hermitian_eigh(mat);
+            let (eigs, rotation) = hermitian_eigh(mat, None, None);
             let eigs = eigs.as_slice().unwrap();
             let diag_coulomb = diag_coulomb_outer(coeff, eigs, eigs);
             (diag_coulomb, rotation)
@@ -397,7 +386,7 @@ pub fn double_factorized_t2(
         t2_amplitudes[[i, j, a, b]]
     });
 
-    let (outer_eigs, outer_vecs) = truncated_eigh(&t2_mat, tol, None);
+    let (outer_eigs, outer_vecs) = hermitian_eigh(&t2_mat, Some(tol), None);
     let n_vecs = outer_eigs.len();
 
     let mut terms: Vec<DoubleFactorizedTerm> = Vec::with_capacity(2 * n_vecs);
@@ -407,7 +396,7 @@ pub fn double_factorized_t2(
 
         for (sign, coeff_sign) in [(1.0, 1.0), (-1.0, -1.0)] {
             let one_body = quadrature(&mat, sign);
-            let (eigs, rotation) = hermitian_eigh(&one_body);
+            let (eigs, rotation) = hermitian_eigh(&one_body, None, None);
             let coeff = coeff_sign * outer_eigs[t];
             let eigs = eigs.as_slice().unwrap();
             let diag_coulomb = diag_coulomb_outer(coeff, eigs, eigs);
@@ -520,8 +509,8 @@ pub fn double_factorized_t2_alpha_beta(
         for (row_idx, (sign, beta_mat)) in rows.iter().enumerate() {
             let one_body_a = quadrature(&left_mat, *sign);
             let one_body_b = quadrature(beta_mat, *sign);
-            let (eigs_a, rotation_a) = hermitian_eigh(&one_body_a);
-            let (eigs_b, rotation_b) = hermitian_eigh(&one_body_b);
+            let (eigs_a, rotation_a) = hermitian_eigh(&one_body_a, None, None);
+            let (eigs_b, rotation_b) = hermitian_eigh(&one_body_b, None, None);
 
             let coeff = 0.5 * coeff_signs[row_idx] * singular_vals[t];
 

--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -286,11 +286,27 @@ pub fn double_factorized(
     }
     let max_vecs = max_vecs.unwrap_or(norb * (norb + 1) / 2);
 
-    if cholesky {
-        double_factorized_explicit_cholesky(two_body_tensor, tol, max_vecs)
+    let norb = two_body_tensor.shape()[0];
+    let reshaped = reshaped_two_body(two_body_tensor);
+
+    // Produce the outer factorization columns and their coefficients. The Cholesky path folds the
+    // scale into the vectors themselves (unit coefficients); the eigh path keeps the eigenvalues
+    // as coefficients.
+    let (outer_columns, outer_coeffs) = if cholesky {
+        let cholesky_vecs = modified_cholesky(&reshaped, tol, Some(max_vecs));
+        let n_vecs = cholesky_vecs.ncols();
+        (cholesky_vecs, vec![1.0; n_vecs])
     } else {
-        double_factorized_explicit_eigh(two_body_tensor, tol, max_vecs)
-    }
+        let (outer_eigs, outer_vecs) = truncated_eigh(&reshaped, tol, Some(max_vecs));
+        let coeffs = outer_eigs.to_vec();
+        (outer_vecs, coeffs)
+    };
+
+    // Each column reshapes to a `(norb, norb)` matrix.
+    let outer_mats: Vec<Array2<Complex64>> = (0..outer_coeffs.len())
+        .map(|t| Array2::from_shape_fn((norb, norb), |(p, q)| outer_columns[[p * norb + q, t]]))
+        .collect();
+    terms_from_outer_matrices(&outer_mats, &outer_coeffs)
 }
 
 /// Reshapes a two-body tensor `(norb, norb, norb, norb)` into a `(norb², norb²)` complex matrix.
@@ -305,6 +321,16 @@ fn reshaped_two_body(two_body_tensor: &Array4<f64>) -> Array2<Complex64> {
     })
 }
 
+/// Builds a diagonal Coulomb matrix as the scaled outer product `coeff * eigs_k[k] * eigs_l[l]`.
+///
+/// The result has shape `(eigs_k.len(), eigs_l.len())`. Passing the same slice for both arguments
+/// yields the common symmetric `coeff * eigs[k] * eigs[l]` form.
+fn diag_coulomb_outer(coeff: f64, eigs_k: &[f64], eigs_l: &[f64]) -> Array2<f64> {
+    Array2::from_shape_fn((eigs_k.len(), eigs_l.len()), |(k, l)| {
+        coeff * eigs_k[k] * eigs_l[l]
+    })
+}
+
 /// Builds the per-term `(Z, U)` factors from a set of reshaped outer matrices, scaling each
 /// diagonal Coulomb matrix by an associated outer coefficient.
 fn terms_from_outer_matrices(
@@ -316,53 +342,31 @@ fn terms_from_outer_matrices(
         .zip(outer_coeffs.iter())
         .map(|(mat, &coeff)| {
             let (eigs, rotation) = hermitian_eigh(mat);
-            let n = eigs.len();
-            let diag_coulomb = Array2::from_shape_fn((n, n), |(k, l)| coeff * eigs[k] * eigs[l]);
+            let eigs = eigs.as_slice().unwrap();
+            let diag_coulomb = diag_coulomb_outer(coeff, eigs, eigs);
             (diag_coulomb, rotation)
         })
         .collect()
 }
 
-/// Explicit double factorization via modified Cholesky.
-fn double_factorized_explicit_cholesky(
-    two_body_tensor: &Array4<f64>,
-    tol: f64,
-    max_vecs: usize,
-) -> Vec<DoubleFactorizedTerm> {
-    let norb = two_body_tensor.shape()[0];
-    let reshaped = reshaped_two_body(two_body_tensor);
-    let cholesky_vecs = modified_cholesky(&reshaped, tol, Some(max_vecs));
-    let n_vecs = cholesky_vecs.ncols();
-
-    // Each Cholesky vector (a column) reshapes to a `(norb, norb)` matrix.
-    let outer_mats: Vec<Array2<Complex64>> = (0..n_vecs)
-        .map(|t| Array2::from_shape_fn((norb, norb), |(p, q)| cholesky_vecs[[p * norb + q, t]]))
-        .collect();
-    let outer_coeffs = vec![1.0; n_vecs];
-    terms_from_outer_matrices(&outer_mats, &outer_coeffs)
-}
-
-/// Explicit double factorization via truncated eigendecomposition.
-fn double_factorized_explicit_eigh(
-    two_body_tensor: &Array4<f64>,
-    tol: f64,
-    max_vecs: usize,
-) -> Vec<DoubleFactorizedTerm> {
-    let norb = two_body_tensor.shape()[0];
-    let reshaped = reshaped_two_body(two_body_tensor);
-    let (outer_eigs, outer_vecs) = truncated_eigh(&reshaped, tol, Some(max_vecs));
-    let n_vecs = outer_eigs.len();
-
-    let outer_mats: Vec<Array2<Complex64>> = (0..n_vecs)
-        .map(|t| Array2::from_shape_fn((norb, norb), |(p, q)| outer_vecs[[p * norb + q, t]]))
-        .collect();
-    let outer_coeffs: Vec<f64> = (0..n_vecs).map(|t| outer_eigs[t]).collect();
-    terms_from_outer_matrices(&outer_mats, &outer_coeffs)
-}
-
 // ---------------------------------------------------------------------------------------------
 // t2 amplitudes (spin-restricted)
 // ---------------------------------------------------------------------------------------------
+
+/// Places a flat occupied×virtual vector into the (virtual, occupied) block of a `(norb, norb)`
+/// zero matrix. The flat index runs in `product(occupied, virtual)` order (occupied outer,
+/// virtual inner): `mat[row, col]` for `row` in `[nocc, norb)` and `col` in `[0, nocc)`.
+fn place_ov_block(norb: usize, nocc: usize, get: impl Fn(usize) -> Complex64) -> Array2<Complex64> {
+    let mut mat: Array2<Complex64> = Array2::zeros((norb, norb));
+    let mut entry = 0;
+    for col in 0..nocc {
+        for row in nocc..norb {
+            mat[[row, col]] = get(entry);
+            entry += 1;
+        }
+    }
+    mat
+}
 
 /// The "quadrature" gadget that turns a placement matrix into a Hermitian one-body tensor:
 /// `0.5 * (1 - sign*i) * (mat + sign*i*mat†)`.
@@ -404,23 +408,15 @@ pub fn double_factorized_t2(
 
     let mut terms: Vec<DoubleFactorizedTerm> = Vec::with_capacity(2 * n_vecs);
     for t in 0..n_vecs {
-        // Place the outer vector into the occupied x virtual block: mat[row, col] where row runs
-        // over the virtual range [nocc, norb) and col over the occupied range [0, nocc).
-        let mut mat: Array2<Complex64> = Array2::zeros((norb, norb));
-        let mut entry = 0;
-        for col in 0..nocc {
-            for row in nocc..norb {
-                mat[[row, col]] = outer_vecs[[entry, t]];
-                entry += 1;
-            }
-        }
+        // Place the outer vector into the occupied x virtual block.
+        let mat = place_ov_block(norb, nocc, |entry| outer_vecs[[entry, t]]);
 
         for (sign, coeff_sign) in [(1.0, 1.0), (-1.0, -1.0)] {
             let one_body = quadrature(&mat, sign);
             let (eigs, rotation) = hermitian_eigh(&one_body);
-            let n = eigs.len();
             let coeff = coeff_sign * outer_eigs[t];
-            let diag_coulomb = Array2::from_shape_fn((n, n), |(k, l)| coeff * eigs[k] * eigs[l]);
+            let eigs = eigs.as_slice().unwrap();
+            let diag_coulomb = diag_coulomb_outer(coeff, eigs, eigs);
             terms.push((diag_coulomb, rotation));
         }
     }
@@ -515,24 +511,9 @@ pub fn double_factorized_t2_alpha_beta(
 
     let mut terms: Vec<DoubleFactorizedT2AlphaBetaTerm> = Vec::with_capacity(4 * n_vecs);
     for t in 0..n_vecs {
-        // Place the left/right singular vectors into the occupied x virtual blocks. The flat
-        // index runs in `product(occupied, virtual)` order (occupied outer, virtual inner).
-        let mut left_mat: Array2<Complex64> = Array2::zeros((norb, norb));
-        let mut entry = 0;
-        for col in 0..nocc_a {
-            for row in nocc_a..norb {
-                left_mat[[row, col]] = left[[entry, t]];
-                entry += 1;
-            }
-        }
-        let mut right_mat: Array2<Complex64> = Array2::zeros((norb, norb));
-        let mut entry = 0;
-        for col in 0..nocc_b {
-            for row in nocc_b..norb {
-                right_mat[[row, col]] = right[[t, entry]];
-                entry += 1;
-            }
-        }
+        // Place the left/right singular vectors into the occupied x virtual blocks.
+        let left_mat = place_ov_block(norb, nocc_a, |entry| left[[entry, t]]);
+        let right_mat = place_ov_block(norb, nocc_b, |entry| right[[t, entry]]);
         let neg_right_mat = right_mat.mapv(|x| -x);
 
         let rows: [(f64, &Array2<Complex64>); 4] = [
@@ -550,22 +531,13 @@ pub fn double_factorized_t2_alpha_beta(
 
             let coeff = 0.5 * coeff_signs[row_idx] * singular_vals[t];
 
-            // Concatenated alpha/beta eigenvalues (length 2*norb); outer product scaled by
-            // `coeff` gives the big diagonal Coulomb matrix, sliced into the aa/ab/bb blocks.
-            let combined_eigs: Vec<f64> = eigs_a
-                .iter()
-                .copied()
-                .chain(eigs_b.iter().copied())
-                .collect();
-            let aa = Array2::from_shape_fn((norb, norb), |(k, l)| {
-                coeff * combined_eigs[k] * combined_eigs[l]
-            });
-            let ab = Array2::from_shape_fn((norb, norb), |(k, l)| {
-                coeff * combined_eigs[k] * combined_eigs[norb + l]
-            });
-            let bb = Array2::from_shape_fn((norb, norb), |(k, l)| {
-                coeff * combined_eigs[norb + k] * combined_eigs[norb + l]
-            });
+            // The big diagonal Coulomb matrix is the `coeff`-scaled outer product of the
+            // concatenated alpha/beta eigenvalues, sliced into the aa/ab/bb blocks.
+            let alpha = eigs_a.as_slice().unwrap();
+            let beta = eigs_b.as_slice().unwrap();
+            let aa = diag_coulomb_outer(coeff, alpha, alpha);
+            let ab = diag_coulomb_outer(coeff, alpha, beta);
+            let bb = diag_coulomb_outer(coeff, beta, beta);
 
             terms.push(DoubleFactorizedT2AlphaBetaTerm {
                 diag_coulomb: [aa, ab, bb],

--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -1,0 +1,872 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2026.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+// The explicit (exact) decompositions in this module were translated from the Python
+// implementation in the `ffsim` library
+// (https://github.com/qiskit-community/ffsim, Apache-2.0, (C) IBM), specifically
+// `ffsim/linalg/double_factorized_decomposition.py`. The `optimize=True` "compressed"
+// code paths from the original are intentionally not ported here.
+
+use nalgebra::DMatrix;
+use ndarray::{Array1, Array2, Array4};
+use num_complex::Complex64;
+
+/// Accuracy threshold below which factorization terms are discarded by default.
+///
+/// Matches the default tolerance used by the original `ffsim` routines; callers can pass this
+/// for the `tol` argument of the public decomposition functions.
+pub const DEFAULT_TOL: f64 = 1e-8;
+
+/// A single term of a double-factorized decomposition: a real symmetric diagonal Coulomb
+/// matrix `Z` paired with a unitary orbital rotation `U`.
+pub type DoubleFactorizedTerm = (Array2<f64>, Array2<Complex64>);
+
+/// A single term of an alpha-beta (spin-unrestricted) `t2` double factorization.
+///
+/// The three diagonal Coulomb matrices are the (alpha-alpha, alpha-beta, beta-beta) blocks,
+/// and the two orbital rotations are the (alpha, beta) rotations.
+#[derive(Debug, Clone)]
+pub struct DoubleFactorizedT2AlphaBetaTerm {
+    /// Diagonal Coulomb matrices in the order `[aa, ab, bb]`.
+    pub diag_coulomb: [Array2<f64>; 3],
+    /// Orbital rotations in the order `[alpha, beta]`.
+    pub orbital_rotations: [Array2<Complex64>; 2],
+}
+
+// ---------------------------------------------------------------------------------------------
+// nalgebra <-> ndarray conversion helpers
+//
+// nalgebra is column-major; ndarray (by default) is row-major. To convert an ndarray matrix
+// into a nalgebra matrix we build it from the row-major data interpreted as `(ncols, nrows)`
+// column-major and transpose, or more simply use `DMatrix::from_row_slice`. To go back, we
+// read the nalgebra matrix in row order via element access.
+// ---------------------------------------------------------------------------------------------
+
+/// Converts a row-major [`Array2`] into a column-major nalgebra [`DMatrix`].
+fn ndarray_to_nalgebra<T: nalgebra::Scalar + Copy>(mat: &Array2<T>) -> DMatrix<T> {
+    let (nrows, ncols) = mat.dim();
+    // `from_row_slice` interprets the slice in row-major order, matching ndarray's standard
+    // layout. Ensure standard layout first in case the input is a transposed/strided view.
+    let standard = mat.as_standard_layout();
+    DMatrix::from_row_slice(nrows, ncols, standard.as_slice().unwrap())
+}
+
+/// Converts a column-major nalgebra [`DMatrix`] into a row-major [`Array2`].
+fn nalgebra_to_ndarray<T: nalgebra::Scalar + Copy>(mat: &DMatrix<T>) -> Array2<T> {
+    let (nrows, ncols) = (mat.nrows(), mat.ncols());
+    Array2::from_shape_fn((nrows, ncols), |(i, j)| mat[(i, j)])
+}
+
+// ---------------------------------------------------------------------------------------------
+// Eigendecomposition / SVD wrappers
+// ---------------------------------------------------------------------------------------------
+
+/// Hermitian eigendecomposition of a complex Hermitian matrix.
+///
+/// Returns eigenvalues sorted in ascending order (matching numpy's `eigh`) together with the
+/// corresponding eigenvectors as the columns of the returned matrix.
+fn hermitian_eigh(mat: &Array2<Complex64>) -> (Array1<f64>, Array2<Complex64>) {
+    let nalg = ndarray_to_nalgebra(mat);
+    let eigen = nalg.symmetric_eigen();
+    sort_eigen_ascending(&eigen.eigenvalues, &eigen.eigenvectors)
+}
+
+/// Sorts eigenpairs in ascending order of eigenvalue and converts them to ndarray types.
+fn sort_eigen_ascending<T: nalgebra::Scalar + Copy>(
+    eigenvalues: &nalgebra::DVector<f64>,
+    eigenvectors: &DMatrix<T>,
+) -> (Array1<f64>, Array2<T>) {
+    let dim = eigenvalues.len();
+    let mut order: Vec<usize> = (0..dim).collect();
+    order.sort_by(|&a, &b| eigenvalues[a].partial_cmp(&eigenvalues[b]).unwrap());
+
+    let sorted_vals = Array1::from_shape_fn(dim, |i| eigenvalues[order[i]]);
+    let sorted_vecs = Array2::from_shape_fn((eigenvectors.nrows(), dim), |(row, col)| {
+        eigenvectors[(row, order[col])]
+    });
+    (sorted_vals, sorted_vecs)
+}
+
+/// Thin SVD of a complex matrix.
+///
+/// Returns `(left_vecs, singular_vals, right_vecs)` where `left_vecs` has the left singular
+/// vectors as columns, `singular_vals` is sorted in descending order, and `right_vecs` has the
+/// right singular vectors as rows (i.e. it is `V^H`, matching `scipy.linalg.svd`).
+fn thin_svd(mat: &Array2<Complex64>) -> (Array2<Complex64>, Array1<f64>, Array2<Complex64>) {
+    let nalg = ndarray_to_nalgebra(mat);
+    // `SVD::new` computes the thin SVD and sorts singular values in descending order.
+    let svd = nalg.svd(true, true);
+    let u: DMatrix<Complex64> = svd.u.expect("left singular vectors were requested");
+    let v_t: DMatrix<Complex64> = svd.v_t.expect("right singular vectors were requested");
+    let singular_vals =
+        Array1::from_shape_fn(svd.singular_values.len(), |i| svd.singular_values[i]);
+    (
+        nalgebra_to_ndarray(&u),
+        singular_vals,
+        nalgebra_to_ndarray(&v_t),
+    )
+}
+
+// ---------------------------------------------------------------------------------------------
+// Truncation helpers
+// ---------------------------------------------------------------------------------------------
+
+/// Computes the number of trailing (smallest) values to discard so that the cumulative sum of
+/// their absolute values stays strictly below `tol`.
+///
+/// This reproduces numpy's `searchsorted(cumsum(abs(values[::-1])), tol)` with the default
+/// `side="left"`: the result is the number of entries of the reversed cumulative sum that are
+/// strictly less than `tol`.
+fn cumulative_discard_count(ascending_abs_tail: impl Iterator<Item = f64>, tol: f64) -> usize {
+    let mut running = 0.0;
+    let mut discard = 0;
+    for value in ascending_abs_tail {
+        running += value;
+        if running < tol {
+            discard += 1;
+        } else {
+            break;
+        }
+    }
+    discard
+}
+
+/// Truncated Hermitian eigendecomposition.
+///
+/// Sorts eigenpairs by descending absolute eigenvalue, then discards the smallest-magnitude
+/// eigenpairs whose cumulative absolute sum stays below `tol`, capping the number of retained
+/// vectors at `max_vecs` (default: all).
+fn truncated_eigh(
+    mat: &Array2<Complex64>,
+    tol: f64,
+    max_vecs: Option<usize>,
+) -> (Array1<f64>, Array2<Complex64>) {
+    let (eigs, vecs) = hermitian_eigh(mat);
+    let dim = eigs.len();
+
+    // Order by descending |eigenvalue|.
+    let mut order: Vec<usize> = (0..dim).collect();
+    order.sort_by(|&a, &b| eigs[b].abs().partial_cmp(&eigs[a].abs()).unwrap());
+
+    // The reversed (ascending-magnitude) tail used for the cumulative discard count.
+    let ascending_abs = order.iter().rev().map(|&i| eigs[i].abs());
+    let n_discard = cumulative_discard_count(ascending_abs, tol);
+
+    let n_vecs = max_vecs.unwrap_or(dim).min(dim - n_discard);
+
+    let kept_eigs = Array1::from_shape_fn(n_vecs, |i| eigs[order[i]]);
+    let kept_vecs =
+        Array2::from_shape_fn((vecs.nrows(), n_vecs), |(row, col)| vecs[[row, order[col]]]);
+    (kept_eigs, kept_vecs)
+}
+
+/// Truncated thin SVD.
+///
+/// Discards the smallest singular values whose cumulative sum stays below `tol`, capping the
+/// number of retained vectors at `max_vecs` (default: all). Singular values are non-negative
+/// and already sorted in descending order.
+fn truncated_svd(
+    mat: &Array2<Complex64>,
+    tol: f64,
+    max_vecs: Option<usize>,
+) -> (Array2<Complex64>, Array1<f64>, Array2<Complex64>) {
+    let (left, singular_vals, right) = thin_svd(mat);
+    let dim = singular_vals.len();
+
+    let ascending = (0..dim).rev().map(|i| singular_vals[i]);
+    let n_discard = cumulative_discard_count(ascending, tol);
+
+    let n_vecs = max_vecs.unwrap_or(dim).min(dim - n_discard);
+
+    let kept_left = Array2::from_shape_fn((left.nrows(), n_vecs), |(row, col)| left[[row, col]]);
+    let kept_s = Array1::from_shape_fn(n_vecs, |i| singular_vals[i]);
+    let kept_right = Array2::from_shape_fn((n_vecs, right.ncols()), |(row, col)| right[[row, col]]);
+    (kept_left, kept_s, kept_right)
+}
+
+// ---------------------------------------------------------------------------------------------
+// Modified Cholesky
+// ---------------------------------------------------------------------------------------------
+
+/// Modified Cholesky decomposition of a Hermitian positive-semidefinite matrix.
+///
+/// Decomposes `mat` into a sum of outer products `mat = Σ_i v_i v_i†`, returning the vectors
+/// `v_i` as the columns of the result. The number of terms is governed by `tol`, while
+/// `max_vecs` (default: the matrix dimension) is always respected even if it forces the
+/// truncation error above `tol`.
+pub fn modified_cholesky(
+    mat: &Array2<Complex64>,
+    tol: f64,
+    max_vecs: Option<usize>,
+) -> Array2<Complex64> {
+    let dim = mat.nrows();
+    if dim == 0 {
+        return Array2::zeros((0, 0));
+    }
+    let max_vecs = max_vecs.unwrap_or(dim);
+
+    let mut cholesky_vecs: Array2<Complex64> = Array2::zeros((dim, max_vecs + 1));
+    let mut errors: Array1<f64> = Array1::from_shape_fn(dim, |i| mat[[i, i]].re);
+
+    // Mirrors the Python `for index in range(max_vecs + 1)` loop: on a clean run `index` ends at
+    // `max_vecs` (so the final filled column is excluded), and on an early `break` it equals the
+    // number of columns filled so far. The returned slice is `cholesky_vecs[:, :index]`.
+    let mut index = max_vecs;
+    for current in 0..=max_vecs {
+        // Index of the maximum remaining error.
+        let mut max_error_index = 0;
+        let mut max_error = errors[0];
+        for i in 1..dim {
+            if errors[i] > max_error {
+                max_error = errors[i];
+                max_error_index = i;
+            }
+        }
+        if max_error < tol {
+            index = current;
+            break;
+        }
+
+        // New Cholesky vector starts as the selected column of `mat`.
+        for row in 0..dim {
+            cholesky_vecs[[row, current]] = mat[[row, max_error_index]];
+        }
+        // Orthogonalize against the previously computed vectors.
+        if current > 0 {
+            for k in 0..current {
+                let coeff = cholesky_vecs[[max_error_index, k]].conj();
+                for row in 0..dim {
+                    let update = cholesky_vecs[[row, k]] * coeff;
+                    cholesky_vecs[[row, current]] -= update;
+                }
+            }
+        }
+        // Normalize and update the running errors.
+        let scale = max_error.sqrt();
+        for row in 0..dim {
+            cholesky_vecs[[row, current]] /= scale;
+            errors[row] -= cholesky_vecs[[row, current]].norm_sqr();
+        }
+    }
+
+    cholesky_vecs.slice(ndarray::s![.., ..index]).to_owned()
+}
+
+// ---------------------------------------------------------------------------------------------
+// Two-body tensor: double_factorized
+// ---------------------------------------------------------------------------------------------
+
+/// Double-factorized decomposition of a real two-body tensor.
+///
+/// Represents `h_{pqrs} = Σ_t Σ_{kl} Z^{(t)}_{kl} U^{(t)}_{pk} U^{(t)}_{qk} U^{(t)}_{rl} U^{(t)}_{sl}`,
+/// returning a list of `(Z, U)` terms where each `Z` is a real symmetric diagonal Coulomb matrix
+/// and each `U` is a unitary orbital rotation.
+///
+/// When `cholesky` is `true` (the default behavior in the original library) the outer
+/// factorization uses a modified Cholesky decomposition; otherwise it uses a truncated
+/// eigendecomposition.
+pub fn double_factorized(
+    two_body_tensor: &Array4<f64>,
+    tol: f64,
+    max_vecs: Option<usize>,
+    cholesky: bool,
+) -> Vec<DoubleFactorizedTerm> {
+    let norb = two_body_tensor.shape()[0];
+    if norb == 0 {
+        return Vec::new();
+    }
+    let max_vecs = max_vecs.unwrap_or(norb * (norb + 1) / 2);
+
+    if cholesky {
+        double_factorized_explicit_cholesky(two_body_tensor, tol, max_vecs)
+    } else {
+        double_factorized_explicit_eigh(two_body_tensor, tol, max_vecs)
+    }
+}
+
+/// Reshapes a two-body tensor `(norb, norb, norb, norb)` into a `(norb², norb²)` complex matrix.
+fn reshaped_two_body(two_body_tensor: &Array4<f64>) -> Array2<Complex64> {
+    let norb = two_body_tensor.shape()[0];
+    Array2::from_shape_fn((norb * norb, norb * norb), |(row, col)| {
+        let p = row / norb;
+        let q = row % norb;
+        let r = col / norb;
+        let s = col % norb;
+        Complex64::new(two_body_tensor[[p, q, r, s]], 0.0)
+    })
+}
+
+/// Builds the per-term `(Z, U)` factors from a set of reshaped outer matrices, scaling each
+/// diagonal Coulomb matrix by an associated outer coefficient.
+fn terms_from_outer_matrices(
+    outer_mats: &[Array2<Complex64>],
+    outer_coeffs: &[f64],
+) -> Vec<DoubleFactorizedTerm> {
+    outer_mats
+        .iter()
+        .zip(outer_coeffs.iter())
+        .map(|(mat, &coeff)| {
+            let (eigs, rotation) = hermitian_eigh(mat);
+            let n = eigs.len();
+            let diag_coulomb = Array2::from_shape_fn((n, n), |(k, l)| coeff * eigs[k] * eigs[l]);
+            (diag_coulomb, rotation)
+        })
+        .collect()
+}
+
+/// Explicit double factorization via modified Cholesky.
+fn double_factorized_explicit_cholesky(
+    two_body_tensor: &Array4<f64>,
+    tol: f64,
+    max_vecs: usize,
+) -> Vec<DoubleFactorizedTerm> {
+    let norb = two_body_tensor.shape()[0];
+    let reshaped = reshaped_two_body(two_body_tensor);
+    let cholesky_vecs = modified_cholesky(&reshaped, tol, Some(max_vecs));
+    let n_vecs = cholesky_vecs.ncols();
+
+    // Each Cholesky vector (a column) reshapes to a `(norb, norb)` matrix.
+    let outer_mats: Vec<Array2<Complex64>> = (0..n_vecs)
+        .map(|t| Array2::from_shape_fn((norb, norb), |(p, q)| cholesky_vecs[[p * norb + q, t]]))
+        .collect();
+    let outer_coeffs = vec![1.0; n_vecs];
+    terms_from_outer_matrices(&outer_mats, &outer_coeffs)
+}
+
+/// Explicit double factorization via truncated eigendecomposition.
+fn double_factorized_explicit_eigh(
+    two_body_tensor: &Array4<f64>,
+    tol: f64,
+    max_vecs: usize,
+) -> Vec<DoubleFactorizedTerm> {
+    let norb = two_body_tensor.shape()[0];
+    let reshaped = reshaped_two_body(two_body_tensor);
+    let (outer_eigs, outer_vecs) = truncated_eigh(&reshaped, tol, Some(max_vecs));
+    let n_vecs = outer_eigs.len();
+
+    let outer_mats: Vec<Array2<Complex64>> = (0..n_vecs)
+        .map(|t| Array2::from_shape_fn((norb, norb), |(p, q)| outer_vecs[[p * norb + q, t]]))
+        .collect();
+    let outer_coeffs: Vec<f64> = (0..n_vecs).map(|t| outer_eigs[t]).collect();
+    terms_from_outer_matrices(&outer_mats, &outer_coeffs)
+}
+
+// ---------------------------------------------------------------------------------------------
+// t2 amplitudes (spin-restricted)
+// ---------------------------------------------------------------------------------------------
+
+/// The "quadrature" gadget that turns a placement matrix into a Hermitian one-body tensor:
+/// `0.5 * (1 - sign*i) * (mat + sign*i*mat†)`.
+fn quadrature(mat: &Array2<Complex64>, sign: f64) -> Array2<Complex64> {
+    let i = Complex64::new(0.0, 1.0);
+    let prefactor = Complex64::new(0.5, 0.0) * (Complex64::new(1.0, 0.0) - sign * i);
+    let (nrows, ncols) = mat.dim();
+    Array2::from_shape_fn((nrows, ncols), |(r, c)| {
+        let adjoint = mat[[c, r]].conj();
+        prefactor * (mat[[r, c]] + sign * i * adjoint)
+    })
+}
+
+/// Double-factorized decomposition of spin-restricted `t2` amplitudes.
+///
+/// Factorizes `t_{ijab}` (with `i,j` occupied and `a,b` virtual) into a list of `(Z, U)` terms
+/// suitable for reconstruction by [`reconstruct_t2`]. The number of terms is truncated to
+/// `max_terms` (default: all).
+pub fn double_factorized_t2(
+    t2_amplitudes: &Array4<Complex64>,
+    tol: f64,
+    max_terms: Option<usize>,
+) -> Vec<DoubleFactorizedTerm> {
+    let nocc = t2_amplitudes.shape()[0];
+    let nvrt = t2_amplitudes.shape()[2];
+    let norb = nocc + nvrt;
+
+    // Transpose axes (0, 2, 1, 3) then reshape to (nocc*nvrt, nocc*nvrt).
+    let t2_mat = Array2::from_shape_fn((nocc * nvrt, nocc * nvrt), |(row, col)| {
+        let i = row / nvrt;
+        let a = row % nvrt;
+        let j = col / nvrt;
+        let b = col % nvrt;
+        t2_amplitudes[[i, j, a, b]]
+    });
+
+    let (outer_eigs, outer_vecs) = truncated_eigh(&t2_mat, tol, None);
+    let n_vecs = outer_eigs.len();
+
+    let mut terms: Vec<DoubleFactorizedTerm> = Vec::with_capacity(2 * n_vecs);
+    for t in 0..n_vecs {
+        // Place the outer vector into the occupied x virtual block: mat[row, col] where row runs
+        // over the virtual range [nocc, norb) and col over the occupied range [0, nocc).
+        let mut mat: Array2<Complex64> = Array2::zeros((norb, norb));
+        let mut entry = 0;
+        for col in 0..nocc {
+            for row in nocc..norb {
+                mat[[row, col]] = outer_vecs[[entry, t]];
+                entry += 1;
+            }
+        }
+
+        for (sign, coeff_sign) in [(1.0, 1.0), (-1.0, -1.0)] {
+            let one_body = quadrature(&mat, sign);
+            let (eigs, rotation) = hermitian_eigh(&one_body);
+            let n = eigs.len();
+            let coeff = coeff_sign * outer_eigs[t];
+            let diag_coulomb = Array2::from_shape_fn((n, n), |(k, l)| coeff * eigs[k] * eigs[l]);
+            terms.push((diag_coulomb, rotation));
+        }
+    }
+
+    if let Some(max_terms) = max_terms {
+        terms.truncate(max_terms);
+    }
+    terms
+}
+
+/// Reconstructs spin-restricted `t2` amplitudes from a double-factorized decomposition.
+///
+/// Computes `i * Σ_k Σ_{pq} Z^{(k)}_{pq} U^{(k)}_{ap} U^{(k)*}_{ip} U^{(k)}_{bq} U^{(k)*}_{jq}`
+/// and slices to the occupied/virtual block `[:nocc, :nocc, nocc:, nocc:]`.
+pub fn reconstruct_t2(terms: &[DoubleFactorizedTerm], nocc: usize) -> Array4<Complex64> {
+    let norb = if terms.is_empty() {
+        0
+    } else {
+        terms[0].1.nrows()
+    };
+    let nvrt = norb - nocc;
+    let i_unit = Complex64::new(0.0, 1.0);
+
+    let mut result: Array4<Complex64> = Array4::zeros((nocc, nocc, nvrt, nvrt));
+    for (z, u) in terms {
+        for occ_i in 0..nocc {
+            for occ_j in 0..nocc {
+                for vrt_a in 0..nvrt {
+                    for vrt_b in 0..nvrt {
+                        let a = nocc + vrt_a;
+                        let b = nocc + vrt_b;
+                        let mut acc = Complex64::new(0.0, 0.0);
+                        for p in 0..norb {
+                            for q in 0..norb {
+                                acc += z[[p, q]]
+                                    * u[[a, p]]
+                                    * u[[occ_i, p]].conj()
+                                    * u[[b, q]]
+                                    * u[[occ_j, q]].conj();
+                            }
+                        }
+                        result[[occ_i, occ_j, vrt_a, vrt_b]] += i_unit * acc;
+                    }
+                }
+            }
+        }
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------------------------
+// t2 amplitudes (alpha-beta / unrestricted)
+// ---------------------------------------------------------------------------------------------
+
+/// Double-factorized decomposition of alpha-beta (spin-unrestricted) `t2` amplitudes.
+///
+/// Returns a list of [`DoubleFactorizedT2AlphaBetaTerm`] suitable for reconstruction by
+/// [`reconstruct_t2_alpha_beta`]. The number of terms is truncated to `max_terms` (default: all).
+pub fn double_factorized_t2_alpha_beta(
+    t2_amplitudes: &Array4<Complex64>,
+    tol: f64,
+    max_terms: Option<usize>,
+) -> Vec<DoubleFactorizedT2AlphaBetaTerm> {
+    let nocc_a = t2_amplitudes.shape()[0];
+    let nocc_b = t2_amplitudes.shape()[1];
+    let nvrt_a = t2_amplitudes.shape()[2];
+    let nvrt_b = t2_amplitudes.shape()[3];
+    let norb = nocc_a + nvrt_a;
+
+    // Transpose axes (0, 2, 1, 3) then reshape to (nocc_a*nvrt_a, nocc_b*nvrt_b).
+    let t2_mat = Array2::from_shape_fn((nocc_a * nvrt_a, nocc_b * nvrt_b), |(row, col)| {
+        let i = row / nvrt_a;
+        let a = row % nvrt_a;
+        let j = col / nvrt_b;
+        let b = col % nvrt_b;
+        t2_amplitudes[[i, j, a, b]]
+    });
+
+    let (left, singular_vals, right) = truncated_svd(&t2_mat, tol, None);
+    let n_vecs = singular_vals.len();
+
+    // The four per-outer-vector "rows" each pair an alpha one-body tensor (from `left_mat`) with
+    // a beta one-body tensor (from `right_mat`), built via the quadrature gadget. The layout
+    // mirrors ffsim's `one_body_tensors[n_vecs, 2, 2, 2, norb, norb]` reshaped to
+    // `(n_vecs, 4, 2, norb, norb)`:
+    //   row 0: alpha=quad(left, +1), beta=quad(+right, +1)
+    //   row 1: alpha=quad(left, +1), beta=quad(-right, +1)
+    //   row 2: alpha=quad(left, -1), beta=quad(+right, -1)
+    //   row 3: alpha=quad(left, -1), beta=quad(-right, -1)
+    // and `coeffs = 0.5 * [1, -1, -1, 1] * singular_val`.
+    let coeff_signs = [1.0, -1.0, -1.0, 1.0];
+
+    let mut terms: Vec<DoubleFactorizedT2AlphaBetaTerm> = Vec::with_capacity(4 * n_vecs);
+    for t in 0..n_vecs {
+        // Place the left/right singular vectors into the occupied x virtual blocks. The flat
+        // index runs in `product(occupied, virtual)` order (occupied outer, virtual inner).
+        let mut left_mat: Array2<Complex64> = Array2::zeros((norb, norb));
+        let mut entry = 0;
+        for col in 0..nocc_a {
+            for row in nocc_a..norb {
+                left_mat[[row, col]] = left[[entry, t]];
+                entry += 1;
+            }
+        }
+        let mut right_mat: Array2<Complex64> = Array2::zeros((norb, norb));
+        let mut entry = 0;
+        for col in 0..nocc_b {
+            for row in nocc_b..norb {
+                right_mat[[row, col]] = right[[t, entry]];
+                entry += 1;
+            }
+        }
+        let neg_right_mat = right_mat.mapv(|x| -x);
+
+        let rows: [(f64, &Array2<Complex64>); 4] = [
+            (1.0, &right_mat),
+            (1.0, &neg_right_mat),
+            (-1.0, &right_mat),
+            (-1.0, &neg_right_mat),
+        ];
+
+        for (row_idx, (sign, beta_mat)) in rows.iter().enumerate() {
+            let one_body_a = quadrature(&left_mat, *sign);
+            let one_body_b = quadrature(beta_mat, *sign);
+            let (eigs_a, rotation_a) = hermitian_eigh(&one_body_a);
+            let (eigs_b, rotation_b) = hermitian_eigh(&one_body_b);
+
+            let coeff = 0.5 * coeff_signs[row_idx] * singular_vals[t];
+
+            // Concatenated alpha/beta eigenvalues (length 2*norb); outer product scaled by
+            // `coeff` gives the big diagonal Coulomb matrix, sliced into the aa/ab/bb blocks.
+            let combined_eigs: Vec<f64> = eigs_a
+                .iter()
+                .copied()
+                .chain(eigs_b.iter().copied())
+                .collect();
+            let aa = Array2::from_shape_fn((norb, norb), |(k, l)| {
+                coeff * combined_eigs[k] * combined_eigs[l]
+            });
+            let ab = Array2::from_shape_fn((norb, norb), |(k, l)| {
+                coeff * combined_eigs[k] * combined_eigs[norb + l]
+            });
+            let bb = Array2::from_shape_fn((norb, norb), |(k, l)| {
+                coeff * combined_eigs[norb + k] * combined_eigs[norb + l]
+            });
+
+            terms.push(DoubleFactorizedT2AlphaBetaTerm {
+                diag_coulomb: [aa, ab, bb],
+                orbital_rotations: [rotation_a, rotation_b],
+            });
+        }
+    }
+
+    if let Some(max_terms) = max_terms {
+        terms.truncate(max_terms);
+    }
+    terms
+}
+
+/// Reconstructs alpha-beta `t2` amplitudes from a double-factorized decomposition.
+///
+/// Each term's three diagonal Coulomb blocks are assembled into a `(2*norb, 2*norb)` matrix and
+/// the two rotations into a block-diagonal `(2*norb, 2*norb)` rotation; the same contraction as
+/// [`reconstruct_t2`] is then applied and sliced to the alpha-occupied / beta-occupied /
+/// alpha-virtual / beta-virtual block.
+pub fn reconstruct_t2_alpha_beta(
+    terms: &[DoubleFactorizedT2AlphaBetaTerm],
+    norb: usize,
+    nocc_a: usize,
+    nocc_b: usize,
+) -> Array4<Complex64> {
+    let nvrt_a = norb - nocc_a;
+    let nvrt_b = norb - nocc_b;
+    let big = 2 * norb;
+    let i_unit = Complex64::new(0.0, 1.0);
+
+    let mut result: Array4<Complex64> = Array4::zeros((nocc_a, nocc_b, nvrt_a, nvrt_b));
+    for term in terms {
+        let [aa, ab, bb] = &term.diag_coulomb;
+        let [rot_a, rot_b] = &term.orbital_rotations;
+
+        // Expanded (2*norb, 2*norb) diagonal Coulomb matrix: [[aa, ab], [ab^T, bb]].
+        let z = Array2::from_shape_fn((big, big), |(row, col)| {
+            if row < norb && col < norb {
+                aa[[row, col]]
+            } else if row < norb {
+                ab[[row, col - norb]]
+            } else if col < norb {
+                ab[[col, row - norb]] // ab^T
+            } else {
+                bb[[row - norb, col - norb]]
+            }
+        });
+        // Block-diagonal rotation: diag(rot_a, rot_b).
+        let u = Array2::from_shape_fn((big, big), |(row, col)| {
+            if row < norb && col < norb {
+                rot_a[[row, col]]
+            } else if row >= norb && col >= norb {
+                rot_b[[row - norb, col - norb]]
+            } else {
+                Complex64::new(0.0, 0.0)
+            }
+        });
+
+        // Contract and slice to [:nocc_a, norb:norb+nocc_b, nocc_a:norb, norb+nocc_b:].
+        for occ_i in 0..nocc_a {
+            for occ_j in 0..nocc_b {
+                let global_j = norb + occ_j;
+                for vrt_a in 0..nvrt_a {
+                    let a = nocc_a + vrt_a;
+                    for vrt_b in 0..nvrt_b {
+                        let b = norb + nocc_b + vrt_b;
+                        let mut acc = Complex64::new(0.0, 0.0);
+                        for p in 0..big {
+                            for q in 0..big {
+                                acc += z[[p, q]]
+                                    * u[[a, p]]
+                                    * u[[occ_i, p]].conj()
+                                    * u[[b, q]]
+                                    * u[[global_j, q]].conj();
+                            }
+                        }
+                        result[[occ_i, occ_j, vrt_a, vrt_b]] += i_unit * acc;
+                    }
+                }
+            }
+        }
+    }
+    result
+}
+
+impl DoubleFactorizedT2AlphaBetaTerm {
+    /// The number of orbitals `norb` represented by this term.
+    pub fn norb(&self) -> usize {
+        self.orbital_rotations[0].nrows()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ndarray::Array2;
+
+    use crate::random::random_unitary;
+
+    /// Returns `true` if two 4-D tensors agree elementwise within `tol`.
+    fn tensors_approx_equal(a: &Array4<Complex64>, b: &Array4<Complex64>, tol: f64) -> bool {
+        if a.shape() != b.shape() {
+            return false;
+        }
+        a.iter().zip(b.iter()).all(|(x, y)| (x - y).norm() <= tol)
+    }
+
+    /// Builds a random Hermitian positive-semidefinite matrix `A A†` of the given dimension.
+    fn random_psd(dim: usize) -> Array2<Complex64> {
+        let a = random_unitary(dim);
+        a.dot(&a.t().mapv(|x| x.conj()))
+    }
+
+    /// Builds a random real two-body tensor whose reshaped `(norb², norb²)` matrix is symmetric
+    /// positive semidefinite — the structure of an electronic-structure two-electron integral
+    /// tensor, and required by the modified-Cholesky path.
+    ///
+    /// We construct `h_{pqrs} = Σ_t g^{(t)}_{pq} g^{(t)}_{rs}` for random real symmetric `g^{(t)}`,
+    /// which makes the reshaped matrix `M[pq, rs] = Σ_t vec(g^{(t)})_{pq} vec(g^{(t)})_{rs}` PSD by
+    /// construction. This tensor is exactly double-factorizable by both the Cholesky and eigh
+    /// paths.
+    fn random_two_body_tensor(norb: usize) -> Array4<f64> {
+        let n_terms = norb; // enough terms for a nontrivial spectrum
+        let mut gs: Vec<Array2<f64>> = Vec::with_capacity(n_terms);
+        for term in 0..n_terms {
+            let g = Array2::<f64>::from_shape_fn((norb, norb), |(p, q)| {
+                ((p + 1) as f64 * 0.37 - (q as f64) * 0.21 + term as f64 * 0.5).sin()
+            });
+            gs.push(&g + &g.t());
+        }
+        Array4::from_shape_fn((norb, norb, norb, norb), |(p, q, r, s)| {
+            gs.iter().map(|g| g[[p, q]] * g[[r, s]]).sum()
+        })
+    }
+
+    /// Reconstructs a two-body tensor from its double-factorized terms.
+    fn reconstruct_two_body(terms: &[DoubleFactorizedTerm], norb: usize) -> Array4<f64> {
+        let mut result = Array4::<f64>::zeros((norb, norb, norb, norb));
+        for (z, u) in terms {
+            for p in 0..norb {
+                for q in 0..norb {
+                    for r in 0..norb {
+                        for s in 0..norb {
+                            let mut acc = 0.0;
+                            for k in 0..norb {
+                                for l in 0..norb {
+                                    acc += z[[k, l]]
+                                        * (u[[p, k]] * u[[q, k]] * u[[r, l]] * u[[s, l]]).re;
+                                }
+                            }
+                            result[[p, q, r, s]] += acc;
+                        }
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    fn tensors_real_approx_equal(a: &Array4<f64>, b: &Array4<f64>, tol: f64) -> bool {
+        if a.shape() != b.shape() {
+            return false;
+        }
+        a.iter().zip(b.iter()).all(|(x, y)| (x - y).abs() <= tol)
+    }
+
+    #[test]
+    fn test_nalgebra_ndarray_roundtrip() {
+        for dim in 1..=5 {
+            let mat = random_unitary(dim);
+            let back = nalgebra_to_ndarray(&ndarray_to_nalgebra(&mat));
+            assert!(
+                mat.iter()
+                    .zip(back.iter())
+                    .all(|(x, y)| (x - y).norm() < 1e-12),
+                "round-trip conversion failed for dim {dim}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_modified_cholesky() {
+        for dim in 1..=6 {
+            let mat = random_psd(dim);
+            let vecs = modified_cholesky(&mat, 1e-12, None);
+            // Reconstruct: sum_i v_i v_i^dagger.
+            let reconstructed = vecs.dot(&vecs.t().mapv(|x| x.conj()));
+            assert!(
+                mat.iter()
+                    .zip(reconstructed.iter())
+                    .all(|(x, y)| (x - y).norm() < 1e-8),
+                "modified Cholesky reconstruction failed for dim {dim}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_double_factorized_cholesky() {
+        for norb in 2..=4 {
+            let tensor = random_two_body_tensor(norb);
+            let terms = double_factorized(&tensor, 1e-10, None, true);
+            let reconstructed = reconstruct_two_body(&terms, norb);
+            assert!(
+                tensors_real_approx_equal(&tensor, &reconstructed, 1e-8),
+                "cholesky double factorization round-trip failed for norb {norb}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_double_factorized_eigh() {
+        for norb in 2..=4 {
+            let tensor = random_two_body_tensor(norb);
+            let terms = double_factorized(&tensor, 1e-10, None, false);
+            let reconstructed = reconstruct_two_body(&terms, norb);
+            assert!(
+                tensors_real_approx_equal(&tensor, &reconstructed, 1e-8),
+                "eigh double factorization round-trip failed for norb {norb}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_double_factorized_max_vecs_truncates() {
+        let norb = 4;
+        let tensor = random_two_body_tensor(norb);
+        let full = double_factorized(&tensor, 1e-10, None, true);
+        let truncated = double_factorized(&tensor, 1e-10, Some(1), true);
+        assert!(truncated.len() <= full.len());
+        assert!(truncated.len() <= 1);
+    }
+
+    #[test]
+    fn test_double_factorized_t2_roundtrip() {
+        for (nocc, nvrt) in [(1usize, 2usize), (2, 2), (2, 3)] {
+            let norb = nocc + nvrt;
+            // Build a random t2 from a known decomposition so reconstruction is exact.
+            let t2 = random_t2(nocc, nvrt);
+            let terms = double_factorized_t2(&t2, 1e-12, None);
+            let reconstructed = reconstruct_t2(&terms, nocc);
+            assert!(
+                tensors_approx_equal(&t2, &reconstructed, 1e-8),
+                "t2 round-trip failed for nocc {nocc} nvrt {nvrt} (norb {norb})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_double_factorized_t2_alpha_beta_roundtrip() {
+        for (nocc, nvrt) in [(1usize, 2usize), (2, 2)] {
+            let norb = nocc + nvrt;
+            let t2 = random_t2_alpha_beta(nocc, nvrt);
+            let terms = double_factorized_t2_alpha_beta(&t2, 1e-12, None);
+            let reconstructed = reconstruct_t2_alpha_beta(&terms, norb, nocc, nocc);
+            assert!(
+                tensors_approx_equal(&t2, &reconstructed, 1e-8),
+                "alpha-beta t2 round-trip failed for nocc {nocc} nvrt {nvrt}"
+            );
+        }
+    }
+
+    /// Builds a random alpha-beta `t2` tensor `t_{ijab}` (alpha indices `i,a`, beta indices
+    /// `j,b`). The opposite-spin amplitudes carry no permutation symmetry, so any tensor is
+    /// exactly representable by the SVD-based factorization. The values are real here, matching
+    /// `ffsim.random.random_t2_amplitudes` with `dtype=float`.
+    fn random_t2_alpha_beta(nocc: usize, nvrt: usize) -> Array4<Complex64> {
+        let mut counter = 0.0_f64;
+        Array4::from_shape_fn((nocc, nocc, nvrt, nvrt), |_| {
+            counter += 1.0;
+            Complex64::new((counter * 0.53).cos(), 0.0)
+        })
+    }
+
+    /// Builds a random `t2` tensor `t_{ijab}` with the symmetry of restricted CCSD amplitudes,
+    /// matching `ffsim.random.random_t2_amplitudes`.
+    ///
+    /// The amplitudes satisfy `t2[i,j,a,b] == t2[j,i,b,a]`, which makes the reshaped matrix
+    /// `t2_mat = t2.transpose(0,2,1,3).reshape(nocc*nvrt, nocc*nvrt)` real symmetric and hence
+    /// exactly representable by the explicit (Hermitian-eigendecomposition) factorization.
+    fn random_t2(nocc: usize, nvrt: usize) -> Array4<Complex64> {
+        // Deterministic pseudo-random real values, assigned to the mirrored positions
+        // (i,a,j,b) and (j,b,i,a) so the CCSD symmetry holds exactly.
+        let mut t2 = Array4::<Complex64>::zeros((nocc, nocc, nvrt, nvrt));
+        let mut counter = 0.0_f64;
+        for i in 0..nocc {
+            for a in 0..nvrt {
+                for j in 0..nocc {
+                    for b in 0..nvrt {
+                        // Iterate over combinations_with_replacement of (occ, virt) pairs.
+                        if (i, a) <= (j, b) {
+                            counter += 1.0;
+                            let val = Complex64::new((counter * 0.7).sin(), 0.0);
+                            t2[[i, j, a, b]] = val;
+                            t2[[j, i, b, a]] = val;
+                        }
+                    }
+                }
+            }
+        }
+        t2
+    }
+}

--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -37,12 +37,11 @@ pub struct DoubleFactorizedT2AlphaBetaTerm {
 }
 
 // ---------------------------------------------------------------------------------------------
-// nalgebra <-> ndarray conversion helpers
+// ndarray -> nalgebra conversion helper
 //
 // nalgebra is column-major; ndarray (by default) is row-major. To convert an ndarray matrix
 // into a nalgebra matrix we build it from the row-major data interpreted as `(ncols, nrows)`
-// column-major and transpose, or more simply use `DMatrix::from_row_slice`. To go back, we
-// read the nalgebra matrix in row order via element access.
+// column-major and transpose, or more simply use `DMatrix::from_row_slice`.
 // ---------------------------------------------------------------------------------------------
 
 /// Converts a row-major [`Array2`] into a column-major nalgebra [`DMatrix`].
@@ -52,12 +51,6 @@ fn ndarray_to_nalgebra<T: nalgebra::Scalar + Copy>(mat: &Array2<T>) -> DMatrix<T
     // layout. Ensure standard layout first in case the input is a transposed/strided view.
     let standard = mat.as_standard_layout();
     DMatrix::from_row_slice(nrows, ncols, standard.as_slice().unwrap())
-}
-
-/// Converts a column-major nalgebra [`DMatrix`] into a row-major [`Array2`].
-fn nalgebra_to_ndarray<T: nalgebra::Scalar + Copy>(mat: &DMatrix<T>) -> Array2<T> {
-    let (nrows, ncols) = (mat.nrows(), mat.ncols());
-    Array2::from_shape_fn((nrows, ncols), |(i, j)| mat[(i, j)])
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -113,7 +106,15 @@ fn hermitian_eigh(
 /// Returns `(left_vecs, singular_vals, right_vecs)` where `left_vecs` has the left singular
 /// vectors as columns, `singular_vals` is sorted in descending order, and `right_vecs` has the
 /// right singular vectors as rows (i.e. it is `V^H`, matching `scipy.linalg.svd`).
-fn thin_svd(mat: &Array2<Complex64>) -> (Array2<Complex64>, Array1<f64>, Array2<Complex64>) {
+///
+/// This function optionally discards the smallest singular values whose cumulative sum stays below
+/// `tol`, capping the number of retained vectors at `max_vecs` (default: all). Singular values are
+/// non-negative and already sorted in descending order.
+fn thin_svd(
+    mat: &Array2<Complex64>,
+    tol: Option<f64>,
+    max_vecs: Option<usize>,
+) -> (Array2<Complex64>, Array1<f64>, Array2<Complex64>) {
     let nalg = ndarray_to_nalgebra(mat);
     // `SVD::new` computes the thin SVD and sorts singular values in descending order.
     let svd = nalg.svd(true, true);
@@ -121,11 +122,21 @@ fn thin_svd(mat: &Array2<Complex64>) -> (Array2<Complex64>, Array1<f64>, Array2<
     let v_t: DMatrix<Complex64> = svd.v_t.expect("right singular vectors were requested");
     let singular_vals =
         Array1::from_shape_fn(svd.singular_values.len(), |i| svd.singular_values[i]);
-    (
-        nalgebra_to_ndarray(&u),
-        singular_vals,
-        nalgebra_to_ndarray(&v_t),
-    )
+
+    let dim = singular_vals.len();
+    let mut n_keep = dim;
+
+    if tol.is_some() {
+        let ascending = (0..dim).rev().map(|i| singular_vals[i]);
+        let n_discard = cumulative_discard_count(ascending, tol.unwrap());
+
+        n_keep = max_vecs.unwrap_or(dim).min(dim - n_discard);
+    }
+
+    let kept_left = Array2::from_shape_fn((u.nrows(), n_keep), |(row, col)| u[(row, col)]);
+    let kept_s = Array1::from_shape_fn(n_keep, |i| singular_vals[i]);
+    let kept_right = Array2::from_shape_fn((n_keep, v_t.ncols()), |(row, col)| v_t[(row, col)]);
+    (kept_left, kept_s, kept_right)
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -150,30 +161,6 @@ fn cumulative_discard_count(ascending_abs_tail: impl Iterator<Item = f64>, tol: 
         }
     }
     discard
-}
-
-/// Truncated thin SVD.
-///
-/// Discards the smallest singular values whose cumulative sum stays below `tol`, capping the
-/// number of retained vectors at `max_vecs` (default: all). Singular values are non-negative
-/// and already sorted in descending order.
-fn truncated_svd(
-    mat: &Array2<Complex64>,
-    tol: f64,
-    max_vecs: Option<usize>,
-) -> (Array2<Complex64>, Array1<f64>, Array2<Complex64>) {
-    let (left, singular_vals, right) = thin_svd(mat);
-    let dim = singular_vals.len();
-
-    let ascending = (0..dim).rev().map(|i| singular_vals[i]);
-    let n_discard = cumulative_discard_count(ascending, tol);
-
-    let n_vecs = max_vecs.unwrap_or(dim).min(dim - n_discard);
-
-    let kept_left = Array2::from_shape_fn((left.nrows(), n_vecs), |(row, col)| left[[row, col]]);
-    let kept_s = Array1::from_shape_fn(n_vecs, |i| singular_vals[i]);
-    let kept_right = Array2::from_shape_fn((n_vecs, right.ncols()), |(row, col)| right[[row, col]]);
-    (kept_left, kept_s, kept_right)
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -478,7 +465,7 @@ pub fn double_factorized_t2_alpha_beta(
         t2_amplitudes[[i, j, a, b]]
     });
 
-    let (left, singular_vals, right) = truncated_svd(&t2_mat, tol, None);
+    let (left, singular_vals, right) = thin_svd(&t2_mat, Some(tol), None);
     let n_vecs = singular_vals.len();
 
     // The four per-outer-vector "rows" each pair an alpha one-body tensor (from `left_mat`) with
@@ -680,20 +667,6 @@ mod tests {
             return false;
         }
         a.iter().zip(b.iter()).all(|(x, y)| (x - y).abs() <= tol)
-    }
-
-    #[test]
-    fn test_nalgebra_ndarray_roundtrip() {
-        for dim in 1..=5 {
-            let mat = random_unitary(dim);
-            let back = nalgebra_to_ndarray(&ndarray_to_nalgebra(&mat));
-            assert!(
-                mat.iter()
-                    .zip(back.iter())
-                    .all(|(x, y)| (x - y).norm() < 1e-12),
-                "round-trip conversion failed for dim {dim}"
-            );
-        }
     }
 
     #[test]

--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -81,18 +81,18 @@ fn hermitian_eigh(
     let mut order: Vec<usize> = (0..dim).collect();
     // When we want to truncate the eigenpairs, we must order the eigenvalues by their |eigs|,
     // otherwise we order them by their non-absolute values.
-    if tol.is_none() {
-        // Order by ascending eigenvalue.
-        order.sort_by(|&a, &b| eigs[a].partial_cmp(&eigs[b]).unwrap());
-    } else {
+    if let Some(tol) = tol {
         // Order by descending |eigenvalue|.
         order.sort_by(|&a, &b| eigs[b].abs().partial_cmp(&eigs[a].abs()).unwrap());
 
         // The reversed (ascending-magnitude) tail used for the cumulative discard count.
         let ascending_abs = order.iter().rev().map(|&i| eigs[i].abs());
-        let n_discard = cumulative_discard_count(ascending_abs, tol.unwrap());
+        let n_discard = cumulative_discard_count(ascending_abs, tol);
 
         n_keep = max_vecs.unwrap_or(dim).min(dim - n_discard);
+    } else {
+        // Order by ascending eigenvalue.
+        order.sort_by(|&a, &b| eigs[a].partial_cmp(&eigs[b]).unwrap());
     }
 
     let kept_vals = Array1::from_shape_fn(n_keep, |i| eigs[order[i]]);
@@ -126,9 +126,9 @@ fn thin_svd(
     let dim = singular_vals.len();
     let mut n_keep = dim;
 
-    if tol.is_some() {
+    if let Some(tol) = tol {
         let ascending = (0..dim).rev().map(|i| singular_vals[i]);
-        let n_discard = cumulative_discard_count(ascending, tol.unwrap());
+        let n_discard = cumulative_discard_count(ascending, tol);
 
         n_keep = max_vecs.unwrap_or(dim).min(dim - n_discard);
     }
@@ -298,7 +298,7 @@ pub fn double_factorized(
     let max_vecs = max_vecs.unwrap_or(norb * (norb + 1) / 2);
 
     let norb = two_body_tensor.shape()[0];
-    /// Reshape the two-body tensor `(norb, norb, norb, norb)` into a `(norb², norb²)`.
+    // Reshape the two-body tensor `(norb, norb, norb, norb)` into a `(norb², norb²)`.
     let reshaped = Array2::from_shape_fn((norb * norb, norb * norb), |(row, col)| {
         let p = row / norb;
         let q = row % norb;
@@ -325,8 +325,8 @@ pub fn double_factorized(
         .map(|t| Array2::from_shape_fn((norb, norb), |(p, q)| outer_columns[[p * norb + q, t]]))
         .collect();
 
-    /// Build the per-term `(Z, U)` factors from the set of reshaped outer matrices, scaling each
-    /// diagonal Coulomb matrix by the associated outer coefficient.
+    // Build the per-term `(Z, U)` factors from the set of reshaped outer matrices, scaling each
+    // diagonal Coulomb matrix by the associated outer coefficient.
     outer_mats
         .iter()
         .zip(outer_coeffs.iter())

--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -173,7 +173,7 @@ fn cumulative_discard_count(ascending_abs_tail: impl Iterator<Item = f64>, tol: 
 /// `v_i` as the columns of the result. The number of terms is governed by `tol`, while
 /// `max_vecs` (default: the matrix dimension) is always respected even if it forces the
 /// truncation error above `tol`.
-pub fn modified_cholesky(
+fn modified_cholesky(
     mat: &Array2<Complex64>,
     tol: f64,
     max_vecs: Option<usize>,

--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -20,12 +20,6 @@ use nalgebra::DMatrix;
 use ndarray::{Array1, Array2, Array4};
 use num_complex::Complex64;
 
-/// Accuracy threshold below which factorization terms are discarded by default.
-///
-/// Matches the default tolerance used by the original `ffsim` routines; callers can pass this
-/// for the `tol` argument of the public decomposition functions.
-pub const DEFAULT_TOL: f64 = 1e-8;
-
 /// A single term of a double-factorized decomposition: a real symmetric diagonal Coulomb
 /// matrix `Z` paired with a unitary orbital rotation `U`.
 pub type DoubleFactorizedTerm = (Array2<f64>, Array2<Complex64>);
@@ -622,13 +616,6 @@ pub fn reconstruct_t2_alpha_beta(
         }
     }
     result
-}
-
-impl DoubleFactorizedT2AlphaBetaTerm {
-    /// The number of orbitals `norb` represented by this term.
-    pub fn norb(&self) -> usize {
-        self.orbital_rotations[0].nrows()
-    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -232,64 +232,8 @@ pub fn modified_cholesky(
 }
 
 // ---------------------------------------------------------------------------------------------
-// Two-body tensor: double_factorized
+// Matrix construction helpers
 // ---------------------------------------------------------------------------------------------
-
-/// Double-factorized decomposition of a real two-body tensor.
-///
-/// Represents `h_{pqrs} = Σ_t Σ_{kl} Z^{(t)}_{kl} U^{(t)}_{pk} U^{(t)}_{qk} U^{(t)}_{rl} U^{(t)}_{sl}`,
-/// returning a list of `(Z, U)` terms where each `Z` is a real symmetric diagonal Coulomb matrix
-/// and each `U` is a unitary orbital rotation.
-///
-/// When `cholesky` is `true` (the default behavior in the original library) the outer
-/// factorization uses a modified Cholesky decomposition; otherwise it uses a truncated
-/// eigendecomposition.
-pub fn double_factorized(
-    two_body_tensor: &Array4<f64>,
-    tol: f64,
-    max_vecs: Option<usize>,
-    cholesky: bool,
-) -> Vec<DoubleFactorizedTerm> {
-    let norb = two_body_tensor.shape()[0];
-    if norb == 0 {
-        return Vec::new();
-    }
-    let max_vecs = max_vecs.unwrap_or(norb * (norb + 1) / 2);
-
-    let norb = two_body_tensor.shape()[0];
-    let reshaped = reshaped_two_body(two_body_tensor);
-
-    // Produce the outer factorization columns and their coefficients. The Cholesky path folds the
-    // scale into the vectors themselves (unit coefficients); the eigh path keeps the eigenvalues
-    // as coefficients.
-    let (outer_columns, outer_coeffs) = if cholesky {
-        let cholesky_vecs = modified_cholesky(&reshaped, tol, Some(max_vecs));
-        let n_vecs = cholesky_vecs.ncols();
-        (cholesky_vecs, vec![1.0; n_vecs])
-    } else {
-        let (outer_eigs, outer_vecs) = hermitian_eigh(&reshaped, Some(tol), Some(max_vecs));
-        let coeffs = outer_eigs.to_vec();
-        (outer_vecs, coeffs)
-    };
-
-    // Each column reshapes to a `(norb, norb)` matrix.
-    let outer_mats: Vec<Array2<Complex64>> = (0..outer_coeffs.len())
-        .map(|t| Array2::from_shape_fn((norb, norb), |(p, q)| outer_columns[[p * norb + q, t]]))
-        .collect();
-    terms_from_outer_matrices(&outer_mats, &outer_coeffs)
-}
-
-/// Reshapes a two-body tensor `(norb, norb, norb, norb)` into a `(norb², norb²)` complex matrix.
-fn reshaped_two_body(two_body_tensor: &Array4<f64>) -> Array2<Complex64> {
-    let norb = two_body_tensor.shape()[0];
-    Array2::from_shape_fn((norb * norb, norb * norb), |(row, col)| {
-        let p = row / norb;
-        let q = row % norb;
-        let r = col / norb;
-        let s = col % norb;
-        Complex64::new(two_body_tensor[[p, q, r, s]], 0.0)
-    })
-}
 
 /// Builds a diagonal Coulomb matrix as the scaled outer product `coeff * eigs_k[k] * eigs_l[l]`.
 ///
@@ -300,28 +244,6 @@ fn diag_coulomb_outer(coeff: f64, eigs_k: &[f64], eigs_l: &[f64]) -> Array2<f64>
         coeff * eigs_k[k] * eigs_l[l]
     })
 }
-
-/// Builds the per-term `(Z, U)` factors from a set of reshaped outer matrices, scaling each
-/// diagonal Coulomb matrix by an associated outer coefficient.
-fn terms_from_outer_matrices(
-    outer_mats: &[Array2<Complex64>],
-    outer_coeffs: &[f64],
-) -> Vec<DoubleFactorizedTerm> {
-    outer_mats
-        .iter()
-        .zip(outer_coeffs.iter())
-        .map(|(mat, &coeff)| {
-            let (eigs, rotation) = hermitian_eigh(mat, None, None);
-            let eigs = eigs.as_slice().unwrap();
-            let diag_coulomb = diag_coulomb_outer(coeff, eigs, eigs);
-            (diag_coulomb, rotation)
-        })
-        .collect()
-}
-
-// ---------------------------------------------------------------------------------------------
-// t2 amplitudes (spin-restricted)
-// ---------------------------------------------------------------------------------------------
 
 /// Places a flat occupied×virtual vector into the (virtual, occupied) block of a `(norb, norb)`
 /// zero matrix. The flat index runs in `product(occupied, virtual)` order (occupied outer,
@@ -349,6 +271,77 @@ fn quadrature(mat: &Array2<Complex64>, sign: f64) -> Array2<Complex64> {
         prefactor * (mat[[r, c]] + sign * i * adjoint)
     })
 }
+
+// ---------------------------------------------------------------------------------------------
+// Two-body tensor: double_factorized
+// ---------------------------------------------------------------------------------------------
+
+/// Double-factorized decomposition of a real two-body tensor.
+///
+/// Represents `h_{pqrs} = Σ_t Σ_{kl} Z^{(t)}_{kl} U^{(t)}_{pk} U^{(t)}_{qk} U^{(t)}_{rl} U^{(t)}_{sl}`,
+/// returning a list of `(Z, U)` terms where each `Z` is a real symmetric diagonal Coulomb matrix
+/// and each `U` is a unitary orbital rotation.
+///
+/// When `cholesky` is `true` (the default behavior in the original library) the outer
+/// factorization uses a modified Cholesky decomposition; otherwise it uses a truncated
+/// eigendecomposition.
+pub fn double_factorized(
+    two_body_tensor: &Array4<f64>,
+    tol: f64,
+    max_vecs: Option<usize>,
+    cholesky: bool,
+) -> Vec<DoubleFactorizedTerm> {
+    let norb = two_body_tensor.shape()[0];
+    if norb == 0 {
+        return Vec::new();
+    }
+    let max_vecs = max_vecs.unwrap_or(norb * (norb + 1) / 2);
+
+    let norb = two_body_tensor.shape()[0];
+    /// Reshape the two-body tensor `(norb, norb, norb, norb)` into a `(norb², norb²)`.
+    let reshaped = Array2::from_shape_fn((norb * norb, norb * norb), |(row, col)| {
+        let p = row / norb;
+        let q = row % norb;
+        let r = col / norb;
+        let s = col % norb;
+        Complex64::new(two_body_tensor[[p, q, r, s]], 0.0)
+    });
+
+    // Produce the outer factorization columns and their coefficients. The Cholesky path folds the
+    // scale into the vectors themselves (unit coefficients); the eigh path keeps the eigenvalues
+    // as coefficients.
+    let (outer_columns, outer_coeffs) = if cholesky {
+        let cholesky_vecs = modified_cholesky(&reshaped, tol, Some(max_vecs));
+        let n_vecs = cholesky_vecs.ncols();
+        (cholesky_vecs, vec![1.0; n_vecs])
+    } else {
+        let (outer_eigs, outer_vecs) = hermitian_eigh(&reshaped, Some(tol), Some(max_vecs));
+        let coeffs = outer_eigs.to_vec();
+        (outer_vecs, coeffs)
+    };
+
+    // Each column reshapes to a `(norb, norb)` matrix.
+    let outer_mats: Vec<Array2<Complex64>> = (0..outer_coeffs.len())
+        .map(|t| Array2::from_shape_fn((norb, norb), |(p, q)| outer_columns[[p * norb + q, t]]))
+        .collect();
+
+    /// Build the per-term `(Z, U)` factors from the set of reshaped outer matrices, scaling each
+    /// diagonal Coulomb matrix by the associated outer coefficient.
+    outer_mats
+        .iter()
+        .zip(outer_coeffs.iter())
+        .map(|(mat, &coeff)| {
+            let (eigs, rotation) = hermitian_eigh(mat, None, None);
+            let eigs = eigs.as_slice().unwrap();
+            let diag_coulomb = diag_coulomb_outer(coeff, eigs, eigs);
+            (diag_coulomb, rotation)
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------------------------
+// t2 amplitudes (spin-restricted)
+// ---------------------------------------------------------------------------------------------
 
 /// Double-factorized decomposition of spin-restricted `t2` amplitudes.
 ///

--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -267,8 +267,7 @@ fn quadrature(mat: &Array2<Complex64>, sign: f64) -> Array2<Complex64> {
     let prefactor = Complex64::new(0.5, 0.0) * (Complex64::new(1.0, 0.0) - sign * i);
     let (nrows, ncols) = mat.dim();
     Array2::from_shape_fn((nrows, ncols), |(r, c)| {
-        let adjoint = mat[[c, r]].conj();
-        prefactor * (mat[[r, c]] + sign * i * adjoint)
+        prefactor * (mat[[r, c]] + sign * i * mat[[c, r]].conj())
     })
 }
 
@@ -300,11 +299,10 @@ pub fn double_factorized(
     let norb = two_body_tensor.shape()[0];
     // Reshape the two-body tensor `(norb, norb, norb, norb)` into a `(norb², norb²)`.
     let reshaped = Array2::from_shape_fn((norb * norb, norb * norb), |(row, col)| {
-        let p = row / norb;
-        let q = row % norb;
-        let r = col / norb;
-        let s = col % norb;
-        Complex64::new(two_body_tensor[[p, q, r, s]], 0.0)
+        Complex64::new(
+            two_body_tensor[[row / norb, row % norb, col / norb, col % norb]],
+            0.0,
+        )
     });
 
     // Produce the outer factorization columns and their coefficients. The Cholesky path folds the
@@ -320,18 +318,14 @@ pub fn double_factorized(
         (outer_vecs, coeffs)
     };
 
-    // Each column reshapes to a `(norb, norb)` matrix.
-    let outer_mats: Vec<Array2<Complex64>> = (0..outer_coeffs.len())
-        .map(|t| Array2::from_shape_fn((norb, norb), |(p, q)| outer_columns[[p * norb + q, t]]))
-        .collect();
-
-    // Build the per-term `(Z, U)` factors from the set of reshaped outer matrices, scaling each
+    // 1. Each column reshapes to a `(norb, norb)` matrix.
+    // 2. Build the per-term `(Z, U)` factors from the set of reshaped outer matrices, scaling each
     // diagonal Coulomb matrix by the associated outer coefficient.
-    outer_mats
-        .iter()
+    (0..outer_coeffs.len())
+        .map(|t| Array2::from_shape_fn((norb, norb), |(p, q)| outer_columns[[p * norb + q, t]]))
         .zip(outer_coeffs.iter())
         .map(|(mat, &coeff)| {
-            let (eigs, rotation) = hermitian_eigh(mat, None, None);
+            let (eigs, rotation) = hermitian_eigh(&mat, None, None);
             let eigs = eigs.as_slice().unwrap();
             let diag_coulomb = diag_coulomb_outer(coeff, eigs, eigs);
             (diag_coulomb, rotation)
@@ -359,11 +353,7 @@ pub fn double_factorized_t2(
 
     // Transpose axes (0, 2, 1, 3) then reshape to (nocc*nvrt, nocc*nvrt).
     let t2_mat = Array2::from_shape_fn((nocc * nvrt, nocc * nvrt), |(row, col)| {
-        let i = row / nvrt;
-        let a = row % nvrt;
-        let j = col / nvrt;
-        let b = col % nvrt;
-        t2_amplitudes[[i, j, a, b]]
+        t2_amplitudes[[row / nvrt, col / nvrt, row % nvrt, col % nvrt]]
     });
 
     let (outer_eigs, outer_vecs) = hermitian_eigh(&t2_mat, Some(tol), None);
@@ -451,11 +441,7 @@ pub fn double_factorized_t2_alpha_beta(
 
     // Transpose axes (0, 2, 1, 3) then reshape to (nocc_a*nvrt_a, nocc_b*nvrt_b).
     let t2_mat = Array2::from_shape_fn((nocc_a * nvrt_a, nocc_b * nvrt_b), |(row, col)| {
-        let i = row / nvrt_a;
-        let a = row % nvrt_a;
-        let j = col / nvrt_b;
-        let b = col % nvrt_b;
-        t2_amplitudes[[i, j, a, b]]
+        t2_amplitudes[[row / nvrt_a, col / nvrt_b, row % nvrt_a, col % nvrt_b]]
     });
 
     let (left, singular_vals, right) = thin_svd(&t2_mat, Some(tol), None);

--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -11,10 +11,12 @@
 // that they have been altered from the originals.
 
 // The explicit (exact) decompositions in this module were translated from the Python
-// implementation in the `ffsim` library
-// (https://github.com/qiskit-community/ffsim, Apache-2.0, (C) IBM), specifically
-// `ffsim/linalg/double_factorized_decomposition.py`. The `optimize=True` "compressed"
-// code paths from the original are intentionally not ported here.
+// implementation in the `ffsim` library (https://github.com/qiskit-community/ffsim, Apache-2.0,
+// (C) IBM), specifically `ffsim/linalg/double_factorized_decomposition.py`. The `optimize=True`
+// "compressed" code paths from the original are intentionally not ported here.
+//
+// Claude Opus 4.8 was used for the original language port but the code has since been reviewed and
+// refactored manually.
 
 use nalgebra::DMatrix;
 use ndarray::{Array1, Array2, Array4};
@@ -281,9 +283,8 @@ fn quadrature(mat: &Array2<Complex64>, sign: f64) -> Array2<Complex64> {
 /// returning a list of `(Z, U)` terms where each `Z` is a real symmetric diagonal Coulomb matrix
 /// and each `U` is a unitary orbital rotation.
 ///
-/// When `cholesky` is `true` (the default behavior in the original library) the outer
-/// factorization uses a modified Cholesky decomposition; otherwise it uses a truncated
-/// eigendecomposition.
+/// When `cholesky` is `true` the outer factorization uses a modified Cholesky decomposition;
+/// otherwise it uses a truncated eigendecomposition.
 pub fn double_factorized_2body(
     two_body_tensor: &Array4<f64>,
     tol: f64,

--- a/crates/core/src/linalg/double_factorized.rs
+++ b/crates/core/src/linalg/double_factorized.rs
@@ -272,7 +272,7 @@ fn quadrature(mat: &Array2<Complex64>, sign: f64) -> Array2<Complex64> {
 }
 
 // ---------------------------------------------------------------------------------------------
-// Two-body tensor: double_factorized
+// Two-body tensor: double_factorized_2body
 // ---------------------------------------------------------------------------------------------
 
 /// Double-factorized decomposition of a real two-body tensor.
@@ -284,7 +284,7 @@ fn quadrature(mat: &Array2<Complex64>, sign: f64) -> Array2<Complex64> {
 /// When `cholesky` is `true` (the default behavior in the original library) the outer
 /// factorization uses a modified Cholesky decomposition; otherwise it uses a truncated
 /// eigendecomposition.
-pub fn double_factorized(
+pub fn double_factorized_2body(
     two_body_tensor: &Array4<f64>,
     tol: f64,
     max_vecs: Option<usize>,
@@ -668,7 +668,7 @@ mod tests {
     fn test_double_factorized_cholesky() {
         for norb in 2..=4 {
             let tensor = random_two_body_tensor(norb);
-            let terms = double_factorized(&tensor, 1e-10, None, true);
+            let terms = double_factorized_2body(&tensor, 1e-10, None, true);
             let reconstructed = reconstruct_two_body(&terms, norb);
             assert!(
                 tensors_real_approx_equal(&tensor, &reconstructed, 1e-8),
@@ -681,7 +681,7 @@ mod tests {
     fn test_double_factorized_eigh() {
         for norb in 2..=4 {
             let tensor = random_two_body_tensor(norb);
-            let terms = double_factorized(&tensor, 1e-10, None, false);
+            let terms = double_factorized_2body(&tensor, 1e-10, None, false);
             let reconstructed = reconstruct_two_body(&terms, norb);
             assert!(
                 tensors_real_approx_equal(&tensor, &reconstructed, 1e-8),
@@ -694,8 +694,8 @@ mod tests {
     fn test_double_factorized_max_vecs_truncates() {
         let norb = 4;
         let tensor = random_two_body_tensor(norb);
-        let full = double_factorized(&tensor, 1e-10, None, true);
-        let truncated = double_factorized(&tensor, 1e-10, Some(1), true);
+        let full = double_factorized_2body(&tensor, 1e-10, None, true);
+        let truncated = double_factorized_2body(&tensor, 1e-10, Some(1), true);
         assert!(truncated.len() <= full.len());
         assert!(truncated.len() <= 1);
     }

--- a/crates/core/src/linalg/mod.rs
+++ b/crates/core/src/linalg/mod.rs
@@ -10,4 +10,5 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+pub mod double_factorized;
 pub mod givens;

--- a/crates/pyext/src/linalg/double_factorized.rs
+++ b/crates/pyext/src/linalg/double_factorized.rs
@@ -22,12 +22,19 @@ use qiskit_fermions_core::linalg::double_factorized::{
 /// A double-factorized term as exposed to Python: a 2-tuple of the diagonal Coulomb matrix and the
 /// orbital rotation, both as numpy arrays.
 type PyDoubleFactorizedTerm<'py> = (Bound<'py, PyArray2<f64>>, Bound<'py, PyArray2<Complex64>>);
+type PyReadonlyDoubleFactorizedTerm<'py> =
+    (PyReadonlyArray2<'py, f64>, PyReadonlyArray2<'py, Complex64>);
 
 /// An alpha-beta double-factorized term as exposed to Python: a 2-tuple of the three diagonal
 /// Coulomb matrices ``(aa, ab, bb)`` and the two orbital rotations ``(alpha, beta)``.
 type PyDoubleFactorizedT2AlphaBetaTerm<'py> = (
     [Bound<'py, PyArray2<f64>>; 3],
     [Bound<'py, PyArray2<Complex64>>; 2],
+);
+
+type PyReadonlyDoubleFactorizedT2AlphaBetaTerm<'py> = (
+    [PyReadonlyArray2<'py, f64>; 3],
+    [PyReadonlyArray2<'py, Complex64>; 2],
 );
 
 /// Converts a single core [`DoubleFactorizedTerm`] into its Python representation.
@@ -143,7 +150,7 @@ pub fn py_double_factorized_t2<'py>(
 #[pyfunction(name = "reconstruct_t2", signature = (terms, nocc))]
 pub fn py_reconstruct_t2<'py>(
     py: Python<'py>,
-    terms: Vec<(PyReadonlyArray2<'py, f64>, PyReadonlyArray2<'py, Complex64>)>,
+    terms: Vec<PyReadonlyDoubleFactorizedTerm>,
     nocc: usize,
 ) -> Bound<'py, PyArray4<Complex64>> {
     let terms: Vec<DoubleFactorizedTerm> = terms
@@ -200,10 +207,7 @@ pub fn py_double_factorized_t2_alpha_beta<'py>(
 #[pyfunction(name = "reconstruct_t2_alpha_beta", signature = (terms, norb, nocc_a, nocc_b))]
 pub fn py_reconstruct_t2_alpha_beta<'py>(
     py: Python<'py>,
-    terms: Vec<(
-        [PyReadonlyArray2<'py, f64>; 3],
-        [PyReadonlyArray2<'py, Complex64>; 2],
-    )>,
+    terms: Vec<PyReadonlyDoubleFactorizedT2AlphaBetaTerm>,
     norb: usize,
     nocc_a: usize,
     nocc_b: usize,

--- a/crates/pyext/src/linalg/double_factorized.rs
+++ b/crates/pyext/src/linalg/double_factorized.rs
@@ -15,8 +15,9 @@ use numpy::{IntoPyArray, PyArray2, PyArray4, PyReadonlyArray2, PyReadonlyArray4}
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
 use qiskit_fermions_core::linalg::double_factorized::{
-    DoubleFactorizedT2AlphaBetaTerm, DoubleFactorizedTerm, double_factorized, double_factorized_t2,
-    double_factorized_t2_alpha_beta, reconstruct_t2, reconstruct_t2_alpha_beta,
+    DoubleFactorizedT2AlphaBetaTerm, DoubleFactorizedTerm, double_factorized_2body,
+    double_factorized_t2, double_factorized_t2_alpha_beta, reconstruct_t2,
+    reconstruct_t2_alpha_beta,
 };
 
 /// A double-factorized term as exposed to Python: a 2-tuple of the diagonal Coulomb matrix and the
@@ -97,9 +98,8 @@ fn dfab_term_from_py(
 /// returning a list of :math:`(Z, U)` terms where each :math:`Z` is a real symmetric diagonal
 /// Coulomb matrix and each :math:`U` is a unitary orbital rotation.
 ///
-/// When ``cholesky`` is ``True`` (the default behavior in the original library) the outer
-/// factorization uses a modified Cholesky decomposition; otherwise it uses a truncated
-/// eigendecomposition.
+/// When ``cholesky`` is ``True`` (the default behavior) the outer factorization uses a modified
+/// Cholesky decomposition; otherwise it uses a truncated eigendecomposition.
 ///
 /// Arguments:
 ///     two_body_tensor: the real two-body tensor of shape ``(norb, norb, norb, norb)``.
@@ -112,15 +112,15 @@ fn dfab_term_from_py(
 ///     A list of :math:`(Z, U)` 2-tuples, where ``Z`` is the diagonal Coulomb matrix and ``U`` is
 ///     the orbital rotation.
 #[gen_stub_pyfunction(module = "qiskit_fermions.linalg.double_factorized")]
-#[pyfunction(name = "double_factorized", signature = (two_body_tensor, tol, max_vecs=None, cholesky=true))]
-pub fn py_double_factorized<'py>(
+#[pyfunction(name = "double_factorized_2body", signature = (two_body_tensor, tol, max_vecs=None, cholesky=true))]
+pub fn py_double_factorized_2body<'py>(
     py: Python<'py>,
     two_body_tensor: PyReadonlyArray4<f64>,
     tol: f64,
     max_vecs: Option<usize>,
     cholesky: bool,
 ) -> Vec<PyDoubleFactorizedTerm<'py>> {
-    double_factorized(
+    double_factorized_2body(
         &two_body_tensor.as_array().to_owned(),
         tol,
         max_vecs,
@@ -247,7 +247,7 @@ pub fn py_reconstruct_t2_alpha_beta<'py>(
 #[pymodule]
 pub mod double_factorized {
     #[pymodule_export]
-    use super::py_double_factorized;
+    use super::py_double_factorized_2body;
     #[pymodule_export]
     use super::py_double_factorized_t2;
     #[pymodule_export]

--- a/crates/pyext/src/linalg/double_factorized.rs
+++ b/crates/pyext/src/linalg/double_factorized.rs
@@ -101,7 +101,7 @@ fn dfab_term_from_py(
 /// When ``cholesky`` is ``True`` (the default behavior) the outer factorization uses a modified
 /// Cholesky decomposition; otherwise it uses a truncated eigendecomposition.
 ///
-/// Arguments:
+/// Args:
 ///     two_body_tensor: the real two-body tensor of shape ``(norb, norb, norb, norb)``.
 ///     tol: the tolerance controlling the truncation error of the decomposition.
 ///     max_vecs: the maximum number of terms to retain. Defaults to ``norb * (norb + 1) / 2``.
@@ -137,7 +137,7 @@ pub fn py_double_factorized_2body<'py>(
 /// :math:`(Z, U)` terms suitable for reconstruction by :func:`reconstruct_t2`. The number of terms
 /// is truncated to ``max_terms`` (default: all).
 ///
-/// Arguments:
+/// Args:
 ///     t2_amplitudes: the :math:`t_2` amplitudes of shape ``(nocc, nocc, nvrt, nvrt)``.
 ///     tol: the tolerance controlling the truncation error of the decomposition.
 ///     max_terms: the maximum number of terms to retain. Defaults to all.
@@ -165,7 +165,7 @@ pub fn py_double_factorized_t2<'py>(
 /// :math:`i \sum_k \sum_{pq} Z^{(k)}_{pq} U^{(k)}_{ap} U^{(k)*}_{ip} U^{(k)}_{bq} U^{(k)*}_{jq}`
 /// and slices to the occupied/virtual block ``[:nocc, :nocc, nocc:, nocc:]``.
 ///
-/// Arguments:
+/// Args:
 ///     terms: the list of :math:`(Z, U)` 2-tuples produced by :func:`double_factorized_t2`.
 ///     nocc: the number of occupied orbitals.
 ///
@@ -190,7 +190,7 @@ pub fn py_reconstruct_t2<'py>(
 /// Returns a list of terms suitable for reconstruction by :func:`reconstruct_t2_alpha_beta`. The
 /// number of terms is truncated to ``max_terms`` (default: all).
 ///
-/// Arguments:
+/// Args:
 ///     t2_amplitudes: the alpha-beta :math:`t_2` amplitudes of shape
 ///         ``(nocc_a, nocc_b, nvrt_a, nvrt_b)``.
 ///     tol: the tolerance controlling the truncation error of the decomposition.
@@ -217,7 +217,7 @@ pub fn py_double_factorized_t2_alpha_beta<'py>(
 
 /// Reconstructs alpha-beta :math:`t_2` amplitudes from a double-factorized decomposition.
 ///
-/// Arguments:
+/// Args:
 ///     terms: the list of terms produced by :func:`double_factorized_t2_alpha_beta`, each a 2-tuple
 ///         of the ``(aa, ab, bb)`` diagonal Coulomb matrices and the ``(alpha, beta)`` orbital
 ///         rotations.

--- a/crates/pyext/src/linalg/double_factorized.rs
+++ b/crates/pyext/src/linalg/double_factorized.rs
@@ -25,20 +25,8 @@ type PyDoubleFactorizedTerm<'py> = (Bound<'py, PyArray2<f64>>, Bound<'py, PyArra
 type PyReadonlyDoubleFactorizedTerm<'py> =
     (PyReadonlyArray2<'py, f64>, PyReadonlyArray2<'py, Complex64>);
 
-/// An alpha-beta double-factorized term as exposed to Python: a 2-tuple of the three diagonal
-/// Coulomb matrices ``(aa, ab, bb)`` and the two orbital rotations ``(alpha, beta)``.
-type PyDoubleFactorizedT2AlphaBetaTerm<'py> = (
-    [Bound<'py, PyArray2<f64>>; 3],
-    [Bound<'py, PyArray2<Complex64>>; 2],
-);
-
-type PyReadonlyDoubleFactorizedT2AlphaBetaTerm<'py> = (
-    [PyReadonlyArray2<'py, f64>; 3],
-    [PyReadonlyArray2<'py, Complex64>; 2],
-);
-
 /// Converts a single core [`DoubleFactorizedTerm`] into its Python representation.
-fn term_into_py(py: Python<'_>, term: DoubleFactorizedTerm) -> PyDoubleFactorizedTerm<'_> {
+fn df_term_into_py(py: Python<'_>, term: DoubleFactorizedTerm) -> PyDoubleFactorizedTerm<'_> {
     let (diag_coulomb, orbital_rotation) = term;
     (
         diag_coulomb.into_pyarray(py),
@@ -46,8 +34,28 @@ fn term_into_py(py: Python<'_>, term: DoubleFactorizedTerm) -> PyDoubleFactorize
     )
 }
 
+/// Converts a Python representation of [`DoubleFactorizedTerm`] to its core form.
+fn df_term_from_py(term: PyReadonlyDoubleFactorizedTerm) -> DoubleFactorizedTerm {
+    let (diag_coulomb, orbital_rotation) = term;
+    (
+        diag_coulomb.as_array().to_owned(),
+        orbital_rotation.as_array().to_owned(),
+    )
+}
+
+/// An alpha-beta double-factorized term as exposed to Python: a 2-tuple of the three diagonal
+/// Coulomb matrices ``(aa, ab, bb)`` and the two orbital rotations ``(alpha, beta)``.
+type PyDoubleFactorizedT2AlphaBetaTerm<'py> = (
+    [Bound<'py, PyArray2<f64>>; 3],
+    [Bound<'py, PyArray2<Complex64>>; 2],
+);
+type PyReadonlyDoubleFactorizedT2AlphaBetaTerm<'py> = (
+    [PyReadonlyArray2<'py, f64>; 3],
+    [PyReadonlyArray2<'py, Complex64>; 2],
+);
+
 /// Converts a single core [`DoubleFactorizedT2AlphaBetaTerm`] into its Python representation.
-fn alpha_beta_term_into_py(
+fn dfab_term_into_py(
     py: Python<'_>,
     term: DoubleFactorizedT2AlphaBetaTerm,
 ) -> PyDoubleFactorizedT2AlphaBetaTerm<'_> {
@@ -63,6 +71,23 @@ fn alpha_beta_term_into_py(
         ],
         [alpha.into_pyarray(py), beta.into_pyarray(py)],
     )
+}
+
+/// Converts a Python representation of [`DoubleFactorizedT2AlphaBetaTerm`] to its core form.
+fn dfab_term_from_py(
+    term: PyReadonlyDoubleFactorizedT2AlphaBetaTerm,
+) -> DoubleFactorizedT2AlphaBetaTerm {
+    let (diag_coulomb, orbital_rotation) = term;
+    let [aa, ab, bb] = diag_coulomb;
+    let [alpha, beta] = orbital_rotation;
+    DoubleFactorizedT2AlphaBetaTerm {
+        diag_coulomb: [
+            aa.as_array().to_owned(),
+            ab.as_array().to_owned(),
+            bb.as_array().to_owned(),
+        ],
+        orbital_rotations: [alpha.as_array().to_owned(), beta.as_array().to_owned()],
+    }
 }
 
 /// Double-factorized decomposition of a real two-body tensor.
@@ -102,7 +127,7 @@ pub fn py_double_factorized<'py>(
         cholesky,
     )
     .into_iter()
-    .map(|term| term_into_py(py, term))
+    .map(|term| df_term_into_py(py, term))
     .collect()
 }
 
@@ -130,7 +155,7 @@ pub fn py_double_factorized_t2<'py>(
 ) -> Vec<PyDoubleFactorizedTerm<'py>> {
     double_factorized_t2(&t2_amplitudes.as_array().to_owned(), tol, max_terms)
         .into_iter()
-        .map(|term| term_into_py(py, term))
+        .map(|term| df_term_into_py(py, term))
         .collect()
 }
 
@@ -155,7 +180,7 @@ pub fn py_reconstruct_t2<'py>(
 ) -> Bound<'py, PyArray4<Complex64>> {
     let terms: Vec<DoubleFactorizedTerm> = terms
         .into_iter()
-        .map(|(z, u)| (z.as_array().to_owned(), u.as_array().to_owned()))
+        .map(|term| df_term_from_py(term))
         .collect();
     reconstruct_t2(&terms, nocc).into_pyarray(py)
 }
@@ -186,7 +211,7 @@ pub fn py_double_factorized_t2_alpha_beta<'py>(
 ) -> Vec<PyDoubleFactorizedT2AlphaBetaTerm<'py>> {
     double_factorized_t2_alpha_beta(&t2_amplitudes.as_array().to_owned(), tol, max_terms)
         .into_iter()
-        .map(|term| alpha_beta_term_into_py(py, term))
+        .map(|term| dfab_term_into_py(py, term))
         .collect()
 }
 
@@ -214,16 +239,7 @@ pub fn py_reconstruct_t2_alpha_beta<'py>(
 ) -> Bound<'py, PyArray4<Complex64>> {
     let terms: Vec<DoubleFactorizedT2AlphaBetaTerm> = terms
         .into_iter()
-        .map(
-            |([aa, ab, bb], [alpha, beta])| DoubleFactorizedT2AlphaBetaTerm {
-                diag_coulomb: [
-                    aa.as_array().to_owned(),
-                    ab.as_array().to_owned(),
-                    bb.as_array().to_owned(),
-                ],
-                orbital_rotations: [alpha.as_array().to_owned(), beta.as_array().to_owned()],
-            },
-        )
+        .map(|term| dfab_term_from_py(term))
         .collect();
     reconstruct_t2_alpha_beta(&terms, norb, nocc_a, nocc_b).into_pyarray(py)
 }

--- a/crates/pyext/src/linalg/double_factorized.rs
+++ b/crates/pyext/src/linalg/double_factorized.rs
@@ -15,9 +15,8 @@ use numpy::{IntoPyArray, PyArray2, PyArray4, PyReadonlyArray2, PyReadonlyArray4}
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
 use qiskit_fermions_core::linalg::double_factorized::{
-    DoubleFactorizedT2AlphaBetaTerm, DoubleFactorizedTerm, double_factorized,
-    double_factorized_t2, double_factorized_t2_alpha_beta, modified_cholesky, reconstruct_t2,
-    reconstruct_t2_alpha_beta,
+    DoubleFactorizedT2AlphaBetaTerm, DoubleFactorizedTerm, double_factorized, double_factorized_t2,
+    double_factorized_t2_alpha_beta, reconstruct_t2, reconstruct_t2_alpha_beta,
 };
 
 /// A double-factorized term as exposed to Python: a 2-tuple of the diagonal Coulomb matrix and the
@@ -50,35 +49,13 @@ fn alpha_beta_term_into_py(
         orbital_rotations: [alpha, beta],
     } = term;
     (
-        [aa.into_pyarray(py), ab.into_pyarray(py), bb.into_pyarray(py)],
+        [
+            aa.into_pyarray(py),
+            ab.into_pyarray(py),
+            bb.into_pyarray(py),
+        ],
         [alpha.into_pyarray(py), beta.into_pyarray(py)],
     )
-}
-
-/// Modified Cholesky decomposition of a Hermitian positive-semidefinite matrix.
-///
-/// Decomposes ``mat`` into a sum of outer products :math:`M = \sum_i v_i v_i^\dagger`, returning the
-/// vectors :math:`v_i` as the columns of the result. The number of terms is governed by ``tol``,
-/// while ``max_vecs`` (default: the matrix dimension) is always respected even if it forces the
-/// truncation error above ``tol``.
-///
-/// Arguments:
-///     mat: the Hermitian positive-semidefinite matrix, :math:`M`, to decompose.
-///     tol: the tolerance controlling the truncation error of the decomposition.
-///     max_vecs: the maximum number of Cholesky vectors to retain. Defaults to the dimension of
-///         ``mat``.
-///
-/// Returns:
-///     A 2-dimensional array whose columns are the Cholesky vectors :math:`v_i`.
-#[gen_stub_pyfunction(module = "qiskit_fermions.linalg.double_factorized")]
-#[pyfunction(name = "modified_cholesky", signature = (mat, tol, max_vecs=None))]
-pub fn py_modified_cholesky<'py>(
-    py: Python<'py>,
-    mat: PyReadonlyArray2<Complex64>,
-    tol: f64,
-    max_vecs: Option<usize>,
-) -> Bound<'py, PyArray2<Complex64>> {
-    modified_cholesky(&mat.as_array().to_owned(), tol, max_vecs).into_pyarray(py)
 }
 
 /// Double-factorized decomposition of a real two-body tensor.
@@ -111,10 +88,15 @@ pub fn py_double_factorized<'py>(
     max_vecs: Option<usize>,
     cholesky: bool,
 ) -> Vec<PyDoubleFactorizedTerm<'py>> {
-    double_factorized(&two_body_tensor.as_array().to_owned(), tol, max_vecs, cholesky)
-        .into_iter()
-        .map(|term| term_into_py(py, term))
-        .collect()
+    double_factorized(
+        &two_body_tensor.as_array().to_owned(),
+        tol,
+        max_vecs,
+        cholesky,
+    )
+    .into_iter()
+    .map(|term| term_into_py(py, term))
+    .collect()
 }
 
 /// Double-factorized decomposition of spin-restricted :math:`t_2` amplitudes.
@@ -228,14 +210,16 @@ pub fn py_reconstruct_t2_alpha_beta<'py>(
 ) -> Bound<'py, PyArray4<Complex64>> {
     let terms: Vec<DoubleFactorizedT2AlphaBetaTerm> = terms
         .into_iter()
-        .map(|([aa, ab, bb], [alpha, beta])| DoubleFactorizedT2AlphaBetaTerm {
-            diag_coulomb: [
-                aa.as_array().to_owned(),
-                ab.as_array().to_owned(),
-                bb.as_array().to_owned(),
-            ],
-            orbital_rotations: [alpha.as_array().to_owned(), beta.as_array().to_owned()],
-        })
+        .map(
+            |([aa, ab, bb], [alpha, beta])| DoubleFactorizedT2AlphaBetaTerm {
+                diag_coulomb: [
+                    aa.as_array().to_owned(),
+                    ab.as_array().to_owned(),
+                    bb.as_array().to_owned(),
+                ],
+                orbital_rotations: [alpha.as_array().to_owned(), beta.as_array().to_owned()],
+            },
+        )
         .collect();
     reconstruct_t2_alpha_beta(&terms, norb, nocc_a, nocc_b).into_pyarray(py)
 }
@@ -243,15 +227,13 @@ pub fn py_reconstruct_t2_alpha_beta<'py>(
 #[pymodule]
 pub mod double_factorized {
     #[pymodule_export]
-    use super::py_modified_cholesky;
-    #[pymodule_export]
     use super::py_double_factorized;
     #[pymodule_export]
     use super::py_double_factorized_t2;
     #[pymodule_export]
-    use super::py_reconstruct_t2;
-    #[pymodule_export]
     use super::py_double_factorized_t2_alpha_beta;
+    #[pymodule_export]
+    use super::py_reconstruct_t2;
     #[pymodule_export]
     use super::py_reconstruct_t2_alpha_beta;
 }

--- a/crates/pyext/src/linalg/double_factorized.rs
+++ b/crates/pyext/src/linalg/double_factorized.rs
@@ -1,0 +1,257 @@
+// This code is a Qiskit project.
+//
+// (C) Copyright IBM 2026.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use num_complex::Complex64;
+use numpy::{IntoPyArray, PyArray2, PyArray4, PyReadonlyArray2, PyReadonlyArray4};
+use pyo3::prelude::*;
+use pyo3_stub_gen::derive::*;
+use qiskit_fermions_core::linalg::double_factorized::{
+    DoubleFactorizedT2AlphaBetaTerm, DoubleFactorizedTerm, double_factorized,
+    double_factorized_t2, double_factorized_t2_alpha_beta, modified_cholesky, reconstruct_t2,
+    reconstruct_t2_alpha_beta,
+};
+
+/// A double-factorized term as exposed to Python: a 2-tuple of the diagonal Coulomb matrix and the
+/// orbital rotation, both as numpy arrays.
+type PyDoubleFactorizedTerm<'py> = (Bound<'py, PyArray2<f64>>, Bound<'py, PyArray2<Complex64>>);
+
+/// An alpha-beta double-factorized term as exposed to Python: a 2-tuple of the three diagonal
+/// Coulomb matrices ``(aa, ab, bb)`` and the two orbital rotations ``(alpha, beta)``.
+type PyDoubleFactorizedT2AlphaBetaTerm<'py> = (
+    [Bound<'py, PyArray2<f64>>; 3],
+    [Bound<'py, PyArray2<Complex64>>; 2],
+);
+
+/// Converts a single core [`DoubleFactorizedTerm`] into its Python representation.
+fn term_into_py(py: Python<'_>, term: DoubleFactorizedTerm) -> PyDoubleFactorizedTerm<'_> {
+    let (diag_coulomb, orbital_rotation) = term;
+    (
+        diag_coulomb.into_pyarray(py),
+        orbital_rotation.into_pyarray(py),
+    )
+}
+
+/// Converts a single core [`DoubleFactorizedT2AlphaBetaTerm`] into its Python representation.
+fn alpha_beta_term_into_py(
+    py: Python<'_>,
+    term: DoubleFactorizedT2AlphaBetaTerm,
+) -> PyDoubleFactorizedT2AlphaBetaTerm<'_> {
+    let DoubleFactorizedT2AlphaBetaTerm {
+        diag_coulomb: [aa, ab, bb],
+        orbital_rotations: [alpha, beta],
+    } = term;
+    (
+        [aa.into_pyarray(py), ab.into_pyarray(py), bb.into_pyarray(py)],
+        [alpha.into_pyarray(py), beta.into_pyarray(py)],
+    )
+}
+
+/// Modified Cholesky decomposition of a Hermitian positive-semidefinite matrix.
+///
+/// Decomposes ``mat`` into a sum of outer products :math:`M = \sum_i v_i v_i^\dagger`, returning the
+/// vectors :math:`v_i` as the columns of the result. The number of terms is governed by ``tol``,
+/// while ``max_vecs`` (default: the matrix dimension) is always respected even if it forces the
+/// truncation error above ``tol``.
+///
+/// Arguments:
+///     mat: the Hermitian positive-semidefinite matrix, :math:`M`, to decompose.
+///     tol: the tolerance controlling the truncation error of the decomposition.
+///     max_vecs: the maximum number of Cholesky vectors to retain. Defaults to the dimension of
+///         ``mat``.
+///
+/// Returns:
+///     A 2-dimensional array whose columns are the Cholesky vectors :math:`v_i`.
+#[gen_stub_pyfunction(module = "qiskit_fermions.linalg.double_factorized")]
+#[pyfunction(name = "modified_cholesky", signature = (mat, tol, max_vecs=None))]
+pub fn py_modified_cholesky<'py>(
+    py: Python<'py>,
+    mat: PyReadonlyArray2<Complex64>,
+    tol: f64,
+    max_vecs: Option<usize>,
+) -> Bound<'py, PyArray2<Complex64>> {
+    modified_cholesky(&mat.as_array().to_owned(), tol, max_vecs).into_pyarray(py)
+}
+
+/// Double-factorized decomposition of a real two-body tensor.
+///
+/// Represents
+/// :math:`h_{pqrs} = \sum_t \sum_{kl} Z^{(t)}_{kl} U^{(t)}_{pk} U^{(t)}_{qk} U^{(t)}_{rl} U^{(t)}_{sl}`,
+/// returning a list of :math:`(Z, U)` terms where each :math:`Z` is a real symmetric diagonal
+/// Coulomb matrix and each :math:`U` is a unitary orbital rotation.
+///
+/// When ``cholesky`` is ``True`` (the default behavior in the original library) the outer
+/// factorization uses a modified Cholesky decomposition; otherwise it uses a truncated
+/// eigendecomposition.
+///
+/// Arguments:
+///     two_body_tensor: the real two-body tensor of shape ``(norb, norb, norb, norb)``.
+///     tol: the tolerance controlling the truncation error of the decomposition.
+///     max_vecs: the maximum number of terms to retain. Defaults to ``norb * (norb + 1) / 2``.
+///     cholesky: whether to use the modified Cholesky decomposition (``True``) or a truncated
+///         eigendecomposition (``False``) for the outer factorization.
+///
+/// Returns:
+///     A list of :math:`(Z, U)` 2-tuples, where ``Z`` is the diagonal Coulomb matrix and ``U`` is
+///     the orbital rotation.
+#[gen_stub_pyfunction(module = "qiskit_fermions.linalg.double_factorized")]
+#[pyfunction(name = "double_factorized", signature = (two_body_tensor, tol, max_vecs=None, cholesky=true))]
+pub fn py_double_factorized<'py>(
+    py: Python<'py>,
+    two_body_tensor: PyReadonlyArray4<f64>,
+    tol: f64,
+    max_vecs: Option<usize>,
+    cholesky: bool,
+) -> Vec<PyDoubleFactorizedTerm<'py>> {
+    double_factorized(&two_body_tensor.as_array().to_owned(), tol, max_vecs, cholesky)
+        .into_iter()
+        .map(|term| term_into_py(py, term))
+        .collect()
+}
+
+/// Double-factorized decomposition of spin-restricted :math:`t_2` amplitudes.
+///
+/// Factorizes :math:`t_{ijab}` (with :math:`i, j` occupied and :math:`a, b` virtual) into a list of
+/// :math:`(Z, U)` terms suitable for reconstruction by :func:`reconstruct_t2`. The number of terms
+/// is truncated to ``max_terms`` (default: all).
+///
+/// Arguments:
+///     t2_amplitudes: the :math:`t_2` amplitudes of shape ``(nocc, nocc, nvrt, nvrt)``.
+///     tol: the tolerance controlling the truncation error of the decomposition.
+///     max_terms: the maximum number of terms to retain. Defaults to all.
+///
+/// Returns:
+///     A list of :math:`(Z, U)` 2-tuples, where ``Z`` is the diagonal Coulomb matrix and ``U`` is
+///     the orbital rotation.
+#[gen_stub_pyfunction(module = "qiskit_fermions.linalg.double_factorized")]
+#[pyfunction(name = "double_factorized_t2", signature = (t2_amplitudes, tol, max_terms=None))]
+pub fn py_double_factorized_t2<'py>(
+    py: Python<'py>,
+    t2_amplitudes: PyReadonlyArray4<Complex64>,
+    tol: f64,
+    max_terms: Option<usize>,
+) -> Vec<PyDoubleFactorizedTerm<'py>> {
+    double_factorized_t2(&t2_amplitudes.as_array().to_owned(), tol, max_terms)
+        .into_iter()
+        .map(|term| term_into_py(py, term))
+        .collect()
+}
+
+/// Reconstructs spin-restricted :math:`t_2` amplitudes from a double-factorized decomposition.
+///
+/// Computes
+/// :math:`i \sum_k \sum_{pq} Z^{(k)}_{pq} U^{(k)}_{ap} U^{(k)*}_{ip} U^{(k)}_{bq} U^{(k)*}_{jq}`
+/// and slices to the occupied/virtual block ``[:nocc, :nocc, nocc:, nocc:]``.
+///
+/// Arguments:
+///     terms: the list of :math:`(Z, U)` 2-tuples produced by :func:`double_factorized_t2`.
+///     nocc: the number of occupied orbitals.
+///
+/// Returns:
+///     The reconstructed :math:`t_2` amplitudes of shape ``(nocc, nocc, nvrt, nvrt)``.
+#[gen_stub_pyfunction(module = "qiskit_fermions.linalg.double_factorized")]
+#[pyfunction(name = "reconstruct_t2", signature = (terms, nocc))]
+pub fn py_reconstruct_t2<'py>(
+    py: Python<'py>,
+    terms: Vec<(PyReadonlyArray2<'py, f64>, PyReadonlyArray2<'py, Complex64>)>,
+    nocc: usize,
+) -> Bound<'py, PyArray4<Complex64>> {
+    let terms: Vec<DoubleFactorizedTerm> = terms
+        .into_iter()
+        .map(|(z, u)| (z.as_array().to_owned(), u.as_array().to_owned()))
+        .collect();
+    reconstruct_t2(&terms, nocc).into_pyarray(py)
+}
+
+/// Double-factorized decomposition of alpha-beta (spin-unrestricted) :math:`t_2` amplitudes.
+///
+/// Returns a list of terms suitable for reconstruction by :func:`reconstruct_t2_alpha_beta`. The
+/// number of terms is truncated to ``max_terms`` (default: all).
+///
+/// Arguments:
+///     t2_amplitudes: the alpha-beta :math:`t_2` amplitudes of shape
+///         ``(nocc_a, nocc_b, nvrt_a, nvrt_b)``.
+///     tol: the tolerance controlling the truncation error of the decomposition.
+///     max_terms: the maximum number of terms to retain. Defaults to all.
+///
+/// Returns:
+///     A list of 2-tuples, each consisting of
+///
+///     * a 3-tuple of the diagonal Coulomb matrices in the order ``(aa, ab, bb)``
+///     * a 2-tuple of the orbital rotations in the order ``(alpha, beta)``
+#[gen_stub_pyfunction(module = "qiskit_fermions.linalg.double_factorized")]
+#[pyfunction(name = "double_factorized_t2_alpha_beta", signature = (t2_amplitudes, tol, max_terms=None))]
+pub fn py_double_factorized_t2_alpha_beta<'py>(
+    py: Python<'py>,
+    t2_amplitudes: PyReadonlyArray4<Complex64>,
+    tol: f64,
+    max_terms: Option<usize>,
+) -> Vec<PyDoubleFactorizedT2AlphaBetaTerm<'py>> {
+    double_factorized_t2_alpha_beta(&t2_amplitudes.as_array().to_owned(), tol, max_terms)
+        .into_iter()
+        .map(|term| alpha_beta_term_into_py(py, term))
+        .collect()
+}
+
+/// Reconstructs alpha-beta :math:`t_2` amplitudes from a double-factorized decomposition.
+///
+/// Arguments:
+///     terms: the list of terms produced by :func:`double_factorized_t2_alpha_beta`, each a 2-tuple
+///         of the ``(aa, ab, bb)`` diagonal Coulomb matrices and the ``(alpha, beta)`` orbital
+///         rotations.
+///     norb: the number of orbitals.
+///     nocc_a: the number of alpha-occupied orbitals.
+///     nocc_b: the number of beta-occupied orbitals.
+///
+/// Returns:
+///     The reconstructed alpha-beta :math:`t_2` amplitudes of shape
+///     ``(nocc_a, nocc_b, nvrt_a, nvrt_b)``.
+#[gen_stub_pyfunction(module = "qiskit_fermions.linalg.double_factorized")]
+#[pyfunction(name = "reconstruct_t2_alpha_beta", signature = (terms, norb, nocc_a, nocc_b))]
+pub fn py_reconstruct_t2_alpha_beta<'py>(
+    py: Python<'py>,
+    terms: Vec<(
+        [PyReadonlyArray2<'py, f64>; 3],
+        [PyReadonlyArray2<'py, Complex64>; 2],
+    )>,
+    norb: usize,
+    nocc_a: usize,
+    nocc_b: usize,
+) -> Bound<'py, PyArray4<Complex64>> {
+    let terms: Vec<DoubleFactorizedT2AlphaBetaTerm> = terms
+        .into_iter()
+        .map(|([aa, ab, bb], [alpha, beta])| DoubleFactorizedT2AlphaBetaTerm {
+            diag_coulomb: [
+                aa.as_array().to_owned(),
+                ab.as_array().to_owned(),
+                bb.as_array().to_owned(),
+            ],
+            orbital_rotations: [alpha.as_array().to_owned(), beta.as_array().to_owned()],
+        })
+        .collect();
+    reconstruct_t2_alpha_beta(&terms, norb, nocc_a, nocc_b).into_pyarray(py)
+}
+
+#[pymodule]
+pub mod double_factorized {
+    #[pymodule_export]
+    use super::py_modified_cholesky;
+    #[pymodule_export]
+    use super::py_double_factorized;
+    #[pymodule_export]
+    use super::py_double_factorized_t2;
+    #[pymodule_export]
+    use super::py_reconstruct_t2;
+    #[pymodule_export]
+    use super::py_double_factorized_t2_alpha_beta;
+    #[pymodule_export]
+    use super::py_reconstruct_t2_alpha_beta;
+}

--- a/crates/pyext/src/linalg/givens.rs
+++ b/crates/pyext/src/linalg/givens.rs
@@ -38,7 +38,7 @@ use qiskit_fermions_core::linalg::givens::{GivensRotation, givens_decomposition}
 ///    -s^\dagger & c
 ///    \end{pmatrix}
 ///
-/// Arguments:
+/// Args:
 ///     unitary: the unitary matrix, :math:`U`, to be decomposed.
 ///
 /// Returns:

--- a/crates/pyext/src/linalg/mod.rs
+++ b/crates/pyext/src/linalg/mod.rs
@@ -12,10 +12,13 @@
 
 use pyo3::prelude::*;
 
+pub mod double_factorized;
 pub mod givens;
 
 #[pymodule]
 pub mod linalg {
+    #[pymodule_export]
+    use super::double_factorized::double_factorized;
     #[pymodule_export]
     use super::givens::givens;
 }

--- a/python/qiskit_fermions/linalg/__init__.py
+++ b/python/qiskit_fermions/linalg/__init__.py
@@ -24,7 +24,7 @@ This module provides various linear algebra utilities.
    :toctree: ../stubs/
 
    givens_decomposition
-   double_factorized
+   double_factorized_2body
    double_factorized_t2
    reconstruct_t2
    double_factorized_t2_alpha_beta
@@ -32,7 +32,7 @@ This module provides various linear algebra utilities.
 """
 
 from qiskit_fermions._lib.linalg.double_factorized import (
-    double_factorized,
+    double_factorized_2body,
     double_factorized_t2,
     double_factorized_t2_alpha_beta,
     reconstruct_t2,
@@ -41,7 +41,7 @@ from qiskit_fermions._lib.linalg.double_factorized import (
 from qiskit_fermions._lib.linalg.givens import givens_decomposition
 
 __all__ = [
-    "double_factorized",
+    "double_factorized_2body",
     "double_factorized_t2",
     "double_factorized_t2_alpha_beta",
     "givens_decomposition",

--- a/python/qiskit_fermions/linalg/__init__.py
+++ b/python/qiskit_fermions/linalg/__init__.py
@@ -24,10 +24,30 @@ This module provides various linear algebra utilities.
    :toctree: ../stubs/
 
    givens_decomposition
+   modified_cholesky
+   double_factorized
+   double_factorized_t2
+   reconstruct_t2
+   double_factorized_t2_alpha_beta
+   reconstruct_t2_alpha_beta
 """
 
+from qiskit_fermions._lib.linalg.double_factorized import (
+    double_factorized,
+    double_factorized_t2,
+    double_factorized_t2_alpha_beta,
+    modified_cholesky,
+    reconstruct_t2,
+    reconstruct_t2_alpha_beta,
+)
 from qiskit_fermions._lib.linalg.givens import givens_decomposition
 
 __all__ = [
     "givens_decomposition",
+    "modified_cholesky",
+    "double_factorized",
+    "double_factorized_t2",
+    "reconstruct_t2",
+    "double_factorized_t2_alpha_beta",
+    "reconstruct_t2_alpha_beta",
 ]

--- a/python/qiskit_fermions/linalg/__init__.py
+++ b/python/qiskit_fermions/linalg/__init__.py
@@ -24,7 +24,6 @@ This module provides various linear algebra utilities.
    :toctree: ../stubs/
 
    givens_decomposition
-   modified_cholesky
    double_factorized
    double_factorized_t2
    reconstruct_t2
@@ -36,7 +35,6 @@ from qiskit_fermions._lib.linalg.double_factorized import (
     double_factorized,
     double_factorized_t2,
     double_factorized_t2_alpha_beta,
-    modified_cholesky,
     reconstruct_t2,
     reconstruct_t2_alpha_beta,
 )
@@ -44,7 +42,6 @@ from qiskit_fermions._lib.linalg.givens import givens_decomposition
 
 __all__ = [
     "givens_decomposition",
-    "modified_cholesky",
     "double_factorized",
     "double_factorized_t2",
     "reconstruct_t2",

--- a/python/qiskit_fermions/linalg/__init__.py
+++ b/python/qiskit_fermions/linalg/__init__.py
@@ -41,10 +41,10 @@ from qiskit_fermions._lib.linalg.double_factorized import (
 from qiskit_fermions._lib.linalg.givens import givens_decomposition
 
 __all__ = [
-    "givens_decomposition",
     "double_factorized",
     "double_factorized_t2",
-    "reconstruct_t2",
     "double_factorized_t2_alpha_beta",
+    "givens_decomposition",
+    "reconstruct_t2",
     "reconstruct_t2_alpha_beta",
 ]

--- a/tests/python/linalg/test_double_factorized.py
+++ b/tests/python/linalg/test_double_factorized.py
@@ -34,7 +34,7 @@ from qiskit_fermions.linalg import (
     reconstruct_t2_alpha_beta,
 )
 
-from ..utils import random_t2_amplitudes, random_two_body_tensor, random_unitary
+from ..utils import random_t2_amplitudes, random_two_body_tensor
 
 RNG = np.random.default_rng(139632037091916421993148931543991464292)
 

--- a/tests/python/linalg/test_double_factorized.py
+++ b/tests/python/linalg/test_double_factorized.py
@@ -1,0 +1,239 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# The tests in this module were adapted from the ffsim library
+# (https://github.com/qiskit-community/ffsim, Apache-2.0, (C) IBM), specifically
+# ``tests/python/linalg/double_factorized_decomposition_test.py``. Only the tests covering the
+# decompositions ported here are included, and they are adapted to this package's API (which returns
+# a list of per-term ``(Z, U)`` tuples rather than stacked arrays) and to ``numpy.einsum`` (in place
+# of ``opt_einsum``). The tests exercising the ``optimize=True`` "compressed" code paths and the
+# pyscf-based molecular fixtures from the original are intentionally not ported.
+
+"""Tests for double factorization utilities."""
+
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+import pytest
+from qiskit_fermions.linalg import (
+    double_factorized,
+    double_factorized_t2,
+    double_factorized_t2_alpha_beta,
+    modified_cholesky,
+    reconstruct_t2,
+    reconstruct_t2_alpha_beta,
+)
+
+from ..utils import random_unitary
+
+RNG = np.random.default_rng(139632037091916421993148931543991464292)
+
+
+def random_two_body_tensor(dim: int, *, rank: int | None = None, seed=None) -> np.ndarray:
+    """Generates a random real two-body tensor with the standard two-body symmetries.
+
+    Mirrors ``ffsim.random.random_two_body_tensor`` with ``dtype=float``: it builds the tensor as a
+    sum of outer products of symmetric "Cholesky" matrices, which makes the reshaped
+    ``(dim**2, dim**2)`` matrix real symmetric positive semidefinite and hence exactly
+    double-factorizable by both the Cholesky and eigendecomposition paths.
+    """
+    rng = np.random.default_rng(seed)
+    if rank is None:
+        rank = dim * (dim + 1) // 2
+    cholesky_vecs = rng.standard_normal((rank, dim, dim))
+    cholesky_vecs += cholesky_vecs.transpose((0, 2, 1))
+    return np.einsum("ipr,iqs->prqs", cholesky_vecs, cholesky_vecs)
+
+
+def random_t2_amplitudes(norb: int, nocc: int, *, seed=None) -> np.ndarray:
+    """Generates random spin-restricted ``t2`` amplitudes.
+
+    Mirrors ``ffsim.random.random_t2_amplitudes`` with ``dtype=float``: the amplitudes satisfy the
+    restricted-CCSD symmetry ``t2[i, j, a, b] == t2[j, i, b, a]``, which makes the corresponding
+    reshaped matrix real symmetric and exactly representable by the explicit factorization.
+    """
+    rng = np.random.default_rng(seed)
+    nvrt = norb - nocc
+    t2 = np.zeros((nocc, nocc, nvrt, nvrt))
+    pairs = itertools.product(range(nocc), range(nocc, norb))
+    for (i, a), (j, b) in itertools.combinations_with_replacement(pairs, 2):
+        val = rng.standard_normal()
+        t2[i, j, a - nocc, b - nocc] = val
+        t2[j, i, b - nocc, a - nocc] = val
+    return t2
+
+
+def _stack_terms(terms):
+    """Stacks a list of ``(Z, U)`` terms into ``(diag_coulomb_mats, orbital_rotations)`` arrays."""
+    if not terms:
+        return np.empty((0,)), np.empty((0,))
+    diag_coulomb_mats = np.array([z for z, _ in terms])
+    orbital_rotations = np.array([u for _, u in terms])
+    return diag_coulomb_mats, orbital_rotations
+
+
+def _stack_alpha_beta_terms(terms):
+    """Stacks alpha-beta terms into ``(n, 3, norb, norb)`` and ``(n, 2, norb, norb)`` arrays."""
+    if not terms:
+        return np.empty((0,)), np.empty((0,))
+    diag_coulomb_mats = np.array([np.stack(z) for z, _ in terms])
+    orbital_rotations = np.array([np.stack(u) for _, u in terms])
+    return diag_coulomb_mats, orbital_rotations
+
+
+def _reconstruct_two_body(terms) -> np.ndarray:
+    """Reconstructs a two-body tensor from its double-factorized ``(Z, U)`` terms."""
+    diag_coulomb_mats, orbital_rotations = _stack_terms(terms)
+    return np.einsum(
+        "kpi,kqi,kij,krj,ksj->pqrs",
+        orbital_rotations,
+        orbital_rotations,
+        diag_coulomb_mats,
+        orbital_rotations,
+        orbital_rotations,
+    )
+
+
+@pytest.mark.parametrize("dim", range(6))
+def test_modified_cholesky(dim: int):
+    """Test modified Cholesky decomposition on a random tensor."""
+    # construct a random positive definite matrix
+    unitary = random_unitary(dim, seed=RNG)
+    eigs = RNG.uniform(size=dim)
+    mat = unitary @ np.diag(eigs) @ unitary.T.conj()
+    cholesky_vecs = modified_cholesky(mat, 1e-8, None)
+    reconstructed = np.einsum("ji,ki->jk", cholesky_vecs, cholesky_vecs.conj())
+    np.testing.assert_allclose(reconstructed, mat, atol=1e-8)
+
+
+@pytest.mark.parametrize("dim, cholesky", itertools.product(range(6), [False, True]))
+def test_double_factorized_random(dim: int, cholesky: bool):
+    """Test double-factorized decomposition on a random tensor."""
+    two_body_tensor = random_two_body_tensor(dim, seed=RNG)
+    terms = double_factorized(two_body_tensor, 1e-8, None, cholesky)
+    if dim == 0:
+        assert terms == []
+        return
+    reconstructed = _reconstruct_two_body(terms)
+    np.testing.assert_allclose(reconstructed, two_body_tensor, atol=1e-8)
+
+
+@pytest.mark.parametrize("cholesky", [True, False])
+def test_double_factorized_tol_max_vecs(cholesky: bool):
+    """Test double-factorized decomposition error threshold and max vecs."""
+    dim = 5
+    two_body_tensor = random_two_body_tensor(dim, seed=RNG)
+    full = double_factorized(two_body_tensor, 1e-8, None, cholesky)
+
+    # test max_vecs caps the number of returned terms
+    max_vecs = 3
+    terms = double_factorized(two_body_tensor, 1e-8, max_vecs, cholesky)
+    assert len(terms) == max_vecs
+    assert len(terms) <= len(full)
+
+    # test that a looser tolerance discards terms
+    loose = double_factorized(two_body_tensor, 1e-1, None, cholesky)
+    assert len(loose) <= len(full)
+    reconstructed = _reconstruct_two_body(loose) if loose else np.zeros_like(two_body_tensor)
+    np.testing.assert_allclose(reconstructed, two_body_tensor, atol=1e-1)
+
+    # test error threshold and max vecs together
+    terms = double_factorized(two_body_tensor, 1e-1, max_vecs, cholesky)
+    assert len(terms) <= max_vecs
+
+
+@pytest.mark.parametrize("norb, nocc", [(4, 2), (5, 2), (5, 3)])
+def test_double_factorized_t2_amplitudes_random(norb: int, nocc: int):
+    """Test double factorization of random t2 amplitudes."""
+    t2 = random_t2_amplitudes(norb, nocc, seed=RNG).astype(complex)
+    terms = double_factorized_t2(t2, 1e-8, None)
+    reconstructed = reconstruct_t2(terms, nocc=nocc)
+    np.testing.assert_allclose(reconstructed, t2, atol=1e-8)
+
+    diag_coulomb_mats, orbital_rotations = _stack_terms(terms)
+    n_reps = len(terms)
+    even_index = list(range(0, n_reps, 2))
+    odd_index = list(range(1, n_reps, 2))
+    np.testing.assert_allclose(
+        diag_coulomb_mats[even_index], -diag_coulomb_mats[odd_index], atol=1e-8
+    )
+    np.testing.assert_allclose(
+        orbital_rotations[even_index], orbital_rotations[odd_index].conj(), atol=1e-8
+    )
+
+
+def test_double_factorized_t2_tol_max_terms():
+    """Test double-factorized t2 decomposition error threshold and max terms."""
+    norb, nocc = 5, 2
+    t2 = random_t2_amplitudes(norb, nocc, seed=RNG).astype(complex)
+    full = double_factorized_t2(t2, 1e-8, None)
+
+    # test max_terms caps the number of returned terms
+    max_terms = 3
+    terms = double_factorized_t2(t2, 1e-8, max_terms)
+    assert len(terms) == max_terms
+    assert len(terms) <= len(full)
+
+    # test error threshold and max terms together
+    terms = double_factorized_t2(t2, 1e-1, max_terms)
+    assert len(terms) <= max_terms
+
+
+def test_double_factorized_t2_alpha_beta_random():
+    """Test double factorization of opposite-spin t2 amplitudes with random tensor."""
+    shape = (3, 6, 7, 4)
+    t2ab = RNG.standard_normal(shape)
+    terms = double_factorized_t2_alpha_beta(t2ab.astype(complex), 1e-8, None)
+    nocc_a, nocc_b, nvrt_a, _ = t2ab.shape
+    norb = nocc_a + nvrt_a
+    reconstructed = reconstruct_t2_alpha_beta(terms, norb, nocc_a, nocc_b)
+    np.testing.assert_allclose(reconstructed, t2ab, atol=1e-8)
+
+    diag_coulomb_mats, orbital_rotations = _stack_alpha_beta_terms(terms)
+    n_reps = len(terms)
+    index_0 = list(range(0, n_reps, 4))
+    index_1 = list(range(1, n_reps, 4))
+    index_2 = list(range(2, n_reps, 4))
+    index_3 = list(range(3, n_reps, 4))
+
+    np.testing.assert_allclose(diag_coulomb_mats[index_0], -diag_coulomb_mats[index_1], atol=1e-8)
+    np.testing.assert_allclose(diag_coulomb_mats[index_0], -diag_coulomb_mats[index_2], atol=1e-8)
+    np.testing.assert_allclose(diag_coulomb_mats[index_0], diag_coulomb_mats[index_3], atol=1e-8)
+
+    np.testing.assert_allclose(
+        orbital_rotations[index_0, 0], orbital_rotations[index_1, 0], atol=1e-8
+    )
+    np.testing.assert_allclose(
+        orbital_rotations[index_0, 0], orbital_rotations[index_2, 0].conj(), atol=1e-8
+    )
+    np.testing.assert_allclose(
+        orbital_rotations[index_0, 0], orbital_rotations[index_3, 0].conj(), atol=1e-8
+    )
+
+
+def test_double_factorized_t2_alpha_beta_tol_max_terms():
+    """Test double-factorized alpha-beta t2 decomposition error threshold and max terms."""
+    shape = (3, 6, 7, 4)
+    t2ab = RNG.standard_normal(shape).astype(complex)
+    full = double_factorized_t2_alpha_beta(t2ab, 1e-8, None)
+
+    # test max_terms caps the number of returned terms
+    max_terms = 5
+    terms = double_factorized_t2_alpha_beta(t2ab, 1e-8, max_terms)
+    assert len(terms) == max_terms
+    assert len(terms) <= len(full)
+
+    # test error threshold and max terms together
+    terms = double_factorized_t2_alpha_beta(t2ab, 1e-1, max_terms)
+    assert len(terms) <= max_terms

--- a/tests/python/linalg/test_double_factorized.py
+++ b/tests/python/linalg/test_double_factorized.py
@@ -27,7 +27,7 @@ import itertools
 import numpy as np
 import pytest
 from qiskit_fermions.linalg import (
-    double_factorized,
+    double_factorized_2body,
     double_factorized_t2,
     double_factorized_t2_alpha_beta,
     reconstruct_t2,
@@ -74,7 +74,7 @@ def _reconstruct_two_body(terms) -> np.ndarray:
 def test_double_factorized_random(dim: int, cholesky: bool):
     """Test double-factorized decomposition on a random tensor."""
     two_body_tensor = random_two_body_tensor(dim, seed=RNG)
-    terms = double_factorized(two_body_tensor, 1e-8, None, cholesky)
+    terms = double_factorized_2body(two_body_tensor, 1e-8, None, cholesky)
     if dim == 0:
         assert terms == []
         return
@@ -87,22 +87,22 @@ def test_double_factorized_tol_max_vecs(cholesky: bool):
     """Test double-factorized decomposition error threshold and max vecs."""
     dim = 5
     two_body_tensor = random_two_body_tensor(dim, seed=RNG)
-    full = double_factorized(two_body_tensor, 1e-8, None, cholesky)
+    full = double_factorized_2body(two_body_tensor, 1e-8, None, cholesky)
 
     # test max_vecs caps the number of returned terms
     max_vecs = 3
-    terms = double_factorized(two_body_tensor, 1e-8, max_vecs, cholesky)
+    terms = double_factorized_2body(two_body_tensor, 1e-8, max_vecs, cholesky)
     assert len(terms) == max_vecs
     assert len(terms) <= len(full)
 
     # test that a looser tolerance discards terms
-    loose = double_factorized(two_body_tensor, 1e-1, None, cholesky)
+    loose = double_factorized_2body(two_body_tensor, 1e-1, None, cholesky)
     assert len(loose) <= len(full)
     reconstructed = _reconstruct_two_body(loose) if loose else np.zeros_like(two_body_tensor)
     np.testing.assert_allclose(reconstructed, two_body_tensor, atol=1e-1)
 
     # test error threshold and max vecs together
-    terms = double_factorized(two_body_tensor, 1e-1, max_vecs, cholesky)
+    terms = double_factorized_2body(two_body_tensor, 1e-1, max_vecs, cholesky)
     assert len(terms) <= max_vecs
 
 

--- a/tests/python/linalg/test_double_factorized.py
+++ b/tests/python/linalg/test_double_factorized.py
@@ -35,43 +35,9 @@ from qiskit_fermions.linalg import (
     reconstruct_t2_alpha_beta,
 )
 
-from ..utils import random_unitary
+from ..utils import random_t2_amplitudes, random_two_body_tensor, random_unitary
 
 RNG = np.random.default_rng(139632037091916421993148931543991464292)
-
-
-def random_two_body_tensor(dim: int, *, rank: int | None = None, seed=None) -> np.ndarray:
-    """Generates a random real two-body tensor with the standard two-body symmetries.
-
-    Mirrors ``ffsim.random.random_two_body_tensor`` with ``dtype=float``: it builds the tensor as a
-    sum of outer products of symmetric "Cholesky" matrices, which makes the reshaped
-    ``(dim**2, dim**2)`` matrix real symmetric positive semidefinite and hence exactly
-    double-factorizable by both the Cholesky and eigendecomposition paths.
-    """
-    rng = np.random.default_rng(seed)
-    if rank is None:
-        rank = dim * (dim + 1) // 2
-    cholesky_vecs = rng.standard_normal((rank, dim, dim))
-    cholesky_vecs += cholesky_vecs.transpose((0, 2, 1))
-    return np.einsum("ipr,iqs->prqs", cholesky_vecs, cholesky_vecs)
-
-
-def random_t2_amplitudes(norb: int, nocc: int, *, seed=None) -> np.ndarray:
-    """Generates random spin-restricted ``t2`` amplitudes.
-
-    Mirrors ``ffsim.random.random_t2_amplitudes`` with ``dtype=float``: the amplitudes satisfy the
-    restricted-CCSD symmetry ``t2[i, j, a, b] == t2[j, i, b, a]``, which makes the corresponding
-    reshaped matrix real symmetric and exactly representable by the explicit factorization.
-    """
-    rng = np.random.default_rng(seed)
-    nvrt = norb - nocc
-    t2 = np.zeros((nocc, nocc, nvrt, nvrt))
-    pairs = itertools.product(range(nocc), range(nocc, norb))
-    for (i, a), (j, b) in itertools.combinations_with_replacement(pairs, 2):
-        val = rng.standard_normal()
-        t2[i, j, a - nocc, b - nocc] = val
-        t2[j, i, b - nocc, a - nocc] = val
-    return t2
 
 
 def _stack_terms(terms):

--- a/tests/python/linalg/test_double_factorized.py
+++ b/tests/python/linalg/test_double_factorized.py
@@ -30,7 +30,6 @@ from qiskit_fermions.linalg import (
     double_factorized,
     double_factorized_t2,
     double_factorized_t2_alpha_beta,
-    modified_cholesky,
     reconstruct_t2,
     reconstruct_t2_alpha_beta,
 )
@@ -69,18 +68,6 @@ def _reconstruct_two_body(terms) -> np.ndarray:
         orbital_rotations,
         orbital_rotations,
     )
-
-
-@pytest.mark.parametrize("dim", range(6))
-def test_modified_cholesky(dim: int):
-    """Test modified Cholesky decomposition on a random tensor."""
-    # construct a random positive definite matrix
-    unitary = random_unitary(dim, seed=RNG)
-    eigs = RNG.uniform(size=dim)
-    mat = unitary @ np.diag(eigs) @ unitary.T.conj()
-    cholesky_vecs = modified_cholesky(mat, 1e-8, None)
-    reconstructed = np.einsum("ji,ki->jk", cholesky_vecs, cholesky_vecs.conj())
-    np.testing.assert_allclose(reconstructed, mat, atol=1e-8)
 
 
 @pytest.mark.parametrize("dim, cholesky", itertools.product(range(6), [False, True]))

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -12,6 +12,8 @@
 
 """Testing utilities."""
 
+import itertools
+
 import numpy as np
 
 
@@ -22,3 +24,37 @@ def random_unitary(dim: int, *, seed=None, dtype=complex) -> np.ndarray:
     q, r = np.linalg.qr(z)
     d = np.diagonal(r)
     return q * (d / np.abs(d))
+
+
+def random_two_body_tensor(dim: int, *, rank: int | None = None, seed=None) -> np.ndarray:
+    """Generates a random real two-body tensor with the standard two-body symmetries.
+
+    Mirrors ``ffsim.random.random_two_body_tensor`` with ``dtype=float``: it builds the tensor as a
+    sum of outer products of symmetric "Cholesky" matrices, which makes the reshaped
+    ``(dim**2, dim**2)`` matrix real symmetric positive semidefinite and hence exactly
+    double-factorizable by both the Cholesky and eigendecomposition paths.
+    """
+    rng = np.random.default_rng(seed)
+    if rank is None:
+        rank = dim * (dim + 1) // 2
+    cholesky_vecs = rng.standard_normal((rank, dim, dim))
+    cholesky_vecs += cholesky_vecs.transpose((0, 2, 1))
+    return np.einsum("ipr,iqs->prqs", cholesky_vecs, cholesky_vecs)
+
+
+def random_t2_amplitudes(norb: int, nocc: int, *, seed=None) -> np.ndarray:
+    """Generates random spin-restricted ``t2`` amplitudes.
+
+    Mirrors ``ffsim.random.random_t2_amplitudes`` with ``dtype=float``: the amplitudes satisfy the
+    restricted-CCSD symmetry ``t2[i, j, a, b] == t2[j, i, b, a]``, which makes the corresponding
+    reshaped matrix real symmetric and exactly representable by the explicit factorization.
+    """
+    rng = np.random.default_rng(seed)
+    nvrt = norb - nocc
+    t2 = np.zeros((nocc, nocc, nvrt, nvrt))
+    pairs = itertools.product(range(nocc), range(nocc, norb))
+    for (i, a), (j, b) in itertools.combinations_with_replacement(pairs, 2):
+        val = rng.standard_normal()
+        t2[i, j, a - nocc, b - nocc] = val
+        t2[j, i, b - nocc, a - nocc] = val
+    return t2


### PR DESCRIPTION
In order to be able to implement commonly used variational circuit Ansätze like LUCJ or the effiicent time evolution of electronic structure Hamiltonians, we require the ability to compress the 2-body terms (and t2 amplitudes) through double factorization (https://arxiv.org/abs/2104.08957).

This PR is an AI-assisted port of `ffsim`'s Python-based implementation of these linear algebra routines to our internal `core` Rust crate. It also already exposes the public function to the Python API. The inclusion in the C API is post-poned.