### PR TITLE
feat: implement `OperatorTrait.num_groups`

### DIFF
--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -402,13 +402,16 @@ pub unsafe extern "C" fn qf_ferm_op_has_groups(op: *const FermionOperator) -> bo
 
 /// @ingroup qf_ferm_op
 ///
-/// @brief Gets the number of unique group indices from an operator.
+/// @brief Gets the number of groups from an operator.
 ///
-/// @param op A pointer to the fermionic operator whose number of group indices to get.
+/// @param op A pointer to the fermionic operator whose number of groups to get.
 ///
-/// @return The number of unique group indices from the operator's ``groups`` attribute.
+/// @return The number of group indices from the operator's ``groups`` attribute.
 ///
 /// @rst
+///
+/// .. note::
+///    The number of groups is evaluated lazily as the largest occurring group index plus 1.
 ///
 /// .. seealso::
 ///    The explanation on :ref:`grouping_explanation`.
@@ -428,11 +431,10 @@ pub unsafe extern "C" fn qf_ferm_op_has_groups(op: *const FermionOperator) -> bo
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qf_ferm_op_num_groups(op: *const FermionOperator) -> u32 {
     let op = unsafe { const_ptr_as_ref(op) };
-    let groups = &op.groups.as_ref().expect(
+    op.num_groups().expect(
         "Expected groups to be present. It is the user's responsibility to check this via \
         qf_ferm_op_has_groups before calling this function.",
-    );
-    groups.iter().max().unwrap() + 1
+    )
 }
 
 /// @ingroup qf_ferm_op

--- a/crates/cext/src/operators/majorana_operator.rs
+++ b/crates/cext/src/operators/majorana_operator.rs
@@ -342,13 +342,16 @@ pub unsafe extern "C" fn qf_maj_op_has_groups(op: *const MajoranaOperator) -> bo
 
 /// @ingroup qf_maj_op
 ///
-/// @brief Gets the number of unique group indices from an operator.
+/// @brief Gets the number of groups from an operator.
 ///
-/// @param op A pointer to the majorana operator whose number of group indices to get.
+/// @param op A pointer to the majorana operator whose number of groups to get.
 ///
-/// @return The number of unique group indices from the operator's ``groups`` attribute.
+/// @return The number of group indices from the operator's ``groups`` attribute.
 ///
 /// @rst
+///
+/// .. note::
+///    The number of groups is evaluated lazily as the largest occurring group index plus 1.
 ///
 /// .. seealso::
 ///    The explanation on :ref:`grouping_explanation`.
@@ -367,11 +370,10 @@ pub unsafe extern "C" fn qf_maj_op_has_groups(op: *const MajoranaOperator) -> bo
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qf_maj_op_num_groups(op: *const MajoranaOperator) -> u32 {
     let op = unsafe { const_ptr_as_ref(op) };
-    let groups = &op.groups.as_ref().expect(
+    op.num_groups().expect(
         "Expected groups to be present. It is the user's responsibility to check this via \
         qf_maj_op_has_groups before calling this function.",
-    );
-    groups.iter().max().unwrap() + 1
+    )
 }
 
 /// @ingroup qf_maj_op

--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -93,9 +93,18 @@ impl EdgeVertexOperator {
         })
     }
 
+    pub fn num_groups(&self) -> Option<u32> {
+        let self_groups = self.groups.as_ref()?;
+        if self_groups.len() == 0 {
+            Some(0)
+        } else {
+            Some(self_groups.iter().max().unwrap() + 1)
+        }
+    }
+
     pub fn split_out_groups(&self) -> Option<Vec<Self>> {
         let self_groups = self.groups.as_ref()?;
-        let num_groups = self_groups.iter().max().unwrap() + 1;
+        let num_groups = self.num_groups()?;
         let mut groups = vec![Self::zero(); num_groups as usize];
         for (group_idx, term) in zip(self_groups.iter(), self.iter()) {
             groups[*group_idx as usize]._append_term(

--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -95,7 +95,7 @@ impl EdgeVertexOperator {
 
     pub fn num_groups(&self) -> Option<u32> {
         let self_groups = self.groups.as_ref()?;
-        if self_groups.len() == 0 {
+        if self_groups.is_empty() {
             Some(0)
         } else {
             Some(self_groups.iter().max().unwrap() + 1)

--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -1050,6 +1050,22 @@ mod tests {
     }
 
     #[test]
+    fn test_num_groups() {
+        let mut zero = EdgeVertexOperator::zero();
+
+        assert!(zero.num_groups().is_none());
+
+        zero.groups = Some(vec![]);
+
+        assert_eq!(zero.num_groups(), Some(0));
+
+        let mut one = EdgeVertexOperator::one();
+        one.groups = Some(vec![0]);
+
+        assert_eq!(one.num_groups(), Some(1));
+    }
+
+    #[test]
     fn test_split_out_groups() {
         let op = EdgeVertexOperator {
             coeffs: vec![

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -96,9 +96,18 @@ impl FermionOperator {
         })
     }
 
+    pub fn num_groups(&self) -> Option<u32> {
+        let self_groups = self.groups.as_ref()?;
+        if self_groups.len() == 0 {
+            Some(0)
+        } else {
+            Some(self_groups.iter().max().unwrap() + 1)
+        }
+    }
+
     pub fn split_out_groups(&self) -> Option<Vec<Self>> {
         let self_groups = self.groups.as_ref()?;
-        let num_groups = self_groups.iter().max().unwrap() + 1;
+        let num_groups = self.num_groups()?;
         let mut groups = vec![Self::zero(); num_groups as usize];
         for (group_idx, term) in zip(self_groups.iter(), self.iter()) {
             groups[*group_idx as usize]._append_term(term.coeff, term.actions, term.modes);

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -1133,6 +1133,22 @@ mod tests {
     }
 
     #[test]
+    fn test_num_groups() {
+        let mut zero = FermionOperator::zero();
+
+        assert!(zero.num_groups().is_none());
+
+        zero.groups = Some(vec![]);
+
+        assert_eq!(zero.num_groups(), Some(0));
+
+        let mut one = FermionOperator::one();
+        one.groups = Some(vec![0]);
+
+        assert_eq!(one.num_groups(), Some(1));
+    }
+
+    #[test]
     fn test_split_out_groups() {
         let op = FermionOperator {
             coeffs: vec![

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -98,7 +98,7 @@ impl FermionOperator {
 
     pub fn num_groups(&self) -> Option<u32> {
         let self_groups = self.groups.as_ref()?;
-        if self_groups.len() == 0 {
+        if self_groups.is_empty() {
             Some(0)
         } else {
             Some(self_groups.iter().max().unwrap() + 1)

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -88,7 +88,7 @@ impl MajoranaOperator {
 
     pub fn num_groups(&self) -> Option<u32> {
         let self_groups = self.groups.as_ref()?;
-        if self_groups.len() == 0 {
+        if self_groups.is_empty() {
             Some(0)
         } else {
             Some(self_groups.iter().max().unwrap() + 1)

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -1012,6 +1012,22 @@ mod tests {
     }
 
     #[test]
+    fn test_num_groups() {
+        let mut zero = MajoranaOperator::zero();
+
+        assert!(zero.num_groups().is_none());
+
+        zero.groups = Some(vec![]);
+
+        assert_eq!(zero.num_groups(), Some(0));
+
+        let mut one = MajoranaOperator::one();
+        one.groups = Some(vec![0]);
+
+        assert_eq!(one.num_groups(), Some(1));
+    }
+
+    #[test]
     fn test_split_out_groups() {
         let op = MajoranaOperator {
             coeffs: vec![

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -86,9 +86,18 @@ impl MajoranaOperator {
         })
     }
 
+    pub fn num_groups(&self) -> Option<u32> {
+        let self_groups = self.groups.as_ref()?;
+        if self_groups.len() == 0 {
+            Some(0)
+        } else {
+            Some(self_groups.iter().max().unwrap() + 1)
+        }
+    }
+
     pub fn split_out_groups(&self) -> Option<Vec<Self>> {
         let self_groups = self.groups.as_ref()?;
-        let num_groups = self_groups.iter().max().unwrap() + 1;
+        let num_groups = self.num_groups()?;
         let mut groups = vec![Self::zero(); num_groups as usize];
         for (group_idx, term) in zip(self_groups.iter(), self.iter()) {
             groups[*group_idx as usize]._append_term(term.coeff, term.modes);

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -1095,6 +1095,22 @@ mod tests {
     }
 
     #[test]
+    fn test_num_groups() {
+        let mut zero = TransferVertexOperator::zero();
+
+        assert!(zero.num_groups().is_none());
+
+        zero.groups = Some(vec![]);
+
+        assert_eq!(zero.num_groups(), Some(0));
+
+        let mut one = TransferVertexOperator::one();
+        one.groups = Some(vec![0]);
+
+        assert_eq!(one.num_groups(), Some(1));
+    }
+
+    #[test]
     fn test_split_out_groups() {
         let op = TransferVertexOperator {
             coeffs: vec![

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -97,7 +97,7 @@ impl TransferVertexOperator {
 
     pub fn num_groups(&self) -> Option<u32> {
         let self_groups = self.groups.as_ref()?;
-        if self_groups.len() == 0 {
+        if self_groups.is_empty() {
             Some(0)
         } else {
             Some(self_groups.iter().max().unwrap() + 1)

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -95,9 +95,18 @@ impl TransferVertexOperator {
         })
     }
 
+    pub fn num_groups(&self) -> Option<u32> {
+        let self_groups = self.groups.as_ref()?;
+        if self_groups.len() == 0 {
+            Some(0)
+        } else {
+            Some(self_groups.iter().max().unwrap() + 1)
+        }
+    }
+
     pub fn split_out_groups(&self) -> Option<Vec<Self>> {
         let self_groups = self.groups.as_ref()?;
-        let num_groups = self_groups.iter().max().unwrap() + 1;
+        let num_groups = self.num_groups()?;
         let mut groups = vec![Self::zero(); num_groups as usize];
         for (group_idx, term) in zip(self_groups.iter(), self.iter()) {
             groups[*group_idx as usize]._append_term(

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -851,6 +851,31 @@ impl PyEdgeVertexOperator {
         self.inner.groups = groups;
     }
 
+    /// Returns the number of groups.
+    ///
+    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
+    /// return the number of groups which is defined to be the largest occurring group index plus
+    /// 1 (which may therefore be used as the index for the next group).
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import EdgeVertexOperator
+    ///     >>> op = EdgeVertexOperator(
+    ///     ...     [1.0, 2.0, -1.0],
+    ///     ...     [0, 1, 2, 3],
+    ///     ...     [1, 0, 3, 2],
+    ///     ...     [0, 1, 3, 4],
+    ///     ... )
+    ///     >>> op.groups = [0, 1, 0]
+    ///     >>> op.num_groups()
+    ///     2
+    ///
+    /// Returns:
+    ///     The largest group index in :attr:`groups` plus 1.
+    pub fn num_groups(&self) -> Option<u32> {
+        self.inner.num_groups()
+    }
+
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -797,6 +797,31 @@ impl PyFermionOperator {
         self.inner.groups = groups;
     }
 
+    /// Returns the number of groups.
+    ///
+    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
+    /// return the number of groups which is defined to be the largest occurring group index plus
+    /// 1 (which may therefore be used as the index for the next group).
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator(
+    ///     ...     [1.0, 2.0, -1.0, -2.0],
+    ///     ...     [True, False, True, False, True, False, True, False],
+    ///     ...     [0, 1, 2, 3, 1, 0, 3, 2],
+    ///     ...     [0, 2, 4, 6, 8],
+    ///     ... )
+    ///     >>> op.groups = [0, 1, 0, 1]
+    ///     >>> op.num_groups()
+    ///     2
+    ///
+    /// Returns:
+    ///     The largest group index in :attr:`groups` plus 1.
+    pub fn num_groups(&self) -> Option<u32> {
+        self.inner.num_groups()
+    }
+
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -755,6 +755,30 @@ impl PyMajoranaOperator {
         self.inner.groups = groups;
     }
 
+    /// Returns the number of groups.
+    ///
+    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
+    /// return the number of groups which is defined to be the largest occurring group index plus
+    /// 1 (which may therefore be used as the index for the next group).
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import MajoranaOperator
+    ///     >>> op = MajoranaOperator(
+    ///     ...     [1.0, 2.0, -1.0, -2.0],
+    ///     ...     [0, 1, 2, 3, 1, 0, 3, 2],
+    ///     ...     [0, 2, 4, 6, 8],
+    ///     ... )
+    ///     >>> op.groups = [0, 1, 0, 1]
+    ///     >>> op.num_groups()
+    ///     2
+    ///
+    /// Returns:
+    ///     The largest group index in :attr:`groups` plus 1.
+    pub fn num_groups(&self) -> Option<u32> {
+        self.inner.num_groups()
+    }
+
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -856,6 +856,31 @@ impl PyTransferVertexOperator {
         self.inner.groups = groups;
     }
 
+    /// Returns the number of groups.
+    ///
+    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
+    /// return the number of groups which is defined to be the largest occurring group index plus
+    /// 1 (which may therefore be used as the index for the next group).
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import TransferVertexOperator
+    ///     >>> op = TransferVertexOperator(
+    ///     ...     [1.0, 2.0, -1.0],
+    ///     ...     [0, 1, 2, 3],
+    ///     ...     [1, 0, 3, 2],
+    ///     ...     [0, 1, 3, 4],
+    ///     ... )
+    ///     >>> op.groups = [0, 1, 0]
+    ///     >>> op.num_groups()
+    ///     2
+    ///
+    /// Returns:
+    ///     The largest group index in :attr:`groups` plus 1.
+    pub fn num_groups(&self) -> Option<u32> {
+        self.inner.num_groups()
+    }
+
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will

--- a/python/qiskit_fermions/operators/protocol.py
+++ b/python/qiskit_fermions/operators/protocol.py
@@ -123,5 +123,8 @@ class OperatorTrait(Protocol):
     def groups(self, groups: list[int] | None) -> None:
         """Sets the groups indices."""
 
+    def num_groups(self) -> int | None:
+        """Returns the number of groups."""
+
     def split_out_groups(self) -> list[Self]:
         """Splits this operator into an optional list of new operators based on its :attr:`.groups`."""

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -336,7 +336,7 @@ class TestEdgeVertexOperator:
             permutation = [4, 2, 5]
             op.relabel_modes(permutation)
 
-    def test_split_out_groups(self):
+    def test_split_out_groups(self, subtests):
         cls = self.get_class()
 
         # NOTE: we rely on Python dict's insertion order to guarantee the correct order of terms in
@@ -347,11 +347,20 @@ class TestEdgeVertexOperator:
         op = cls.from_dict(group0)
         group1 = {((1, 0), (2, 3)): 2}
         op += cls.from_dict(group1)
+
+        with subtests.test("num_groups none"):
+            assert op.num_groups() is None
+
         op.groups = [0, 0, 1]
+
+        with subtests.test("num_groups some"):
+            assert op.num_groups() == 2
 
         groups = op.split_out_groups()
         expected = [cls.from_dict(group0), cls.from_dict(group1)]
-        assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
+
+        with subtests.test("split groups"):
+            assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
 
     def test_split_out_groups_err(self):
         cls = self.get_class()

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -403,7 +403,7 @@ class TestFermionOperator:
             permutation = [4, 2, 5]
             op.relabel_modes(permutation)
 
-    def test_split_out_groups(self):
+    def test_split_out_groups(self, subtests):
         cls = self.get_class()
 
         # NOTE: we rely on Python dict's insertion order to guarantee the correct order of terms in
@@ -414,11 +414,20 @@ class TestFermionOperator:
         op = cls.from_dict(group0)
         group1 = {(cre(0), cre(0), ann(1), ann(1)): 2}
         op += cls.from_dict(group1)
+
+        with subtests.test("num_groups none"):
+            assert op.num_groups() is None
+
         op.groups = [0, 0, 1]
+
+        with subtests.test("num_groups some"):
+            assert op.num_groups() == 2
 
         groups = op.split_out_groups()
         expected = [cls.from_dict(group0), cls.from_dict(group1)]
-        assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
+
+        with subtests.test("split groups"):
+            assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
 
     def test_split_out_groups_err(self):
         cls = self.get_class()

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -377,7 +377,7 @@ class TestMajoranaOperator:
             permutation = [4, 2, 5]
             op.relabel_modes(permutation)
 
-    def test_split_out_groups(self):
+    def test_split_out_groups(self, subtests):
         cls = self.get_class()
 
         # NOTE: we rely on Python dict's insertion order to guarantee the correct order of terms in
@@ -388,11 +388,20 @@ class TestMajoranaOperator:
         op = cls.from_dict(group0)
         group1 = {(0, 0, 1, 1): 2}
         op += cls.from_dict(group1)
+
+        with subtests.test("num_groups none"):
+            assert op.num_groups() is None
+
         op.groups = [0, 0, 1]
+
+        with subtests.test("num_groups some"):
+            assert op.num_groups() == 2
 
         groups = op.split_out_groups()
         expected = [cls.from_dict(group0), cls.from_dict(group1)]
-        assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
+
+        with subtests.test("split groups"):
+            assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
 
     def test_split_out_groups_err(self):
         cls = self.get_class()

--- a/tests/python/operators/test_transfer_vertex_operator.py
+++ b/tests/python/operators/test_transfer_vertex_operator.py
@@ -352,7 +352,7 @@ class TestTransferVertexOperator:
             permutation = [4, 2, 5]
             op.relabel_modes(permutation)
 
-    def test_split_out_groups(self):
+    def test_split_out_groups(self, subtests):
         cls = self.get_class()
 
         # NOTE: we rely on Python dict's insertion order to guarantee the correct order of terms in
@@ -363,11 +363,20 @@ class TestTransferVertexOperator:
         op = cls.from_dict(group0)
         group1 = {((1, 0), (2, 3)): 2}
         op += cls.from_dict(group1)
+
+        with subtests.test("num_groups none"):
+            assert op.num_groups() is None
+
         op.groups = [0, 0, 1]
+
+        with subtests.test("num_groups some"):
+            assert op.num_groups() == 2
 
         groups = op.split_out_groups()
         expected = [cls.from_dict(group0), cls.from_dict(group1)]
-        assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
+
+        with subtests.test("split groups"):
+            assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
 
     def test_split_out_groups_err(self):
         cls = self.get_class()


### PR DESCRIPTION
We already had an equivalent function on the C API, but now I'm moving that to the Rust core and am adding it to the Python API, too. The main motivation is to provide better handling of edge-cases, e.g. when `op.groups == []`.

That said, it also makes a future implementation of tracking electronic structure term grouping during the FCIDump parsing a lot easier (I will follow up with a PR on that soon).