### PR TITLE
Add operator iterator methods with groups

### DIFF
--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -41,6 +41,28 @@ impl EdgeVertexOperatorTermView<'_> {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EdgeVertexOperatorGroupTermView<'a> {
+    pub coeff: Complex64,
+    pub left_indices: &'a [u32],
+    pub right_indices: &'a [u32],
+    pub group: u32,
+}
+
+impl EdgeVertexOperatorGroupTermView<'_> {
+    pub fn iter(&'_ self) -> impl ExactSizeIterator<Item = EdgeAction<'_>> + '_ {
+        zip(self.left_indices, self.right_indices)
+    }
+
+    pub fn to_vec(&'_ self) -> Vec<EdgeAction<'_>> {
+        zip(self.left_indices, self.right_indices).collect()
+    }
+
+    pub fn into_vec(&'_ self) -> Vec<(u32, u32)> {
+        zip(self.left_indices.to_vec(), self.right_indices.to_vec()).collect()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct EdgeVertexOperator {
     pub coeffs: Vec<Complex64>,
@@ -93,6 +115,29 @@ impl EdgeVertexOperator {
         })
     }
 
+    pub fn iter_with_groups(
+        &'_ self,
+    ) -> impl ExactSizeIterator<Item = EdgeVertexOperatorGroupTermView<'_>> + '_ {
+        if let Some(groups) = &self.groups {
+            return self
+                .coeffs
+                .iter()
+                .zip(groups)
+                .enumerate()
+                .map(|(i, (coeff, gidx))| {
+                    let start = self.boundaries[i];
+                    let end = self.boundaries[i + 1];
+                    EdgeVertexOperatorGroupTermView {
+                        coeff: *coeff,
+                        left_indices: &self.left_indices[start..end],
+                        right_indices: &self.right_indices[start..end],
+                        group: *gidx,
+                    }
+                });
+        }
+        panic!("This method can only be called when groups are present!");
+    }
+
     pub fn num_groups(&self) -> Option<u32> {
         let self_groups = self.groups.as_ref()?;
         if self_groups.is_empty() {
@@ -103,11 +148,9 @@ impl EdgeVertexOperator {
     }
 
     pub fn split_out_groups(&self) -> Option<Vec<Self>> {
-        let self_groups = self.groups.as_ref()?;
-        let num_groups = self.num_groups()?;
-        let mut groups = vec![Self::zero(); num_groups as usize];
-        for (group_idx, term) in zip(self_groups.iter(), self.iter()) {
-            groups[*group_idx as usize]._append_term(
+        let mut groups = vec![Self::zero(); self.num_groups()? as usize];
+        for term in self.iter_with_groups() {
+            groups[term.group as usize]._append_term(
                 term.coeff,
                 term.left_indices,
                 term.right_indices,
@@ -1116,5 +1159,45 @@ mod tests {
 
         let groups = op.split_out_groups();
         assert!(groups.is_none());
+    }
+
+    #[test]
+    fn test_iter_with_groups() {
+        let op = EdgeVertexOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 0.0),
+            ],
+            left_indices: vec![0, 2, 1, 3],
+            right_indices: vec![1, 3, 0, 2],
+            boundaries: vec![0, 1, 2, 4],
+            groups: Some(vec![0, 0, 1]),
+        };
+
+        let terms: Vec<EdgeVertexOperatorGroupTermView> = op.iter_with_groups().collect();
+
+        let expected = vec![
+            EdgeVertexOperatorGroupTermView {
+                coeff: Complex64::new(1.0, 0.0),
+                left_indices: &[0],
+                right_indices: &[1],
+                group: 0,
+            },
+            EdgeVertexOperatorGroupTermView {
+                coeff: Complex64::new(1.0, 0.0),
+                left_indices: &[2],
+                right_indices: &[3],
+                group: 0,
+            },
+            EdgeVertexOperatorGroupTermView {
+                coeff: Complex64::new(2.0, 0.0),
+                left_indices: &[1, 3],
+                right_indices: &[0, 2],
+                group: 1,
+            },
+        ];
+
+        assert_eq!(terms, expected);
     }
 }

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -33,7 +33,27 @@ impl FermionOperatorTermView<'_> {
         zip(self.actions, self.modes)
     }
 
-    // TODO: refactor these following methods
+    pub fn to_vec(&'_ self) -> Vec<FermionAction<'_>> {
+        zip(self.actions, self.modes).collect()
+    }
+
+    pub fn into_vec(&'_ self) -> Vec<(bool, u32)> {
+        zip(self.actions.to_vec(), self.modes.to_vec()).collect()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FermionOperatorGroupTermView<'a> {
+    pub coeff: Complex64,
+    pub actions: &'a [bool],
+    pub modes: &'a [u32],
+    pub group: u32,
+}
+
+impl FermionOperatorGroupTermView<'_> {
+    pub fn iter(&'_ self) -> impl ExactSizeIterator<Item = FermionAction<'_>> + '_ {
+        zip(self.actions, self.modes)
+    }
 
     pub fn to_vec(&'_ self) -> Vec<FermionAction<'_>> {
         zip(self.actions, self.modes).collect()
@@ -96,6 +116,29 @@ impl FermionOperator {
         })
     }
 
+    pub fn iter_with_groups(
+        &'_ self,
+    ) -> impl ExactSizeIterator<Item = FermionOperatorGroupTermView<'_>> + '_ {
+        if let Some(groups) = &self.groups {
+            return self
+                .coeffs
+                .iter()
+                .zip(groups)
+                .enumerate()
+                .map(|(i, (coeff, gidx))| {
+                    let start = self.boundaries[i];
+                    let end = self.boundaries[i + 1];
+                    FermionOperatorGroupTermView {
+                        coeff: *coeff,
+                        actions: &self.actions[start..end],
+                        modes: &self.modes[start..end],
+                        group: *gidx,
+                    }
+                });
+        }
+        panic!("This method can only be called when groups are present!");
+    }
+
     pub fn num_groups(&self) -> Option<u32> {
         let self_groups = self.groups.as_ref()?;
         if self_groups.is_empty() {
@@ -106,11 +149,9 @@ impl FermionOperator {
     }
 
     pub fn split_out_groups(&self) -> Option<Vec<Self>> {
-        let self_groups = self.groups.as_ref()?;
-        let num_groups = self.num_groups()?;
-        let mut groups = vec![Self::zero(); num_groups as usize];
-        for (group_idx, term) in zip(self_groups.iter(), self.iter()) {
-            groups[*group_idx as usize]._append_term(term.coeff, term.actions, term.modes);
+        let mut groups = vec![Self::zero(); self.num_groups()? as usize];
+        for term in self.iter_with_groups() {
+            groups[term.group as usize]._append_term(term.coeff, term.actions, term.modes);
         }
         Some(groups)
     }
@@ -1199,5 +1240,45 @@ mod tests {
 
         let groups = op.split_out_groups();
         assert!(groups.is_none());
+    }
+
+    #[test]
+    fn test_iter_with_groups() {
+        let op = FermionOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 0.0),
+            ],
+            actions: vec![true, false, true, false, true, true, false, false],
+            modes: vec![0, 1, 1, 0, 0, 0, 1, 1],
+            boundaries: vec![0, 2, 4, 8],
+            groups: Some(vec![0, 0, 1]),
+        };
+
+        let terms: Vec<FermionOperatorGroupTermView> = op.iter_with_groups().collect();
+
+        let expected = vec![
+            FermionOperatorGroupTermView {
+                coeff: Complex64::new(1.0, 0.0),
+                actions: &[true, false],
+                modes: &[0, 1],
+                group: 0,
+            },
+            FermionOperatorGroupTermView {
+                coeff: Complex64::new(1.0, 0.0),
+                actions: &[true, false],
+                modes: &[1, 0],
+                group: 0,
+            },
+            FermionOperatorGroupTermView {
+                coeff: Complex64::new(2.0, 0.0),
+                actions: &[true, true, false, false],
+                modes: &[0, 0, 1, 1],
+                group: 1,
+            },
+        ];
+
+        assert_eq!(terms, expected);
     }
 }

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -13,7 +13,6 @@
 use crate::operators::{CoherenceError, OperatorMacro, OperatorTrait};
 use num_complex::{Complex64, ComplexFloat};
 use std::collections::{HashMap, HashSet};
-use std::iter::zip;
 use std::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign,
 };
@@ -31,7 +30,26 @@ impl MajoranaOperatorTermView<'_> {
         self.modes.iter()
     }
 
-    // TODO: refactor these following methods
+    pub fn to_vec(&'_ self) -> Vec<MajoranaAction<'_>> {
+        self.modes.iter().collect()
+    }
+
+    pub fn into_vec(&'_ self) -> Vec<u32> {
+        self.modes.to_vec()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MajoranaOperatorGroupTermView<'a> {
+    pub coeff: Complex64,
+    pub modes: &'a [u32],
+    pub group: u32,
+}
+
+impl MajoranaOperatorGroupTermView<'_> {
+    pub fn iter(&'_ self) -> impl ExactSizeIterator<Item = MajoranaAction<'_>> + '_ {
+        self.modes.iter()
+    }
 
     pub fn to_vec(&'_ self) -> Vec<MajoranaAction<'_>> {
         self.modes.iter().collect()
@@ -86,6 +104,28 @@ impl MajoranaOperator {
         })
     }
 
+    pub fn iter_with_groups(
+        &'_ self,
+    ) -> impl ExactSizeIterator<Item = MajoranaOperatorGroupTermView<'_>> + '_ {
+        if let Some(groups) = &self.groups {
+            return self
+                .coeffs
+                .iter()
+                .zip(groups)
+                .enumerate()
+                .map(|(i, (coeff, gidx))| {
+                    let start = self.boundaries[i];
+                    let end = self.boundaries[i + 1];
+                    MajoranaOperatorGroupTermView {
+                        coeff: *coeff,
+                        modes: &self.modes[start..end],
+                        group: *gidx,
+                    }
+                });
+        }
+        panic!("This method can only be called when groups are present!");
+    }
+
     pub fn num_groups(&self) -> Option<u32> {
         let self_groups = self.groups.as_ref()?;
         if self_groups.is_empty() {
@@ -96,11 +136,9 @@ impl MajoranaOperator {
     }
 
     pub fn split_out_groups(&self) -> Option<Vec<Self>> {
-        let self_groups = self.groups.as_ref()?;
-        let num_groups = self.num_groups()?;
-        let mut groups = vec![Self::zero(); num_groups as usize];
-        for (group_idx, term) in zip(self_groups.iter(), self.iter()) {
-            groups[*group_idx as usize]._append_term(term.coeff, term.modes);
+        let mut groups = vec![Self::zero(); self.num_groups()? as usize];
+        for term in self.iter_with_groups() {
+            groups[term.group as usize]._append_term(term.coeff, term.modes);
         }
         Some(groups)
     }
@@ -1074,5 +1112,41 @@ mod tests {
 
         let groups = op.split_out_groups();
         assert!(groups.is_none());
+    }
+
+    #[test]
+    fn test_iter_with_groups() {
+        let op = MajoranaOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 0.0),
+            ],
+            modes: vec![0, 1, 1, 0, 0, 0, 1, 1],
+            boundaries: vec![0, 2, 4, 8],
+            groups: Some(vec![0, 0, 1]),
+        };
+
+        let terms: Vec<MajoranaOperatorGroupTermView> = op.iter_with_groups().collect();
+
+        let expected = vec![
+            MajoranaOperatorGroupTermView {
+                coeff: Complex64::new(1.0, 0.0),
+                modes: &[0, 1],
+                group: 0,
+            },
+            MajoranaOperatorGroupTermView {
+                coeff: Complex64::new(1.0, 0.0),
+                modes: &[1, 0],
+                group: 0,
+            },
+            MajoranaOperatorGroupTermView {
+                coeff: Complex64::new(2.0, 0.0),
+                modes: &[0, 0, 1, 1],
+                group: 1,
+            },
+        ];
+
+        assert_eq!(terms, expected);
     }
 }

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -41,6 +41,28 @@ impl TransferVertexOperatorTermView<'_> {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TransferVertexOperatorGroupTermView<'a> {
+    pub coeff: Complex64,
+    pub left_indices: &'a [u32],
+    pub right_indices: &'a [u32],
+    pub group: u32,
+}
+
+impl TransferVertexOperatorGroupTermView<'_> {
+    pub fn iter(&'_ self) -> impl ExactSizeIterator<Item = TransferAction<'_>> + '_ {
+        zip(self.left_indices, self.right_indices)
+    }
+
+    pub fn to_vec(&'_ self) -> Vec<TransferAction<'_>> {
+        zip(self.left_indices, self.right_indices).collect()
+    }
+
+    pub fn into_vec(&'_ self) -> Vec<(u32, u32)> {
+        zip(self.left_indices.to_vec(), self.right_indices.to_vec()).collect()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct TransferVertexOperator {
     pub coeffs: Vec<Complex64>,
@@ -95,6 +117,29 @@ impl TransferVertexOperator {
         })
     }
 
+    pub fn iter_with_groups(
+        &'_ self,
+    ) -> impl ExactSizeIterator<Item = TransferVertexOperatorGroupTermView<'_>> + '_ {
+        if let Some(groups) = &self.groups {
+            return self
+                .coeffs
+                .iter()
+                .zip(groups)
+                .enumerate()
+                .map(|(i, (coeff, gidx))| {
+                    let start = self.boundaries[i];
+                    let end = self.boundaries[i + 1];
+                    TransferVertexOperatorGroupTermView {
+                        coeff: *coeff,
+                        left_indices: &self.left_indices[start..end],
+                        right_indices: &self.right_indices[start..end],
+                        group: *gidx,
+                    }
+                });
+        }
+        panic!("This method can only be called when groups are present!");
+    }
+
     pub fn num_groups(&self) -> Option<u32> {
         let self_groups = self.groups.as_ref()?;
         if self_groups.is_empty() {
@@ -105,11 +150,9 @@ impl TransferVertexOperator {
     }
 
     pub fn split_out_groups(&self) -> Option<Vec<Self>> {
-        let self_groups = self.groups.as_ref()?;
-        let num_groups = self.num_groups()?;
-        let mut groups = vec![Self::zero(); num_groups as usize];
-        for (group_idx, term) in zip(self_groups.iter(), self.iter()) {
-            groups[*group_idx as usize]._append_term(
+        let mut groups = vec![Self::zero(); self.num_groups()? as usize];
+        for term in self.iter_with_groups() {
+            groups[term.group as usize]._append_term(
                 term.coeff,
                 term.left_indices,
                 term.right_indices,
@@ -1161,5 +1204,45 @@ mod tests {
 
         let groups = op.split_out_groups();
         assert!(groups.is_none());
+    }
+
+    #[test]
+    fn test_iter_with_groups() {
+        let op = TransferVertexOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 0.0),
+            ],
+            left_indices: vec![0, 2, 1, 3],
+            right_indices: vec![1, 3, 0, 2],
+            boundaries: vec![0, 1, 2, 4],
+            groups: Some(vec![0, 0, 1]),
+        };
+
+        let terms: Vec<TransferVertexOperatorGroupTermView> = op.iter_with_groups().collect();
+
+        let expected = vec![
+            TransferVertexOperatorGroupTermView {
+                coeff: Complex64::new(1.0, 0.0),
+                left_indices: &[0],
+                right_indices: &[1],
+                group: 0,
+            },
+            TransferVertexOperatorGroupTermView {
+                coeff: Complex64::new(1.0, 0.0),
+                left_indices: &[2],
+                right_indices: &[3],
+                group: 0,
+            },
+            TransferVertexOperatorGroupTermView {
+                coeff: Complex64::new(2.0, 0.0),
+                left_indices: &[1, 3],
+                right_indices: &[0, 2],
+                group: 1,
+            },
+        ];
+
+        assert_eq!(terms, expected);
     }
 }

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -46,6 +46,27 @@ impl EdgeVertexOperatorDataIter {
     }
 }
 
+#[gen_stub_pyclass]
+#[pyclass(
+    module = "qiskit_fermions.operators.edge_vertex_operator",
+    name = "EdgeVertexOperatorDataGroupIter"
+)]
+struct EdgeVertexOperatorDataGroupIter {
+    inner: std::vec::IntoIter<(Vec<PyEdgeAction>, Complex64, u32)>,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl EdgeVertexOperatorDataGroupIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<(Vec<PyEdgeAction>, Complex64, u32)> {
+        slf.inner.next()
+    }
+}
+
 /// An edge-vertex operator.
 ///
 /// ----
@@ -834,6 +855,73 @@ impl PyEdgeVertexOperator {
             inner.boundaries.push(inner.right_indices.len());
             Ok(())
         })?;
+        Ok(Self { inner })
+    }
+
+    /// An iterator over the operator's terms with their associated group index.
+    ///
+    /// .. warning::
+    ///    Mutating the iteration items does **not** affect the underlying operator data.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import EdgeVertexOperator
+    ///     >>> op = EdgeVertexOperator([2.0, 1.0, -1.0j], [0, 0], [0, 1], [0, 0, 1, 2])
+    ///     >>> op.groups = [0, 1, 1]
+    ///     >>> list(op.iter_terms_with_groups())
+    ///     [([], (2+0j), 0), ([(0, 0)], (1+0j), 1), ([(0, 1)], (-0-1j), 1)]
+    ///
+    /// ..
+    fn iter_terms_with_groups(
+        slf: PyRef<'_, Self>,
+    ) -> PyResult<Py<EdgeVertexOperatorDataGroupIter>> {
+        let vectorized: Vec<(Vec<PyEdgeAction>, Complex64, u32)> = slf
+            .inner
+            .iter_with_groups()
+            .map(|term| (term.into_vec(), term.coeff, term.group))
+            .collect();
+        let iter = EdgeVertexOperatorDataGroupIter {
+            inner: vectorized.into_iter(),
+        };
+        Py::new(slf.py(), iter)
+    }
+
+    /// Constructs a new operator from an iterator of terms with groups (see also
+    /// :meth:`.iter_terms_with_groups`).
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import EdgeVertexOperator
+    ///     >>> op = EdgeVertexOperator([2.0, 1.0, -1.0j], [0, 0], [0, 1], [0, 0, 1, 2])
+    ///     >>> op.groups = [0, 1, 1]
+    ///     >>> reconstructed = EdgeVertexOperator.from_terms_with_groups(op.iter_terms_with_groups())
+    ///     >>> op.equiv(reconstructed) and op.groups == reconstructed.groups
+    ///     True
+    ///
+    /// Args:
+    ///     terms: an iterator of terms as produced by :meth:`.iter_terms_with_groups`.
+    ///
+    /// Returns:
+    ///     A new operator.
+    #[classmethod]
+    fn from_terms_with_groups(
+        _cls: &Bound<'_, PyType>,
+        terms: &Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
+        let mut inner = EdgeVertexOperator::zero();
+        let mut groups = vec![];
+        terms.try_iter()?.try_for_each(|item| -> PyResult<()> {
+            let (term, coeff, group) = item?.extract::<(Vec<PyEdgeAction>, Complex64, u32)>()?;
+            inner.coeffs.push(coeff);
+            term.iter().for_each(|(l, r)| {
+                inner.left_indices.push(*l);
+                inner.right_indices.push(*r);
+            });
+            inner.boundaries.push(inner.right_indices.len());
+            groups.push(group);
+            Ok(())
+        })?;
+        inner.groups = Some(groups);
         Ok(Self { inner })
     }
 

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -219,6 +219,7 @@ impl EdgeVertexOperatorDataGroupIter {
 ///    zero
 ///    one
 ///    from_terms
+///    from_terms_with_groups
 ///
 /// Formatting
 /// ----------
@@ -285,6 +286,7 @@ impl EdgeVertexOperatorDataGroupIter {
 /// .. autosummary::
 ///
 ///    iter_terms
+///    iter_terms_with_groups
 ///
 /// Arithmetics
 /// -----------

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -180,6 +180,7 @@ impl FermionOperatorDataGroupIter {
 ///    zero
 ///    one
 ///    from_terms
+///    from_terms_with_groups
 ///
 /// Formatting
 /// ----------
@@ -246,6 +247,7 @@ impl FermionOperatorDataGroupIter {
 /// .. autosummary::
 ///
 ///    iter_terms
+///    iter_terms_with_groups
 ///
 /// Arithmetics
 /// -----------

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -46,6 +46,27 @@ impl FermionOperatorDataIter {
     }
 }
 
+#[gen_stub_pyclass]
+#[pyclass(
+    module = "qiskit_fermions.operators.fermion_operator",
+    name = "FermionOperatorDataGroupIter"
+)]
+struct FermionOperatorDataGroupIter {
+    inner: std::vec::IntoIter<(Vec<PyFermionAction>, Complex64, u32)>,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl FermionOperatorDataGroupIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<(Vec<PyFermionAction>, Complex64, u32)> {
+        slf.inner.next()
+    }
+}
+
 /// A spin-less fermionic operator.
 ///
 /// ----
@@ -780,6 +801,81 @@ impl PyFermionOperator {
             inner.boundaries.push(inner.modes.len());
             Ok(())
         })?;
+        Ok(Self { inner })
+    }
+
+    /// An iterator over the operator's terms with their associated group index.
+    ///
+    /// .. warning::
+    ///    Mutating the iteration items does **not** affect the underlying operator data.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator(
+    ///     ...     [2.0, 1.0, -1.0],
+    ///     ...     [True, False, True, False],
+    ///     ...     [0, 1, 1, 0],
+    ///     ...     [0, 0, 2, 4],
+    ///     ... )
+    ///     >>> op.groups = [0, 1, 1]
+    ///     >>> list(sorted(op.iter_terms_with_groups()))
+    ///     [([], (2+0j), 0), ([(True, 0), (False, 1)], (1+0j), 1), ([(True, 1), (False, 0)], (-1+0j), 1)]
+    ///
+    /// ..
+    fn iter_terms_with_groups(slf: PyRef<'_, Self>) -> PyResult<Py<FermionOperatorDataGroupIter>> {
+        let vectorized: Vec<(Vec<PyFermionAction>, Complex64, u32)> = slf
+            .inner
+            .iter_with_groups()
+            .map(|term| (term.into_vec(), term.coeff, term.group))
+            .collect();
+        let iter = FermionOperatorDataGroupIter {
+            inner: vectorized.into_iter(),
+        };
+        Py::new(slf.py(), iter)
+    }
+
+    /// Constructs a new operator from an iterator of terms with groups (see also
+    /// :meth:`.iter_terms_with_groups`).
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator(
+    ///     ...     [2.0, 1.0, -1.0],
+    ///     ...     [True, False, True, False],
+    ///     ...     [0, 1, 1, 0],
+    ///     ...     [0, 0, 2, 4],
+    ///     ... )
+    ///     >>> op.groups = [0, 1, 1]
+    ///     >>> reconstructed = FermionOperator.from_terms_with_groups(op.iter_terms_with_groups())
+    ///     >>> op.equiv(reconstructed) and op.groups == reconstructed.groups
+    ///     True
+    ///
+    /// Args:
+    ///     terms: an iterator of terms as produced by :meth:`.iter_terms_with_groups`.
+    ///
+    /// Returns:
+    ///     A new operator.
+    #[classmethod]
+    fn from_terms_with_groups(
+        _cls: &Bound<'_, PyType>,
+        terms: &Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
+        let mut inner = FermionOperator::zero();
+        let mut groups = vec![];
+        terms.try_iter()?.try_for_each(|item| -> PyResult<()> {
+            let (term, coeff, group) = item?.extract::<(Vec<PyFermionAction>, Complex64, u32)>()?;
+            inner.coeffs.push(coeff);
+            term.iter().for_each(|(a, m)| {
+                inner.actions.push(*a);
+                inner.modes.push(*m);
+            });
+            inner.boundaries.push(inner.modes.len());
+            groups.push(group);
+            Ok(())
+        })?;
+        inner.groups = Some(groups);
         Ok(Self { inner })
     }
 

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -46,6 +46,27 @@ impl MajoranaOperatorDataIter {
     }
 }
 
+#[gen_stub_pyclass]
+#[pyclass(
+    module = "qiskit_fermions.operators.majorana_operator",
+    name = "MajoranaOperatorDataGroupIter"
+)]
+struct MajoranaOperatorDataGroupIter {
+    inner: std::vec::IntoIter<(Vec<PyMajoranaAction>, Complex64, u32)>,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl MajoranaOperatorDataGroupIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<(Vec<PyMajoranaAction>, Complex64, u32)> {
+        slf.inner.next()
+    }
+}
+
 /// A Majorana fermion operator.
 ///
 /// ----
@@ -738,6 +759,69 @@ impl PyMajoranaOperator {
             inner.boundaries.push(inner.modes.len());
             Ok(())
         })?;
+        Ok(Self { inner })
+    }
+
+    /// An iterator over the operator's terms with their associated group index.
+    ///
+    /// .. warning::
+    ///    Mutating the iteration items does **not** affect the underlying operator data.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import MajoranaOperator
+    ///     >>> op = MajoranaOperator([2.0, 1.0, -1.0j], [0, 1], [0, 0, 1, 2])
+    ///     >>> op.groups = [0, 1, 1]
+    ///     >>> list(op.iter_terms_with_groups())
+    ///     [([], (2+0j), 0), ([0], (1+0j), 1), ([1], (-0-1j), 1)]
+    ///
+    /// ..
+    fn iter_terms_with_groups(slf: PyRef<'_, Self>) -> PyResult<Py<MajoranaOperatorDataGroupIter>> {
+        let vectorized: Vec<(Vec<PyMajoranaAction>, Complex64, u32)> = slf
+            .inner
+            .iter_with_groups()
+            .map(|term| (term.into_vec(), term.coeff, term.group))
+            .collect();
+        let iter = MajoranaOperatorDataGroupIter {
+            inner: vectorized.into_iter(),
+        };
+        Py::new(slf.py(), iter)
+    }
+
+    /// Constructs a new operator from an iterator of terms with groups (see also
+    /// :meth:`.iter_terms_with_groups`).
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import MajoranaOperator
+    ///     >>> op = MajoranaOperator([2.0, 1.0, -1.0j], [0, 1], [0, 0, 1, 2])
+    ///     >>> op.groups = [0, 1, 1]
+    ///     >>> reconstructed = MajoranaOperator.from_terms_with_groups(op.iter_terms_with_groups())
+    ///     >>> op.equiv(reconstructed) and op.groups == reconstructed.groups
+    ///     True
+    ///
+    /// Args:
+    ///     terms: an iterator of terms as produced by :meth:`.iter_terms_with_groups`.
+    ///
+    /// Returns:
+    ///     A new operator.
+    #[classmethod]
+    fn from_terms_with_groups(
+        _cls: &Bound<'_, PyType>,
+        terms: &Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
+        let mut inner = MajoranaOperator::zero();
+        let mut groups = vec![];
+        terms.try_iter()?.try_for_each(|item| -> PyResult<()> {
+            let (term, coeff, group) =
+                item?.extract::<(Vec<PyMajoranaAction>, Complex64, u32)>()?;
+            inner.coeffs.push(coeff);
+            inner.modes.extend_from_slice(&term);
+            inner.boundaries.push(inner.modes.len());
+            groups.push(group);
+            Ok(())
+        })?;
+        inner.groups = Some(groups);
         Ok(Self { inner })
     }
 

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -181,6 +181,7 @@ impl MajoranaOperatorDataGroupIter {
 ///    zero
 ///    one
 ///    from_terms
+///    from_terms_with_groups
 ///
 /// Formatting
 /// ----------
@@ -246,6 +247,7 @@ impl MajoranaOperatorDataGroupIter {
 /// .. autosummary::
 ///
 ///    iter_terms
+///    iter_terms_with_groups
 ///
 /// Arithmetics
 /// -----------

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -46,6 +46,27 @@ impl TransferVertexOperatorDataIter {
     }
 }
 
+#[gen_stub_pyclass]
+#[pyclass(
+    module = "qiskit_fermions.operators.transfer_vertex_operator",
+    name = "TransferVertexOperatorDataGroupIter"
+)]
+struct TransferVertexOperatorDataGroupIter {
+    inner: std::vec::IntoIter<(Vec<PyTransferAction>, Complex64, u32)>,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl TransferVertexOperatorDataGroupIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<(Vec<PyTransferAction>, Complex64, u32)> {
+        slf.inner.next()
+    }
+}
+
 /// An transfer-vertex operator.
 ///
 /// ----
@@ -839,6 +860,74 @@ impl PyTransferVertexOperator {
             inner.boundaries.push(inner.right_indices.len());
             Ok(())
         })?;
+        Ok(Self { inner })
+    }
+
+    /// An iterator over the operator's terms with their associated group index.
+    ///
+    /// .. warning::
+    ///    Mutating the iteration items does **not** affect the underlying operator data.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import TransferVertexOperator
+    ///     >>> op = TransferVertexOperator([2.0, 1.0, -1.0j], [0, 0], [0, 1], [0, 0, 1, 2])
+    ///     >>> op.groups = [0, 1, 1]
+    ///     >>> list(op.iter_terms_with_groups())
+    ///     [([], (2+0j), 0), ([(0, 0)], (1+0j), 1), ([(0, 1)], (-0-1j), 1)]
+    ///
+    /// ..
+    fn iter_terms_with_groups(
+        slf: PyRef<'_, Self>,
+    ) -> PyResult<Py<TransferVertexOperatorDataGroupIter>> {
+        let vectorized: Vec<(Vec<PyTransferAction>, Complex64, u32)> = slf
+            .inner
+            .iter_with_groups()
+            .map(|term| (term.into_vec(), term.coeff, term.group))
+            .collect();
+        let iter = TransferVertexOperatorDataGroupIter {
+            inner: vectorized.into_iter(),
+        };
+        Py::new(slf.py(), iter)
+    }
+
+    /// Constructs a new operator from an iterator of terms with groups (see also
+    /// :meth:`.iter_terms_with_groups`).
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import TransferVertexOperator
+    ///     >>> op = TransferVertexOperator([2.0, 1.0, -1.0j], [0, 0], [0, 1], [0, 0, 1, 2])
+    ///     >>> op.groups = [0, 1, 1]
+    ///     >>> reconstructed = TransferVertexOperator.from_terms_with_groups(op.iter_terms_with_groups())
+    ///     >>> op.equiv(reconstructed) and op.groups == reconstructed.groups
+    ///     True
+    ///
+    /// Args:
+    ///     terms: an iterator of terms as produced by :meth:`.iter_terms_with_groups`.
+    ///
+    /// Returns:
+    ///     A new operator.
+    #[classmethod]
+    fn from_terms_with_groups(
+        _cls: &Bound<'_, PyType>,
+        terms: &Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
+        let mut inner = TransferVertexOperator::zero();
+        let mut groups = vec![];
+        terms.try_iter()?.try_for_each(|item| -> PyResult<()> {
+            let (term, coeff, group) =
+                item?.extract::<(Vec<PyTransferAction>, Complex64, u32)>()?;
+            inner.coeffs.push(coeff);
+            term.iter().for_each(|(l, r)| {
+                inner.left_indices.push(*l);
+                inner.right_indices.push(*r);
+            });
+            inner.boundaries.push(inner.right_indices.len());
+            groups.push(group);
+            Ok(())
+        })?;
+        inner.groups = Some(groups);
         Ok(Self { inner })
     }
 

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -224,6 +224,7 @@ impl TransferVertexOperatorDataGroupIter {
 ///    zero
 ///    one
 ///    from_terms
+///    from_terms_with_groups
 ///
 /// Formatting
 /// ----------
@@ -290,6 +291,7 @@ impl TransferVertexOperatorDataGroupIter {
 /// .. autosummary::
 ///
 ///    iter_terms
+///    iter_terms_with_groups
 ///
 /// Arithmetics
 /// -----------

--- a/python/qiskit_fermions/operators/protocol.py
+++ b/python/qiskit_fermions/operators/protocol.py
@@ -87,6 +87,13 @@ class OperatorTrait(Protocol):
     def from_terms(cls, terms: Iterable) -> Self:
         """Constructs a new operator from an iterator (see also :meth:`.iter_terms`)."""
 
+    def iter_terms_with_groups(self) -> Iterator:
+        """Iterates over the terms of this operator with their group indices."""
+
+    @classmethod
+    def from_terms_with_groups(cls, terms: Iterable) -> Self:
+        """Constructs a new operator from an iterator (see also :meth:`.iter_terms_with_groups`)."""
+
     def equiv(self, other: Self, atol: float) -> bool:
         """Checks this operator with another for equivalence up to the specified absolute tolerance."""
 

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -102,6 +102,33 @@ class TestEdgeVertexOperator:
         with subtests.test("list"):
             assert op.equiv(cls.from_terms(list(op.iter_terms())))
 
+    def test_iter_with_groups(self):
+        cls = self.get_class()
+        op = cls.one()
+        op.groups = [0]
+        assert list(op.iter_terms_with_groups()) == [([], 1, 0)]
+
+    def test_from_terms_with_groups(self, subtests):
+        cls = self.get_class()
+        op = cls.from_dict(
+            {
+                (): 2,
+                ((0, 1),): 1,
+                ((3, 4),): 0.5,
+                ((0, 1), (2, 3)): -0.5j,
+                ((3, 4), (0, 1)): 1 - 0.5j,
+            }
+        )
+        op.groups = [0, 1, 2, 3, 4]
+        with subtests.test("iterator"):
+            reconstructed = cls.from_terms_with_groups(op.iter_terms_with_groups())
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+        with subtests.test("list"):
+            reconstructed = cls.from_terms_with_groups(list(op.iter_terms_with_groups()))
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+
     def test_ichop(self):
         cls = self.get_class()
         op = cls.from_dict({(): 1e-4, ((0, 1),): 1e-6, ((1, 2),): 1e-10})

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -104,6 +104,33 @@ class TestFermionOperator:
         with subtests.test("list"):
             assert op.equiv(cls.from_terms(list(op.iter_terms())))
 
+    def test_iter_with_groups(self):
+        cls = self.get_class()
+        op = cls.one()
+        op.groups = [0]
+        assert list(op.iter_terms_with_groups()) == [([], 1, 0)]
+
+    def test_from_terms_with_groups(self, subtests):
+        cls = self.get_class()
+        op = cls.from_dict(
+            {
+                (): 2,
+                (cre(1), ann(2)): 1,
+                (cre(2), ann(1)): 0.5,
+                (cre(3), ann(4)): -0.5j,
+                (cre(4), ann(3)): 1 - 0.5j,
+            }
+        )
+        op.groups = [0, 1, 2, 3, 4]
+        with subtests.test("iterator"):
+            reconstructed = cls.from_terms_with_groups(op.iter_terms_with_groups())
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+        with subtests.test("list"):
+            reconstructed = cls.from_terms_with_groups(list(op.iter_terms_with_groups()))
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+
     def test_ichop(self):
         cls = self.get_class()
         op = cls.from_dict({(): 1e-4, ((True, 0),): 1e-6, ((False, 0),): 1e-10})

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -99,6 +99,33 @@ class TestMajoranaOperator:
         with subtests.test("list"):
             assert op.equiv(cls.from_terms(list(op.iter_terms())))
 
+    def test_iter_with_groups(self):
+        cls = self.get_class()
+        op = cls.one()
+        op.groups = [0]
+        assert list(op.iter_terms_with_groups()) == [([], 1, 0)]
+
+    def test_from_terms_with_groups(self, subtests):
+        cls = self.get_class()
+        op = cls.from_dict(
+            {
+                (): 2,
+                (gamma(0, False),): 1,
+                (gamma(0, False), gamma(0, True)): 0.5,
+                (gamma(1, False), gamma(0, True)): -0.5j,
+                (gamma(1, True), gamma(1, False)): 1 - 0.5j,
+            }
+        )
+        op.groups = [0, 1, 2, 3, 4]
+        with subtests.test("iterator"):
+            reconstructed = cls.from_terms_with_groups(op.iter_terms_with_groups())
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+        with subtests.test("list"):
+            reconstructed = cls.from_terms_with_groups(list(op.iter_terms_with_groups()))
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+
     def test_ichop(self):
         cls = self.get_class()
         op = cls.from_dict({(): 1e-4, (0,): 1e-6, (1,): 1e-10})

--- a/tests/python/operators/test_transfer_vertex_operator.py
+++ b/tests/python/operators/test_transfer_vertex_operator.py
@@ -102,6 +102,33 @@ class TestTransferVertexOperator:
         with subtests.test("list"):
             assert op.equiv(cls.from_terms(list(op.iter_terms())))
 
+    def test_iter_with_groups(self):
+        cls = self.get_class()
+        op = cls.one()
+        op.groups = [0]
+        assert list(op.iter_terms_with_groups()) == [([], 1, 0)]
+
+    def test_from_terms_with_groups(self, subtests):
+        cls = self.get_class()
+        op = cls.from_dict(
+            {
+                (): 2,
+                ((0, 1),): 1,
+                ((3, 4),): 0.5,
+                ((0, 1), (2, 3)): -0.5j,
+                ((3, 4), (0, 1)): 1 - 0.5j,
+            }
+        )
+        op.groups = [0, 1, 2, 3, 4]
+        with subtests.test("iterator"):
+            reconstructed = cls.from_terms_with_groups(op.iter_terms_with_groups())
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+        with subtests.test("list"):
+            reconstructed = cls.from_terms_with_groups(list(op.iter_terms_with_groups()))
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+
     def test_ichop(self):
         cls = self.get_class()
         op = cls.from_dict({(): 1e-4, ((0, 1),): 1e-6, ((1, 2),): 1e-10})


### PR DESCRIPTION
This PR adds a new iterator interface to the operator data structures which includes the group index for each operator term. While iteration over `zip(op.iter_terms(), op.groups)` would probably fulfill most needs, having access to `Operator.from_terms_with_groups` can make certain scenarios a lot more ergonomic to implement.