### PR TITLE
Group terms while loading an `FCIDump`

### DIFF
--- a/crates/core/src/operators/grouping/electronic_structure.rs
+++ b/crates/core/src/operators/grouping/electronic_structure.rs
@@ -228,11 +228,12 @@ mod tests {
         let fcidump = FCIDump::from_file(file_path);
 
         let op = FermionOperator::from(&fcidump);
-
-        let groups = op.split_out_groups();
+        // NOTE: even though the FCIDump loading automatically tracks groups, we can reduce the
+        // overall number of groups by first normal-ordering the Hamiltonian and grouping the
+        // remaining terms.
         assert!(
-            groups.is_none(),
-            "We should not have any group indices yet!"
+            op.num_groups() == Some(23),
+            "Expected 23 groups to be found by the FCIDump parsing."
         );
 
         let mut normal = op.normal_ordered(None).simplify(1e-16);
@@ -277,11 +278,12 @@ mod tests {
         let fcidump = FCIDump::from_file(file_path);
 
         let op = FermionOperator::from(&fcidump);
-
-        let groups = op.split_out_groups();
+        // NOTE: even though the FCIDump loading automatically tracks groups, we can reduce the
+        // overall number of groups by first normal-ordering the Hamiltonian and grouping the
+        // remaining terms.
         assert!(
-            groups.is_none(),
-            "We should not have any group indices yet!"
+            op.num_groups() == Some(23),
+            "Expected 23 groups to be found by the FCIDump parsing."
         );
 
         let mut normal = op.normal_ordered(None).simplify(1e-16);

--- a/crates/core/src/operators/library/electronic_integrals.rs
+++ b/crates/core/src/operators/library/electronic_integrals.rs
@@ -100,13 +100,16 @@ pub trait From1Body {
 
 impl FermionOperator {
     #[inline]
-    fn _insert_1body_idx(op: &mut Self, c: Complex64, i: u32, a: u32) {
+    fn _insert_1body_idx(op: &mut Self, c: Complex64, i: u32, a: u32, group_idx: Option<u32>) {
         op.coeffs.push(c);
         op.actions.push(true);
         op.actions.push(false);
         op.modes.push(i);
         op.modes.push(a);
         op.boundaries.push(op.modes.len());
+        if let Some(idx) = group_idx {
+            op.groups.as_mut().unwrap().push(idx);
+        }
         if i != a {
             op.coeffs.push(c);
             op.actions.push(true);
@@ -114,11 +117,22 @@ impl FermionOperator {
             op.modes.push(a);
             op.modes.push(i);
             op.boundaries.push(op.modes.len());
+            if let Some(idx) = group_idx {
+                op.groups.as_mut().unwrap().push(idx);
+            }
         }
     }
 
     #[inline]
-    fn _insert_2body_idx(op: &mut Self, c: Complex64, i: u32, j: u32, b: u32, a: u32) {
+    fn _insert_2body_idx(
+        op: &mut Self,
+        c: Complex64,
+        i: u32,
+        j: u32,
+        b: u32,
+        a: u32,
+        group_idx: Option<u32>,
+    ) {
         op.coeffs.push(c);
         op.actions.push(true);
         op.actions.push(true);
@@ -129,6 +143,9 @@ impl FermionOperator {
         op.modes.push(b);
         op.modes.push(a);
         op.boundaries.push(op.modes.len());
+        if let Some(idx) = group_idx {
+            op.groups.as_mut().unwrap().push(idx);
+        }
     }
 }
 
@@ -140,13 +157,16 @@ impl From1Body for FermionOperator {
             .for_each(|(ia, &coeff)| {
                 let (i, a) = _inflate_index(ia as u32);
                 let c = Complex64::new(coeff, 0.0);
-                Self::_insert_1body_idx(self, c, i, a);
-                Self::_insert_1body_idx(self, c, i + norb, a + norb);
+                let mut next_group_idx = self.num_groups();
+                Self::_insert_1body_idx(self, c, i, a, next_group_idx);
+                next_group_idx = self.num_groups();
+                Self::_insert_1body_idx(self, c, i + norb, a + norb, next_group_idx);
             });
     }
 
     fn from_1body_tril_spin_sym(one_body_a: ArrayView1<f64>, norb: u32) -> Self {
         let mut op = Self::zero();
+        op.groups = Some(vec![]);
         op.add_1body_tril_spin_sym(one_body_a, norb);
         op
     }
@@ -163,7 +183,8 @@ impl From1Body for FermionOperator {
             .for_each(|(ia, &coeff)| {
                 let (i, a) = _inflate_index(ia as u32);
                 let c = Complex64::new(coeff, 0.0);
-                Self::_insert_1body_idx(self, c, i, a);
+                let next_group_idx = self.num_groups();
+                Self::_insert_1body_idx(self, c, i, a, next_group_idx);
             });
 
         one_body_b
@@ -172,7 +193,8 @@ impl From1Body for FermionOperator {
             .for_each(|(ia, &coeff)| {
                 let (i, a) = _inflate_index(ia as u32);
                 let c = Complex64::new(coeff, 0.0);
-                Self::_insert_1body_idx(self, c, i + norb, a + norb);
+                let next_group_idx = self.num_groups();
+                Self::_insert_1body_idx(self, c, i + norb, a + norb, next_group_idx);
             });
     }
 
@@ -182,6 +204,7 @@ impl From1Body for FermionOperator {
         norb: u32,
     ) -> Self {
         let mut op = Self::zero();
+        op.groups = Some(vec![]);
         op.add_1body_tril_spin(one_body_a, one_body_b, norb);
         op
     }
@@ -219,19 +242,32 @@ impl From2Body for FermionOperator {
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
             .for_each(|(iajb, &coeff)| {
                 let c = Complex64::new(0.5 * coeff, 0.0);
+                let next_group_idx = self.num_groups();
+                let group_idx_ab = next_group_idx.map(|x| x + 1);
+                let group_idx_ba = next_group_idx.map(|x| x + 2);
+                let group_idx_bb = next_group_idx.map(|x| x + 3);
                 _expand_s8_index(iajb as u32)
                     .iter()
                     .for_each(|&(i, a, j, b)| {
-                        Self::_insert_2body_idx(self, c, i, j, b, a);
-                        Self::_insert_2body_idx(self, c, i + norb, j, b, a + norb);
-                        Self::_insert_2body_idx(self, c, i, j + norb, b + norb, a);
-                        Self::_insert_2body_idx(self, c, i + norb, j + norb, b + norb, a + norb);
+                        Self::_insert_2body_idx(self, c, i, j, b, a, next_group_idx);
+                        Self::_insert_2body_idx(self, c, i + norb, j, b, a + norb, group_idx_ab);
+                        Self::_insert_2body_idx(self, c, i, j + norb, b + norb, a, group_idx_ba);
+                        Self::_insert_2body_idx(
+                            self,
+                            c,
+                            i + norb,
+                            j + norb,
+                            b + norb,
+                            a + norb,
+                            group_idx_bb,
+                        );
                     });
             });
     }
 
     fn from_2body_tril_spin_sym(two_body_aa: ArrayView1<f64>, norb: u32) -> Self {
         let mut op = Self::zero();
+        op.groups = Some(vec![]);
         op.add_2body_tril_spin_sym(two_body_aa, norb);
         op
     }
@@ -248,10 +284,11 @@ impl From2Body for FermionOperator {
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
             .for_each(|(iajb, &coeff)| {
                 let c = Complex64::new(0.5 * coeff, 0.0);
+                let next_group_idx = self.num_groups();
                 _expand_s8_index(iajb as u32)
                     .iter()
                     .for_each(|&(i, a, j, b)| {
-                        Self::_insert_2body_idx(self, c, i, j, b, a);
+                        Self::_insert_2body_idx(self, c, i, j, b, a, next_group_idx);
                     });
             });
 
@@ -261,11 +298,13 @@ impl From2Body for FermionOperator {
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
             .for_each(|(iajb, &coeff)| {
                 let c = Complex64::new(0.5 * coeff, 0.0);
+                let next_group_idx = self.num_groups();
+                let group_idx_b = next_group_idx.map(|x| x + 1);
                 _expand_s4_index(iajb as u32, npair)
                     .iter()
                     .for_each(|&(i, a, j, b)| {
-                        Self::_insert_2body_idx(self, c, i, j + norb, b + norb, a);
-                        Self::_insert_2body_idx(self, c, j + norb, i, a, b + norb);
+                        Self::_insert_2body_idx(self, c, i, j + norb, b + norb, a, next_group_idx);
+                        Self::_insert_2body_idx(self, c, j + norb, i, a, b + norb, group_idx_b);
                     });
             });
 
@@ -274,10 +313,19 @@ impl From2Body for FermionOperator {
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
             .for_each(|(iajb, &coeff)| {
                 let c = Complex64::new(0.5 * coeff, 0.0);
+                let next_group_idx = self.num_groups();
                 _expand_s8_index(iajb as u32)
                     .iter()
                     .for_each(|&(i, a, j, b)| {
-                        Self::_insert_2body_idx(self, c, i + norb, j + norb, b + norb, a + norb);
+                        Self::_insert_2body_idx(
+                            self,
+                            c,
+                            i + norb,
+                            j + norb,
+                            b + norb,
+                            a + norb,
+                            next_group_idx,
+                        );
                     });
             });
     }
@@ -289,6 +337,7 @@ impl From2Body for FermionOperator {
         norb: u32,
     ) -> Self {
         let mut op = Self::zero();
+        op.groups = Some(vec![]);
         op.add_2body_tril_spin(two_body_aa, two_body_ab, two_body_bb, norb);
         op
     }
@@ -316,7 +365,7 @@ mod tests {
             actions: [true, false].iter().cloned().cycle().take(16).collect(),
             modes: vec![0, 0, 2, 2, 1, 0, 0, 1, 3, 2, 2, 3, 1, 1, 3, 3],
             boundaries: vec![0, 2, 4, 6, 8, 10, 12, 14, 16],
-            groups: None,
+            groups: Some(vec![0, 1, 2, 2, 3, 3, 4, 5]),
         };
 
         assert_eq!(op, expected);
@@ -342,7 +391,7 @@ mod tests {
             actions: [true, false].iter().cloned().cycle().take(16).collect(),
             modes: vec![0, 0, 1, 0, 0, 1, 1, 1, 2, 2, 3, 2, 2, 3, 3, 3],
             boundaries: vec![0, 2, 4, 6, 8, 10, 12, 14, 16],
-            groups: None,
+            groups: Some(vec![0, 1, 1, 2, 3, 4, 4, 5]),
         };
 
         assert_eq!(op, expected);
@@ -384,7 +433,11 @@ mod tests {
                 3, 3, 3, 3,
             ],
             boundaries: (0..257).step_by(4).collect(),
-            groups: None,
+            groups: Some(vec![
+                0, 1, 2, 3, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7, 8, 9, 10, 11, 8, 9, 10,
+                11, 8, 9, 10, 11, 8, 9, 10, 11, 12, 13, 14, 15, 12, 13, 14, 15, 16, 17, 18, 19, 16,
+                17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 20, 21, 22, 23,
+            ]),
         };
 
         assert_eq!(op, expected);
@@ -434,7 +487,11 @@ mod tests {
                 3, 3, 3, 3,
             ],
             boundaries: (0..257).step_by(4).collect(),
-            groups: None,
+            groups: Some(vec![
+                0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 4, 4, 5, 6, 7, 8, 9, 8, 9, 10, 11, 12, 13,
+                12, 13, 14, 15, 14, 15, 14, 15, 14, 15, 16, 17, 16, 17, 18, 19, 20, 21, 20, 21, 22,
+                23, 24, 25, 25, 25, 25, 26, 26, 26, 26, 27, 27, 28, 28, 28, 28, 29,
+            ]),
         };
 
         assert_eq!(op, expected);

--- a/crates/core/src/operators/library/fcidump.rs
+++ b/crates/core/src/operators/library/fcidump.rs
@@ -183,10 +183,12 @@ impl FCIDump {
 impl From<&FCIDump> for FermionOperator {
     fn from(fcidump: &FCIDump) -> Self {
         let mut op = Self::zero();
+        op.groups = Some(vec![]);
 
         if let Some(coeff) = fcidump.constant {
             op.coeffs.push(Complex64::new(coeff, 0.0));
             op.boundaries.push(op.boundaries.len() - 1);
+            op.groups = Some(vec![0]);
         };
 
         match &fcidump.one_body_b {
@@ -348,10 +350,13 @@ mod tests {
                 72, 76, 80, 84, 88, 92, 96, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140,
                 144,
             ],
-            groups: None,
+            groups: Some(vec![
+                0, 1, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 10, 11, 12, 13, 10, 11, 12, 13,
+                10, 11, 12, 13, 14, 15, 16, 17, 14, 15, 16, 17, 18, 19, 20, 21,
+            ]),
         };
 
-        assert!(op.equiv(&expected, 1e-10));
+        assert_eq!(op, expected);
     }
 
     #[test]
@@ -576,10 +581,14 @@ mod tests {
                 208, 212, 216, 220, 224, 228, 232, 236, 240, 244, 248, 252, 256, 260, 264, 268,
                 272,
             ],
-            groups: None,
+            groups: Some(vec![
+                0, 1, 1, 2, 3, 4, 4, 5, 6, 7, 7, 7, 7, 8, 8, 8, 8, 9, 9, 10, 10, 10, 10, 11, 12,
+                13, 14, 15, 14, 15, 16, 17, 18, 19, 18, 19, 20, 21, 20, 21, 20, 21, 20, 21, 22, 23,
+                22, 23, 24, 25, 26, 27, 26, 27, 28, 29, 30, 31, 31, 31, 31, 32, 32, 32, 32, 33, 33,
+                34, 34, 34, 34, 35,
+            ]),
         };
 
-        println!("{op:#?}");
-        assert!(op.equiv(&expected, 1e-10));
+        assert_eq!(op, expected);
     }
 }

--- a/tests/c/test_electronic_integrals.c
+++ b/tests/c/test_electronic_integrals.c
@@ -31,6 +31,9 @@ static int test_ferm_op_from_1body_tril_spin_sym(void) {
     QfFermionOperator *expected = qf_ferm_op_new(num_terms, num_actions, coeffs_exp, actions_exp,
                                                  indices_exp, boundaries_exp);
 
+    uint32_t groups[8] = {0, 1, 2, 2, 3, 3, 4, 5};
+    qf_ferm_op_set_groups(expected, groups, 8);
+
     bool is_equal = qf_ferm_op_equal(op, expected);
 
     qf_ferm_op_free(op);
@@ -58,6 +61,9 @@ static int test_ferm_op_from_1body_tril_spin(void) {
     uint32_t boundaries_exp[9] = {0, 2, 4, 6, 8, 10, 12, 14, 16};
     QfFermionOperator *expected = qf_ferm_op_new(num_terms, num_actions, coeffs_exp, actions_exp,
                                                  indices_exp, boundaries_exp);
+
+    uint32_t groups[8] = {0, 1, 1, 2, 3, 4, 4, 5};
+    qf_ferm_op_set_groups(expected, groups, 8);
 
     bool is_equal = qf_ferm_op_equal(op, expected);
 
@@ -127,6 +133,13 @@ static int test_ferm_op_from_2body_tril_spin_sym(void) {
 
     QfFermionOperator *expected = qf_ferm_op_new(num_terms, num_actions, coeffs_exp, actions_exp,
                                                  indices_exp, boundaries_exp);
+
+    uint32_t groups[64] = {
+        0,  1,  2,  3,  4,  5,  6,  7,  4,  5,  6,  7,  4,  5,  6,  7,  4,  5,  6,  7,  8,  9,
+        10, 11, 8,  9,  10, 11, 8,  9,  10, 11, 8,  9,  10, 11, 12, 13, 14, 15, 12, 13, 14, 15,
+        16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 16, 17, 18, 19, 20, 21, 22, 23,
+    };
+    qf_ferm_op_set_groups(expected, groups, 64);
 
     bool is_equal = qf_ferm_op_equal(op, expected);
 
@@ -198,6 +211,13 @@ static int test_ferm_op_from_2body_tril_spin(void) {
                                    208, 212, 216, 220, 224, 228, 232, 236, 240, 244, 248, 252, 256};
     QfFermionOperator *expected = qf_ferm_op_new(num_terms, num_actions, coeffs_exp, actions_exp,
                                                  indices_exp, boundaries_exp);
+
+    uint32_t groups[64] = {
+        0,  1,  1,  1,  1,  2,  2,  2,  2,  3,  3,  4,  4,  4,  4,  5,  6,  7,  8,  9,  8,  9,
+        10, 11, 12, 13, 12, 13, 14, 15, 14, 15, 14, 15, 14, 15, 16, 17, 16, 17, 18, 19, 20, 21,
+        20, 21, 22, 23, 24, 25, 25, 25, 25, 26, 26, 26, 26, 27, 27, 28, 28, 28, 28, 29,
+    };
+    qf_ferm_op_set_groups(expected, groups, 64);
 
     bool is_equal = qf_ferm_op_equal(op, expected);
 

--- a/tests/python/operators/grouping/test_electronic_structure.py
+++ b/tests/python/operators/grouping/test_electronic_structure.py
@@ -31,7 +31,10 @@ def test_group_terms_by_electronic_structure():
     fcidump = FCIDump.from_file(str(file_path))
 
     op = FermionOperator.from_fcidump(fcidump)
-    assert op.groups is None, "We should not have any group indices yet!"
+    # NOTE: even though the FCIDump loading automatically tracks groups, we can reduce the
+    # overall number of groups by first normal-ordering the Hamiltonian and grouping the
+    # remaining terms.
+    assert op.num_groups() == 23, "Expected 23 groups to be found by the FCIDump parsing."
 
     normal = op.normal_ordered().simplify(atol=1e-16)
 
@@ -40,9 +43,7 @@ def test_group_terms_by_electronic_structure():
     )
     assert res is None, "We should not have a GroupingError here!"
     assert normal.groups is not None, "Now we should have group indices!"
-    assert max(normal.groups) == 13, (
-        "The number of groups we expect is 14, meaning the highest group index should be 13!"
-    )
+    assert normal.num_groups() == 14, "The number of groups we expect is 14!"
 
     groups = normal.split_out_groups()
     assert len(groups) == 14, "Expected 14 individual operators, one for each group."

--- a/tests/python/transpiler/passes/test_qdrift_optimization.py
+++ b/tests/python/transpiler/passes/test_qdrift_optimization.py
@@ -31,6 +31,7 @@ def test_qdrift_optimization_no_groups(subtests):
     fcidump = FCIDump.from_file(str(file_path))
     num_modes = 2 * fcidump.norb
     hamil = FermionOperator.from_fcidump(fcidump)
+    hamil.groups = None
     time = 1.5
     circ = FermionicCircuit(num_modes)
     evo = Evolution(num_modes, hamil, time=time)


### PR DESCRIPTION
This follows up on #149 by automatically tracking the grouping of electronic structure terms when loading integrals from an FCIDump file.

We keep the SqDRIFT tutorial unchanged, since normal-ordering the operator first and grouping afterwards, can result in an equivalent operator with fewer groups. Exposing both paths, however, gives more flexibility to the user.