### PR TITLE
Refactor the pass manager to Qiskit 2.5's Multi-IR transpiler pipeline

### DIFF
--- a/docs/_templates/autosummary/typealias.rst
+++ b/docs/_templates/autosummary/typealias.rst
@@ -1,0 +1,13 @@
+{#
+   Type aliases are module-level data, not classes. We render them with
+   ``autodata`` so that Sphinx documents the alias itself (and its docstring)
+   rather than trying to enumerate the members of the aliased class -- the
+   latter emits "don't know which module to import" warnings for every
+   inherited member.
+-#}
+
+{{ objname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autodata:: {{ objname }}

--- a/docs/guides/transpilation.rst
+++ b/docs/guides/transpilation.rst
@@ -15,7 +15,11 @@ example from the :ref:`fermionic circuits guide <fermionic_circuit_explanation>`
 Transpilation stages
 --------------------
 
-The :class:`.FermionicStagedPassManager` splits transpilation into four stages:
+As explained in :mod:`qiskit_fermions.transpiler`, the preset pass managers in
+this project split the transpilation into the following stages:
+
+**Input**
+   Converts the input circuit to a DAG data structure.
 
 **Optimization**
    Fermionic-level optimizations that keep the circuit in fermionic space. These
@@ -33,9 +37,12 @@ The :class:`.FermionicStagedPassManager` splits transpilation into four stages:
    mapping. :class:`.FermionicGate` instances are transformed into sequences of
    standard quantum gates.
 
-**Quantum**
+**Qubit**
    Standard Qiskit transpilation on the resulting qubit circuit, including
    optimization, layout, and routing for your target hardware.
+
+**Output**
+   Converts the internal DAG data structure to the desirerd output format.
 
 A practical example: transpilation using Jordan-Wigner
 ------------------------------------------------------

--- a/python/qiskit_fermions/circuit/__init__.py
+++ b/python/qiskit_fermions/circuit/__init__.py
@@ -26,6 +26,7 @@ The following objects are simple type aliases to make this re-interpretation mor
 .. autosummary::
    :toctree: ../stubs/
 
+   FermionicDAGCircuit
    FermionicMode
    FermionicRegister
    FermionicSpecifier
@@ -47,8 +48,18 @@ from qiskit.circuit import QuantumRegister, Qubit
 from qiskit.dagcircuit import DAGCircuit
 
 FermionicMode: TypeAlias = Qubit
+"""A type alias of :class:`~qiskit.circuit.Qubit`.
+
+Although this does not really give us any functional guarantees, it serves to better document the
+API contract that instances of this type are interpreted as fermionic modes.
+"""
 
 FermionicRegister: TypeAlias = QuantumRegister
+"""A type alias of :class:`~qiskit.circuit.QubitRegister`.
+
+Although this does not really give us any functional guarantees, it serves to better document the
+API contract that instances of this type are interpreted as registers of fermionic modes.
+"""
 
 FermionicSpecifier: TypeAlias = (
     FermionicMode | FermionicRegister | int | slice | Sequence[FermionicMode | int]
@@ -56,6 +67,12 @@ FermionicSpecifier: TypeAlias = (
 """A type alias equivalent to Qiskit's ``QubitSpecifier`` but for fermionic modes."""
 
 FermionicDAGCircuit: TypeAlias = DAGCircuit
+"""A type alias of :class:`~qiskit.dagcircuit.DAGCircuit`.
+
+Although this does not really give us any functional guarantees, it serves to better document the
+API contract that instances of this type only contain circuit instructions of type
+:class:`.FermionicGate`.
+"""
 
 # NOTE: we must explicitly define the type aliases _before_ the following imports to ensure that
 # they can actually use those type aliases themselves.
@@ -65,6 +82,7 @@ from .fermionic_gate import FermionicGate
 
 __all__ = [
     "FermionicCircuit",
+    "FermionicDAGCircuit",
     "FermionicGate",
     "FermionicMode",
     "FermionicRegister",

--- a/python/qiskit_fermions/circuit/__init__.py
+++ b/python/qiskit_fermions/circuit/__init__.py
@@ -44,6 +44,7 @@ from collections.abc import Sequence
 from typing import TypeAlias
 
 from qiskit.circuit import QuantumRegister, Qubit
+from qiskit.dagcircuit import DAGCircuit
 
 FermionicMode: TypeAlias = Qubit
 
@@ -53,6 +54,8 @@ FermionicSpecifier: TypeAlias = (
     FermionicMode | FermionicRegister | int | slice | Sequence[FermionicMode | int]
 )
 """A type alias equivalent to Qiskit's ``QubitSpecifier`` but for fermionic modes."""
+
+FermionicDAGCircuit: TypeAlias = DAGCircuit
 
 # NOTE: we must explicitly define the type aliases _before_ the following imports to ensure that
 # they can actually use those type aliases themselves.

--- a/python/qiskit_fermions/circuit/__init__.py
+++ b/python/qiskit_fermions/circuit/__init__.py
@@ -25,6 +25,7 @@ The following objects are simple type aliases to make this re-interpretation mor
 
 .. autosummary::
    :toctree: ../stubs/
+   :template: autosummary/typealias.rst
 
    FermionicDAGCircuit
    FermionicMode

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -127,8 +127,6 @@ its own interfaces of these transpiler pass managers listed below.
    :toctree: ../stubs/
 
    FermionicPassManager
-   FermionicStagedPassManager
-   FermionicToQubitConverter
 
 Presets
 ^^^^^^^
@@ -141,11 +139,28 @@ from __future__ import annotations
 
 from typing import TypeAlias
 
-from qiskit.circuit import QuantumRegister
+from qiskit.circuit import QuantumCircuit, QuantumRegister
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.passmanager import GenericPass
+from qiskit.transpiler import TranspileLayout
 
-from qiskit_fermions.circuit import FermionicRegister
+from qiskit_fermions.circuit import FermionicDAGCircuit, FermionicRegister
 
-from .passmanager import FermionicPassManager, FermionicStagedPassManager, FermionicToQubitConverter
+from .passmanager import FermionicCircuitToDAG, FermionicDAGToCircuit, FermionicPassManager
+
+
+class QuantumDAGToCircuit(GenericPass[DAGCircuit, QuantumCircuit]):
+    """TODO."""
+
+    def run(self, passmanager_ir: DAGCircuit) -> QuantumCircuit:
+        """TODO."""
+        qc = passmanager_ir.to_circuit(copy_operations=False)
+        qc._layout = TranspileLayout.from_property_set(passmanager_ir, self.property_set)
+        return qc
+
+
+FermionicDAGCircuitPass: TypeAlias = GenericPass[FermionicDAGCircuit, FermionicDAGCircuit]
+"""TODO."""
 
 F2QLayout: TypeAlias = dict[FermionicRegister, QuantumRegister]
 """A mapping of fermionic mode registers to quantum registers.
@@ -159,7 +174,7 @@ size of the registers on either side of this mapping may differ.
 
 __all__ = [
     "F2QLayout",
+    "FermionicCircuitToDAG",
+    "FermionicDAGToCircuit",
     "FermionicPassManager",
-    "FermionicStagedPassManager",
-    "FermionicToQubitConverter",
 ]

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -42,7 +42,7 @@ Stage                                                Description
 :ref:`qiskit_fermions-transpiler-stage-optimization` fermionic-level optimization
 :ref:`qiskit_fermions-transpiler-stage-layout`       fermion-to-qubit layouting
 :ref:`qiskit_fermions-transpiler-stage-synthesis`    fermion-to-qubit synthesis
-:ref:`qiskit_fermions-transpiler-stage-quantum`      continued transpilation on the qubit-level
+:ref:`qiskit_fermions-transpiler-stage-qubit`        continued transpilation on the qubit-level
 ==================================================== ==========================================
 
 .. _qiskit_fermions-transpiler-stage-optimization:
@@ -93,12 +93,12 @@ How a given :class:`.FermionicGate` can be synthesized in terms of qubit-based o
 on the particular gate type as well as the user-chosen fermion-to-qubit mapping. For more details,
 refer to :ref:`qiskit_fermions-transpiler-passes-synthesis-plugins`.
 
-.. _qiskit_fermions-transpiler-stage-quantum:
+.. _qiskit_fermions-transpiler-stage-qubit:
 
-Quantum
-^^^^^^^
+Qubit
+^^^^^
 
-At this point in the transpilation process, we have reached :class:`~qiskit.circuit.QuantumCircuit`
+At this point in the transpilation process, we have reached a :class:`~qiskit.circuit.QuantumCircuit`
 instance and can continue to use Qiskit's transpilation pipeline as one would usually.
 
 .. hint::

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -27,8 +27,8 @@ such as topological and operational constraints of the hardware used to execute 
 We are not going to explain this in more detail here, and instead refer to Qiskit's documentation of
 the :mod:`qiskit.transpiler` module.
 
-The focus here lies on explaining how we achieve the transpilation of a :class:`.FermionicCircuit` to
-a :class:`~qiskit.circuit.QuantumCircuit`.
+The focus here lies on explaining how we achieve the transpilation of a :class:`.FermionicCircuit`
+to a :class:`~qiskit.circuit.QuantumCircuit`.
 
 ------
 Stages
@@ -39,11 +39,26 @@ Conceptually, we split the transpilation process into several stages:
 ==================================================== ==========================================
 Stage                                                Description
 ==================================================== ==========================================
+:ref:`qiskit_fermions-transpiler-stage-input`        convert to DAG data structure
 :ref:`qiskit_fermions-transpiler-stage-optimization` fermionic-level optimization
 :ref:`qiskit_fermions-transpiler-stage-layout`       fermion-to-qubit layouting
 :ref:`qiskit_fermions-transpiler-stage-synthesis`    fermion-to-qubit synthesis
 :ref:`qiskit_fermions-transpiler-stage-qubit`        continued transpilation on the qubit-level
+:ref:`qiskit_fermions-transpiler-stage-output`       convert from DAG data structure
 ==================================================== ==========================================
+
+.. _qiskit_fermions-transpiler-stage-input:
+
+Input
+^^^^^
+
+The various transpiler passes are implemented to work with :class:`.FermionicDAGCircuit` as the
+underlying data structure to store the circuit operations. Such `directed acyclic graphs` (DAGs)
+provide an efficient data model for the traversal and manipulation of circuits.
+
+However, an end-user is more likely to work with a :class:`.FermionicCircuit` as it provides a more
+intuitive interface and data model. As such, this input stage simply runs the
+:class:`.FermionicCircuitToDAG` transpiler pass.
 
 .. _qiskit_fermions-transpiler-stage-optimization:
 
@@ -51,7 +66,7 @@ Optimization
 ^^^^^^^^^^^^
 
 This stage of the transpilation pipeline can implement circuit optimizations while preserving the
-type of circuit to be an instance of :class:`.FermionicCircuit`. As such, no qubit information is
+type of circuit to be an instance of :class:`.FermionicDAGCircuit`. As such, no qubit information is
 required (or necessarily available) at this point in the transpilation pipeline.
 
 .. _qiskit_fermions-transpiler-stage-layout:
@@ -89,44 +104,65 @@ conceptually similar to Qiskit's :class:`~qiskit.transpiler.passes.HighLevelSynt
 uses various `plugins` for transpiling high-level circuit instructions. For more details, refer to
 the documentation of :class:`.F2QSynthesis` directly.
 
-How a given :class:`.FermionicGate` can be synthesized in terms of qubit-based operations will depend
-on the particular gate type as well as the user-chosen fermion-to-qubit mapping. For more details,
-refer to :ref:`qiskit_fermions-transpiler-passes-synthesis-plugins`.
+How a given :class:`.FermionicGate` can be synthesized in terms of qubit-based operations will
+depend on the particular gate type as well as the user-chosen fermion-to-qubit mapping. For more
+details, refer to :ref:`qiskit_fermions-transpiler-passes-synthesis-plugins`.
 
 .. _qiskit_fermions-transpiler-stage-qubit:
 
 Qubit
 ^^^^^
 
-At this point in the transpilation process, we have reached a :class:`~qiskit.circuit.QuantumCircuit`
-instance and can continue to use Qiskit's transpilation pipeline as one would usually.
+At this point in the transpilation process, we have reached a
+:class:`~qiskit.dagcircuit.DAGCircuit` instance and can continue to use Qiskit's transpilation
+pipeline as one would usually.
 
 .. hint::
    Additional transpiler passes for optimizations on the qubit-level that take into account the
    knowledge of a circuit originating from a :class:`.FermionicCircuit` may be added in the future!
 
+.. _qiskit_fermions-transpiler-stage-output:
+
+Output
+^^^^^^
+
+This stage implements effectively the reverse of :ref:`qiskit_fermions-transpiler-stage-input`, by
+calling the :class:`.QuantumDAGToCircuit` transpiler pass.
+
 -------------
 Pass Managers
 -------------
 
-Qiskit's transpilation process is orchestrated by a :class:`~qiskit.transpiler.PassManager`.
-In particular, a :class:`~qiskit.transpiler.StagedPassManager` can be used to orchestrate the
-transpilation into stages as explained above.
+All of the stages above are the default stages by how the :mod:`~qiskit_fermions.transpiler.presets`
+orchestrate the various :class:`~qiskit.passmanager.BasePassManager`s in their resulting
+:class:`~qiskit.passmanager.MultiStagePassManager`.
 
-Here, we are dealing with a change of circuit representation converting :class:`.FermionicCircuit`
-instances to :external:class:`~qiskit.circuit.QuantumCircuit` ones. As such, this module provides
-its own interfaces of these transpiler pass managers listed below.
+The individual stages can be either a single pass (when they change from one internal representation
+(IR) to another, such as the :ref:`qiskit_fermions-transpiler-stage-input`,
+:ref:`qiskit_fermions-transpiler-stage-synthesis`, and
+:ref:`qiskit_fermions-transpiler-stage-output` stages above) or a stage can be a
+:class:`~qiskit.passmanager.BasePassManager` whose internal passes can be modified.
 
-.. note::
-   Qiskit is currently working on native support of transpiler pipelines involving more than a
-   single intermediate representation. Once that gets more formalized, the implementation here
-   will be aligned with the resulting interfaces. See also `this tracking issue
-   <https://github.com/Qiskit/qiskit/issues/16115>`_.
+For the stages operating on fermionic circuits (:ref:`qiskit_fermions-transpiler-stage-optimization`
+and :ref:`qiskit_fermions-transpiler-stage-layout`), the type of passmanager to use is
+:class:`.FermionicPassManager`.
 
 .. autosummary::
    :toctree: ../stubs/
 
    FermionicPassManager
+
+Conversion Passes
+^^^^^^^^^^^^^^^^^
+
+Some very basic conversion passes are provided directly by this module:
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   FermionicCircuitToDAG
+   FermionicDAGToCircuit
+   QuantumDAGToCircuit
 
 Presets
 ^^^^^^^
@@ -139,28 +175,16 @@ from __future__ import annotations
 
 from typing import TypeAlias
 
-from qiskit.circuit import QuantumCircuit, QuantumRegister
-from qiskit.dagcircuit import DAGCircuit
+from qiskit.circuit import QuantumRegister
 from qiskit.passmanager import GenericPass
-from qiskit.transpiler import TranspileLayout
 
 from qiskit_fermions.circuit import FermionicDAGCircuit, FermionicRegister
 
-from .passmanager import FermionicCircuitToDAG, FermionicDAGToCircuit, FermionicPassManager
-
-
-class QuantumDAGToCircuit(GenericPass[DAGCircuit, QuantumCircuit]):
-    """TODO."""
-
-    def run(self, passmanager_ir: DAGCircuit) -> QuantumCircuit:
-        """TODO."""
-        qc = passmanager_ir.to_circuit(copy_operations=False)
-        qc._layout = TranspileLayout.from_property_set(passmanager_ir, self.property_set)
-        return qc
-
+from .converters import FermionicCircuitToDAG, FermionicDAGToCircuit, QuantumDAGToCircuit
+from .passmanager import FermionicPassManager
 
 FermionicDAGCircuitPass: TypeAlias = GenericPass[FermionicDAGCircuit, FermionicDAGCircuit]
-"""TODO."""
+"""The type definition of a fermionic-to-fermionic generic transpiler pass."""
 
 F2QLayout: TypeAlias = dict[FermionicRegister, QuantumRegister]
 """A mapping of fermionic mode registers to quantum registers.
@@ -177,4 +201,5 @@ __all__ = [
     "FermionicCircuitToDAG",
     "FermionicDAGToCircuit",
     "FermionicPassManager",
+    "QuantumDAGToCircuit",
 ]

--- a/python/qiskit_fermions/transpiler/converters.py
+++ b/python/qiskit_fermions/transpiler/converters.py
@@ -1,0 +1,72 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Minimalistic conversion transpiler passes."""
+
+from __future__ import annotations
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.converters import circuit_to_dag, dag_to_circuit
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.passmanager import GenericPass
+from qiskit.transpiler import TranspileLayout
+
+from qiskit_fermions.circuit import FermionicCircuit, FermionicDAGCircuit
+
+
+class FermionicCircuitToDAG(GenericPass[FermionicCircuit, FermionicDAGCircuit]):
+    """Converts a :class:`.FermionicCircuit` to a :class:`.FermionicDAGCircuit`."""
+
+    def run(self, passmanager_ir: FermionicCircuit) -> FermionicDAGCircuit:
+        """Runs this conversion pass.
+
+        Args:
+            passmanager_ir: the input circuit to convert.
+
+        Returns:
+            The converted circuit.
+        """
+        return circuit_to_dag(passmanager_ir._inner, copy_operations=True)
+
+
+class FermionicDAGToCircuit(GenericPass[FermionicDAGCircuit, FermionicCircuit]):
+    """Converts a :class:`.FermionicDAGCircuit` to a :class:`.FermionicCircuit`."""
+
+    def run(self, passmanager_ir: FermionicDAGCircuit) -> FermionicCircuit:
+        """Runs this conversion pass.
+
+        Args:
+            passmanager_ir: the input circuit to convert.
+
+        Returns:
+            The converted circuit.
+        """
+        out = FermionicCircuit(passmanager_ir.num_qubits())
+        out._inner = dag_to_circuit(passmanager_ir, copy_operations=False)
+        return out
+
+
+class QuantumDAGToCircuit(GenericPass[DAGCircuit, QuantumCircuit]):
+    """Converts a :class:`~qiskit.dagcircuit.DAGCircuit` to a :class:`~qiskit.circuit.QuantumCircuit`."""
+
+    def run(self, passmanager_ir: DAGCircuit) -> QuantumCircuit:
+        """Runs this conversion pass.
+
+        Args:
+            passmanager_ir: the input circuit to convert.
+
+        Returns:
+            The converted circuit.
+        """
+        qc = passmanager_ir.to_circuit(copy_operations=False)
+        qc._layout = TranspileLayout.from_property_set(passmanager_ir, self.property_set)
+        return qc

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -26,7 +26,7 @@ This module provides various transpiler passes for the stages explained in
 Optimization Passes
 -------------------
 
-These passes provide different kinds of optimization of :class:`.FermionicCircuit` instances.
+These passes provide different kinds of optimization of :class:`.FermionicDAGCircuit` instances.
 
 .. autosummary::
    :toctree: ../stubs/
@@ -56,11 +56,12 @@ needs to be placed in the ``f2q_layout`` field of the
 Synthesis Passes
 ----------------
 
-The main logic for mapping a :class:`.FermionicCircuit` to a :class:`~qiskit.circuit.QuantumCircuit`
-is implemented by a single synthesis pass, namely the :class:`.F2QSynthesis`. It is conceptually
-similar to Qiskit's :class:`~qiskit.transpiler.passes.HighLevelSynthesis` because it simply iterates
-over the :class:`.FermionicCircuit` instructions and delegates the mapping to qubit-based instructions
-to :ref:`qiskit_fermions-transpiler-passes-synthesis-plugins` for each of the encountered types of
+The main logic for mapping a :class:`.FermionicDAGCircuit` to a
+:class:`~qiskit.dagcircuit.DAGCircuit` is implemented by a single synthesis pass, namely the
+:class:`.F2QSynthesis`. It is conceptually similar to Qiskit's
+:class:`~qiskit.transpiler.passes.HighLevelSynthesis` because it simply iterates over the
+:class:`.FermionicDAGCircuit` instructions and delegates the mapping to qubit-based instructions to
+:ref:`qiskit_fermions-transpiler-passes-synthesis-plugins` for each of the encountered types of
 :class:`.FermionicGate`.
 
 .. autosummary::

--- a/python/qiskit_fermions/transpiler/passes/layout/custom.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/custom.py
@@ -14,13 +14,12 @@
 
 from __future__ import annotations
 
-from qiskit.dagcircuit import DAGCircuit
-from qiskit.transpiler import AnalysisPass
+from qiskit_fermions.circuit import FermionicDAGCircuit
 
-from ... import F2QLayout
+from ... import F2QLayout, FermionicDAGCircuitPass
 
 
-class CustomF2QLayout(AnalysisPass):
+class CustomF2QLayout(FermionicDAGCircuitPass):
     """Sets the user-provided :type:`~qiskit_fermions.transpiler.F2QLayout` in the transpiler.
 
     This pass simply populates the ``f2q_layout`` field of the
@@ -44,10 +43,12 @@ class CustomF2QLayout(AnalysisPass):
         """The user-provided mapping of :type:`~qiskit_fermions.circuit.FermionicRegister` to
         :class:`~qiskit.circuit.QuantumRegister`."""
 
-    def run(self, dag: DAGCircuit) -> None:
+    def run(self, dag: FermionicDAGCircuit) -> FermionicDAGCircuit:
         """Runs this analysis pass.
 
         Args:
             dag: the DAG circuit representation of a :class:`.FermionicCircuit`.
         """
         self.property_set["f2q_layout"] = self.layout
+
+        return dag

--- a/python/qiskit_fermions/transpiler/passes/layout/custom.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/custom.py
@@ -48,6 +48,10 @@ class CustomF2QLayout(FermionicDAGCircuitPass):
 
         Args:
             dag: the DAG circuit representation of a :class:`.FermionicCircuit`.
+
+        Returns:
+            The unchanged input. But the :attr:`.property_set` of this transpilation pipeline will
+            be updated.
         """
         self.property_set["f2q_layout"] = self.layout
 

--- a/python/qiskit_fermions/transpiler/passes/layout/trivial.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/trivial.py
@@ -15,13 +15,13 @@
 from __future__ import annotations
 
 from qiskit.circuit import QuantumRegister
-from qiskit.dagcircuit import DAGCircuit
-from qiskit.transpiler import AnalysisPass
 
-from ... import F2QLayout
+from qiskit_fermions.circuit import FermionicDAGCircuit
+
+from ... import F2QLayout, FermionicDAGCircuitPass
 
 
-class TrivialF2QLayout(AnalysisPass):
+class TrivialF2QLayout(FermionicDAGCircuitPass):
     """Trivially maps :math:`n` fermionic modes to :math:`n` qubits.
 
     This pass simply populates the ``f2q_layout`` field of the
@@ -30,7 +30,7 @@ class TrivialF2QLayout(AnalysisPass):
     :class:`~qiskit.circuit.QuantumRegister`.
     """
 
-    def run(self, dag: DAGCircuit) -> None:
+    def run(self, dag: FermionicDAGCircuit) -> FermionicDAGCircuit:
         """Runs this analysis pass.
 
         Args:
@@ -41,3 +41,5 @@ class TrivialF2QLayout(AnalysisPass):
             layout[qreg] = QuantumRegister(len(qreg))
 
         self.property_set["f2q_layout"] = layout
+
+        return dag

--- a/python/qiskit_fermions/transpiler/passes/layout/trivial.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/trivial.py
@@ -35,6 +35,10 @@ class TrivialF2QLayout(FermionicDAGCircuitPass):
 
         Args:
             dag: the DAG circuit representation of a :class:`.FermionicCircuit`.
+
+        Returns:
+            The unchanged input. But the :attr:`.property_set` of this transpilation pipeline will
+            be updated.
         """
         layout: F2QLayout = {}
         for qreg in dag.qregs.values():

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -17,13 +17,14 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
-from qiskit.dagcircuit import DAGCircuit
-from qiskit.transpiler import TransformationPass
 
+from qiskit_fermions.circuit import FermionicDAGCircuit
 from qiskit_fermions.circuit.library import Evolution
 
+from ... import FermionicDAGCircuitPass
 
-class QDriftTrotterization(TransformationPass):
+
+class QDriftTrotterization(FermionicDAGCircuitPass):
     """A transpilation pass to Trotterize :class:`.Evolution` gates via the qDRIFT protocol."""
 
     def __init__(self, num_terms: int, *, rng: np.random.Generator | int | None = None) -> None:
@@ -41,7 +42,7 @@ class QDriftTrotterization(TransformationPass):
 
         self._rng = rng if isinstance(rng, np.random.Generator) else np.random.default_rng(rng)
 
-    def run(self, dag: DAGCircuit) -> DAGCircuit:
+    def run(self, dag: FermionicDAGCircuit) -> FermionicDAGCircuit:
         """Runs this transpilation pass.
 
         Args:

--- a/python/qiskit_fermions/transpiler/passes/optimization/relabel_modes.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/relabel_modes.py
@@ -21,14 +21,14 @@ from itertools import islice
 from typing import TYPE_CHECKING, Any
 
 from qiskit import QuantumRegister
-from qiskit.dagcircuit import DAGCircuit
-from qiskit.transpiler import TransformationPass
 
 from qiskit_fermions._lib.operators.fermion_operator import FermionOperator
-from qiskit_fermions.circuit import FermionicRegister
+from qiskit_fermions.circuit import FermionicDAGCircuit, FermionicRegister
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.mappers.optimization import build_excitation_span_minimization_model
 from qiskit_fermions.utils.optionals import HAS_PYOMO
+
+from ... import FermionicDAGCircuitPass
 
 if TYPE_CHECKING:
     import pyomo
@@ -48,7 +48,7 @@ def _sliding_window(iterable: Iterable[Any], n: int) -> Generator[tuple[Any, ...
         yield tuple(window)
 
 
-class RelabelModes(TransformationPass):
+class RelabelModes(FermionicDAGCircuitPass):
     """A transpilation pass to relabel the fermionic modes.
 
     .. caution::
@@ -111,7 +111,7 @@ class RelabelModes(TransformationPass):
         self._model_kwargs = kwargs
 
     def find_permutation(
-        self, dag: DAGCircuit
+        self, dag: FermionicDAGCircuit
     ) -> tuple[list[int] | None, pyomo.opt.results.results_.SolverResults | None]:
         """Finds a mode index :attr:`.permutation` when not specified by the user.
 
@@ -198,7 +198,7 @@ class RelabelModes(TransformationPass):
         permutation = [round(value(model.y[i])) for i in range(num_modes)]
         return permutation, result
 
-    def run(self, dag: DAGCircuit) -> DAGCircuit:
+    def run(self, dag: FermionicDAGCircuit) -> FermionicDAGCircuit:
         """Runs this transpilation pass.
 
         Args:

--- a/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 from typing import Protocol, cast
 
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode
-from qiskit.transpiler import TransformationPass
+from qiskit.passmanager import GenericPass
 
-from qiskit_fermions.circuit import FermionicGate
+from qiskit_fermions.circuit import FermionicDAGCircuit, FermionicGate
 
 from ... import F2QLayout
 
@@ -44,7 +44,7 @@ class F2QSynthesisPlugin(Protocol):
         ...
 
 
-class F2QSynthesis(TransformationPass):
+class F2QSynthesis(GenericPass[FermionicDAGCircuit, DAGCircuit]):
     """A transpilation pass to map fermion-based circuit instructions to qubit-based ones.
 
     This transpilation pass works similarly to Qiskit's
@@ -72,7 +72,7 @@ class F2QSynthesis(TransformationPass):
            :no-special-members:
         """
 
-    def run(self, dag: DAGCircuit) -> DAGCircuit:
+    def run(self, dag: FermionicDAGCircuit) -> DAGCircuit:
         """Runs this transpilation pass.
 
         Args:

--- a/python/qiskit_fermions/transpiler/passmanager.py
+++ b/python/qiskit_fermions/transpiler/passmanager.py
@@ -12,18 +12,35 @@
 
 """PassManager interfaces for FermionicCircuits."""
 
-from collections.abc import Callable, Iterable
+from typing import TypeAlias
 
-from qiskit import QuantumCircuit
 from qiskit.converters import circuit_to_dag, dag_to_circuit
-from qiskit.dagcircuit import DAGCircuit
-from qiskit.passmanager import BasePassManager
-from qiskit.transpiler import StagedPassManager
+from qiskit.passmanager import BasePassManager, GenericPass
 
-from qiskit_fermions.circuit import FermionicCircuit
+from qiskit_fermions.circuit import FermionicCircuit, FermionicDAGCircuit
+
+FermionicDAGCircuitPass: TypeAlias = GenericPass[FermionicDAGCircuit, FermionicDAGCircuit]
 
 
-class FermionicPassManager(BasePassManager):
+class FermionicCircuitToDAG(GenericPass[FermionicCircuit, FermionicDAGCircuit]):
+    """TODO."""
+
+    def run(self, passmanager_ir: FermionicCircuit) -> FermionicDAGCircuit:
+        """TODO."""
+        return circuit_to_dag(passmanager_ir._inner, copy_operations=True)
+
+
+class FermionicDAGToCircuit(GenericPass[FermionicDAGCircuit, FermionicCircuit]):
+    """TODO."""
+
+    def run(self, passmanager_ir: FermionicDAGCircuit) -> FermionicCircuit:
+        """TODO."""
+        out = FermionicCircuit(passmanager_ir.num_qubits())
+        out._inner = dag_to_circuit(passmanager_ir, copy_operations=False)
+        return out
+
+
+class FermionicPassManager(BasePassManager[FermionicDAGCircuit]):
     """A transpiler pass manager converting one :class:`.FermionicCircuit` to another.
 
     .. note::
@@ -33,74 +50,12 @@ class FermionicPassManager(BasePassManager):
        <https://github.com/Qiskit/qiskit/issues/16115>`_.
     """
 
-    def _passmanager_frontend(self, input_program: FermionicCircuit, **kwargs) -> DAGCircuit:
-        return circuit_to_dag(input_program._inner, copy_operations=True)
+    def _passmanager_frontend(
+        self, input_program: FermionicCircuit, **kwargs
+    ) -> FermionicDAGCircuit:
+        return FermionicCircuitToDAG().run(input_program)
 
     def _passmanager_backend(
-        self, passmanager_ir: DAGCircuit, in_program: FermionicCircuit, **kwargs
+        self, passmanager_ir: FermionicDAGCircuit, in_program: FermionicCircuit, **kwargs
     ) -> FermionicCircuit:
-        out = FermionicCircuit(passmanager_ir.num_qubits())
-        out._inner = dag_to_circuit(passmanager_ir, copy_operations=False)
-        return out
-
-
-class FermionicToQubitConverter(BasePassManager):
-    """A transpiler pass manager converting a :class:`.FermionicCircuit` to a :class:`~qiskit.circuit.QuantumCircuit`.
-
-    .. note::
-       Qiskit is currently working on native support of transpiler pipelines involving more than a
-       single intermediate representation. Once that gets more formalized, the implementation here
-       will be aligned with the resulting interfaces. See also `this tracking issue
-       <https://github.com/Qiskit/qiskit/issues/16115>`_.
-    """
-
-    def _passmanager_frontend(self, input_program: FermionicCircuit, **kwargs) -> DAGCircuit:
-        return circuit_to_dag(input_program._inner, copy_operations=True)
-
-    def _passmanager_backend(
-        self, passmanager_ir: DAGCircuit, in_program: FermionicCircuit, **kwargs
-    ) -> QuantumCircuit:
-        return dag_to_circuit(passmanager_ir, copy_operations=False)
-
-
-class FermionicStagedPassManager(StagedPassManager):
-    """The staged fermion-to-qubit transpilation pipeline.
-
-    This
-
-    .. note::
-       Qiskit is currently working on native support of transpiler pipelines involving more than a
-       single intermediate representation. Once that gets more formalized, the implementation here
-       will be aligned with the resulting interfaces. See also `this tracking issue
-       <https://github.com/Qiskit/qiskit/issues/16115>`_.
-    """
-
-    def _passmanager_frontend(self, input_program: FermionicCircuit, **kwargs) -> DAGCircuit:
-        return circuit_to_dag(input_program._inner, copy_operations=True)
-
-    def __init__(self, stages: Iterable[str] | None = None, **kwargs) -> None:  # noqa: D107
-        stages = stages or [
-            "optimization",
-            "layout",
-            "synthesis",
-            "quantum",
-        ]
-        super().__init__(stages, **kwargs)
-
-    def run(  # noqa: D102
-        self,
-        in_programs: FermionicCircuit | list[FermionicCircuit],
-        callback: Callable | None = None,
-        num_processes: int | None = None,
-        *,
-        property_set: dict[str, object] | None = None,
-        **kwargs,
-    ) -> QuantumCircuit:
-        self._update_passmanager()
-        return super().run(
-            in_programs,
-            callback,
-            num_processes=num_processes,
-            property_set=property_set,
-            **kwargs,
-        )
+        return FermionicDAGToCircuit().run(passmanager_ir)

--- a/python/qiskit_fermions/transpiler/passmanager.py
+++ b/python/qiskit_fermions/transpiler/passmanager.py
@@ -10,44 +10,20 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""PassManager interfaces for FermionicCircuits."""
+"""The passmanager interface for fermionic circuits."""
 
-from typing import TypeAlias
-
-from qiskit.converters import circuit_to_dag, dag_to_circuit
-from qiskit.passmanager import BasePassManager, GenericPass
+from qiskit.passmanager import BasePassManager
 
 from qiskit_fermions.circuit import FermionicCircuit, FermionicDAGCircuit
 
-FermionicDAGCircuitPass: TypeAlias = GenericPass[FermionicDAGCircuit, FermionicDAGCircuit]
-
-
-class FermionicCircuitToDAG(GenericPass[FermionicCircuit, FermionicDAGCircuit]):
-    """TODO."""
-
-    def run(self, passmanager_ir: FermionicCircuit) -> FermionicDAGCircuit:
-        """TODO."""
-        return circuit_to_dag(passmanager_ir._inner, copy_operations=True)
-
-
-class FermionicDAGToCircuit(GenericPass[FermionicDAGCircuit, FermionicCircuit]):
-    """TODO."""
-
-    def run(self, passmanager_ir: FermionicDAGCircuit) -> FermionicCircuit:
-        """TODO."""
-        out = FermionicCircuit(passmanager_ir.num_qubits())
-        out._inner = dag_to_circuit(passmanager_ir, copy_operations=False)
-        return out
+from .converters import FermionicCircuitToDAG, FermionicDAGToCircuit
 
 
 class FermionicPassManager(BasePassManager[FermionicDAGCircuit]):
     """A transpiler pass manager converting one :class:`.FermionicCircuit` to another.
 
-    .. note::
-       Qiskit is currently working on native support of transpiler pipelines involving more than a
-       single intermediate representation. Once that gets more formalized, the implementation here
-       will be aligned with the resulting interfaces. See also `this tracking issue
-       <https://github.com/Qiskit/qiskit/issues/16115>`_.
+    The internal representation (IR) of this pass manager is :class:`.FermionicDAGCircuit`, but the
+    input and output type are :class:`.FermionicCircuit`.
     """
 
     def _passmanager_frontend(

--- a/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
+++ b/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
@@ -12,12 +12,13 @@
 
 """The preset transpiler pipeline based on the Jordan-Wigner fermion-to-qubit mapping."""
 
+from qiskit.passmanager import MultiStagePassManager
 from qiskit.transpiler import generate_preset_pass_manager
 
 from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
 from qiskit_fermions.mappers.library import jordan_wigner
 
-from .. import FermionicPassManager, FermionicStagedPassManager, FermionicToQubitConverter
+from .. import FermionicCircuitToDAG, FermionicPassManager, QuantumDAGToCircuit
 from ..passes import (
     EvolutionSynthesis,
     F2QSynthesis,
@@ -27,13 +28,13 @@ from ..passes import (
 )
 
 
-def generate_preset_jw_pass_manager(**kwargs) -> FermionicStagedPassManager:
+def generate_preset_jw_pass_manager(**kwargs) -> MultiStagePassManager:
     """Generates a preset transpiler pipeline based on the :func:`.jordan_wigner` mapping.
 
     Args:
         kwargs: any additional keyword arguments are forwarded to
             :external:func:`~qiskit.transpiler.generate_preset_pass_manager` whose output is used
-            for the ``quantum`` stage of the resulting :class:`.FermionicStagedPassManager`.
+            for the ``quantum`` stage.
 
     Returns:
         The preset staged fermion-to-qubit transpiler pipeline.
@@ -47,12 +48,13 @@ def generate_preset_jw_pass_manager(**kwargs) -> FermionicStagedPassManager:
     synth.plugins[InitializeModes] = InitializeModesSynthesis()
     synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
 
-    synthesis = FermionicToQubitConverter(synth)
-
-    pm = FermionicStagedPassManager()
-    pm.optimization = optimization
-    pm.layout = layout
-    pm.synthesis = synthesis
-    pm.quantum = generate_preset_pass_manager(**kwargs)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        optimization=optimization,
+        layout=layout,
+        synthesis=synth,
+        quantum=generate_preset_pass_manager(**kwargs),
+        output=QuantumDAGToCircuit(),
+    )
 
     return pm

--- a/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
+++ b/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
@@ -34,7 +34,7 @@ def generate_preset_jw_pass_manager(**kwargs) -> MultiStagePassManager:
     Args:
         kwargs: any additional keyword arguments are forwarded to
             :external:func:`~qiskit.transpiler.generate_preset_pass_manager` whose output is used
-            for the ``quantum`` stage.
+            for the ``qubit`` stage.
 
     Returns:
         The preset staged fermion-to-qubit transpiler pipeline.
@@ -53,7 +53,7 @@ def generate_preset_jw_pass_manager(**kwargs) -> MultiStagePassManager:
         optimization=optimization,
         layout=layout,
         synthesis=synth,
-        quantum=generate_preset_pass_manager(**kwargs),
+        qubit=generate_preset_pass_manager(**kwargs),
         output=QuantumDAGToCircuit(),
     )
 

--- a/tests/python/transpiler/passes/test_custom_layout.py
+++ b/tests/python/transpiler/passes/test_custom_layout.py
@@ -18,13 +18,13 @@ from collections import defaultdict
 from functools import partial
 
 from qiskit.circuit import QuantumRegister
+from qiskit.passmanager import MultiStagePassManager
 from qiskit.quantum_info import SparseObservable
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import MajoranaOperator
-from qiskit_fermions.transpiler import FermionicStagedPassManager
+from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
 from qiskit_fermions.transpiler.passes import CustomF2QLayout, EvolutionSynthesis, F2QSynthesis
-from qiskit_fermions.transpiler.passmanager import FermionicPassManager, FermionicToQubitConverter
 
 
 # NOTE: this is a very specific implementation of the Fermi-Hubbard model on a square lattice. It is
@@ -331,9 +331,12 @@ def test_custom_layout():
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(mapper_fn)
 
-    pm = FermionicStagedPassManager()
-    pm.layout = FermionicPassManager(layout)
-    pm.synthesis = FermionicToQubitConverter(synth)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=layout,
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
 
     qu_circ = pm.run(circ)
     qu_circ_decomp = qu_circ.decompose()

--- a/tests/python/transpiler/passes/test_evolution_synthesis.py
+++ b/tests/python/transpiler/passes/test_evolution_synthesis.py
@@ -15,16 +15,13 @@
 from __future__ import annotations
 
 from qiskit.circuit.library import PauliEvolutionGate
+from qiskit.passmanager import MultiStagePassManager
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
+from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
 from qiskit_fermions.transpiler.passes import EvolutionSynthesis, F2QSynthesis, TrivialF2QLayout
-from qiskit_fermions.transpiler.passmanager import (
-    FermionicPassManager,
-    FermionicStagedPassManager,
-    FermionicToQubitConverter,
-)
 
 
 def test_evolution_gate_synthesis():
@@ -45,9 +42,12 @@ def test_evolution_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
 
-    pm = FermionicStagedPassManager()
-    pm.layout = FermionicPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionicToQubitConverter(synth)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
 
     qu_circ = pm.run(circ)
 
@@ -83,9 +83,12 @@ def test_custom_qubit_ordering():
     synth = F2QSynthesis()
     synth.plugins[Evolution] = EvolutionSynthesis(custom_qubit_ordering_mapper_fn)
 
-    pm = FermionicStagedPassManager()
-    pm.layout = FermionicPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionicToQubitConverter(synth)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
 
     qu_circ = pm.run(circ)
 

--- a/tests/python/transpiler/passes/test_f2q_synthesis.py
+++ b/tests/python/transpiler/passes/test_f2q_synthesis.py
@@ -15,17 +15,12 @@
 from __future__ import annotations
 
 import pytest
-from qiskit.circuit import QuantumCircuit
-from qiskit.transpiler import PassManager
+from qiskit.passmanager import MultiStagePassManager
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import FermionOperator
+from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
 from qiskit_fermions.transpiler.passes import F2QSynthesis, TrivialF2QLayout
-from qiskit_fermions.transpiler.passmanager import (
-    FermionicPassManager,
-    FermionicStagedPassManager,
-    FermionicToQubitConverter,
-)
 
 
 def test_missing_plugin():
@@ -44,20 +39,12 @@ def test_missing_plugin():
     evo = Evolution(num_modes, hamil, time=time)
     circ.append(evo, circ.modes)
 
-    pm = FermionicStagedPassManager()
-    pm.layout = FermionicPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionicToQubitConverter(F2QSynthesis())
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=F2QSynthesis(),
+        output=QuantumDAGToCircuit(),
+    )
 
     with pytest.raises(TypeError, match="No plugin registered"):
-        _ = pm.run(circ)
-
-
-def test_unsupported_gate():
-    """Test the handling of an unsupported circuit instruction."""
-    circ = QuantumCircuit(2)
-    circ.x(0)
-
-    pm = PassManager([TrivialF2QLayout(), F2QSynthesis()])
-
-    with pytest.raises(ValueError, match="unsupported circuit instruction"):
         _ = pm.run(circ)

--- a/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
+++ b/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
@@ -15,16 +15,16 @@
 from __future__ import annotations
 
 from qiskit.circuit import QuantumCircuit
+from qiskit.passmanager import MultiStagePassManager
 from qiskit.quantum_info import Statevector
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import InitializeModes
-from qiskit_fermions.transpiler import FermionicPassManager, FermionicStagedPassManager
+from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
 from qiskit_fermions.transpiler.passes import (
     F2QSynthesis,
     InitializeModesSynthesis,
     TrivialF2QLayout,
 )
-from qiskit_fermions.transpiler.passmanager import FermionicToQubitConverter
 
 
 def test_initialize_modes_global_gate_synthesis():
@@ -37,9 +37,12 @@ def test_initialize_modes_global_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[InitializeModes] = InitializeModesSynthesis()
 
-    pm = FermionicStagedPassManager()
-    pm.layout = FermionicPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionicToQubitConverter(synth)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
 
     qu_circ = pm.run(circ)
 
@@ -60,9 +63,12 @@ def test_initialize_modes_local_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[InitializeModes] = InitializeModesSynthesis()
 
-    pm = FermionicStagedPassManager()
-    pm.layout = FermionicPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionicToQubitConverter(synth)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
 
     qu_circ = pm.run(circ)
 

--- a/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
+++ b/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
@@ -14,15 +14,15 @@
 
 from __future__ import annotations
 
+from qiskit.passmanager import MultiStagePassManager
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import OrbitalRotation
-from qiskit_fermions.transpiler import FermionicPassManager, FermionicStagedPassManager
+from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
 from qiskit_fermions.transpiler.passes import (
     F2QSynthesis,
     OrbitalRotationSynthesis,
     TrivialF2QLayout,
 )
-from qiskit_fermions.transpiler.passmanager import FermionicToQubitConverter
 
 from ...utils import random_unitary
 
@@ -37,9 +37,12 @@ def test_orbital_rotation_global_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
 
-    pm = FermionicStagedPassManager()
-    pm.layout = FermionicPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionicToQubitConverter(synth)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
 
     qu_circ = pm.run(circ)
 
@@ -60,9 +63,12 @@ def test_initialize_modes_local_gate_synthesis():
     synth = F2QSynthesis()
     synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
 
-    pm = FermionicStagedPassManager()
-    pm.layout = FermionicPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionicToQubitConverter(synth)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
 
     qu_circ = pm.run(circ)
 

--- a/tests/python/transpiler/passes/test_relabel_modes.py
+++ b/tests/python/transpiler/passes/test_relabel_modes.py
@@ -16,21 +16,18 @@ from __future__ import annotations
 
 import pytest
 from qiskit.circuit.library import PauliEvolutionGate
+from qiskit.passmanager import MultiStagePassManager
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution, InitializeModes
 from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
+from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
 from qiskit_fermions.transpiler.passes import (
     EvolutionSynthesis,
     F2QSynthesis,
     InitializeModesSynthesis,
     RelabelModes,
     TrivialF2QLayout,
-)
-from qiskit_fermions.transpiler.passmanager import (
-    FermionicPassManager,
-    FermionicStagedPassManager,
-    FermionicToQubitConverter,
 )
 from qiskit_fermions.utils.optionals import HAS_PYOMO
 
@@ -64,10 +61,13 @@ def test_relabel_modes_fixed_permutation():
     permutation = [0, 2, 1, 3]
     relabel = RelabelModes(permutation)
 
-    pm = FermionicStagedPassManager()
-    pm.optimization = FermionicPassManager(relabel)
-    pm.layout = FermionicPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionicToQubitConverter(synth)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        optimization=relabel,
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
 
     qu_circ = pm.run(circ)
 
@@ -105,10 +105,13 @@ def test_relabel_modes_local_indices():
     permutation = [0, 2, 1, 3, 4, 5, 6, 7]
     relabel = RelabelModes(permutation)
 
-    pm = FermionicStagedPassManager()
-    pm.optimization = FermionicPassManager(relabel)
-    pm.layout = FermionicPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionicToQubitConverter(synth)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        optimization=relabel,
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
 
     qu_circ = pm.run(circ)
 
@@ -139,10 +142,13 @@ def test_relabel_modes_pyomo_optimization():
     solver.options["time_limit"] = 60
     relabel = RelabelModes(solver=solver)
 
-    pm = FermionicStagedPassManager()
-    pm.optimization = FermionicPassManager(relabel)
-    pm.layout = FermionicPassManager(TrivialF2QLayout())
-    pm.synthesis = FermionicToQubitConverter(synth)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        optimization=relabel,
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
 
     qu_circ = pm.run(circ)
 


### PR DESCRIPTION
Qiskit 2.5 introduces a multi-IR transpiler pass management, providing native support for transpilation workflow that work with multiple changing internal representations (IRs). We previously wrote some "hacky" interfaces and leveraged Python's lack of type enforcement to have a working pipeline before this feature arrived, but this PR refactors our interfaces to follow the new and properly typed interfaces provided by Qiskit 2.5

This is still a Python-only feature until a proper the Qiskit SDK refactors the transpiler pass management to become entirely Rust (at which point a C API becomes feasible, too).

Closes #124 

---

The documentation still needs to be updated:
- [x] document new interfaces
- [x] verify documentation of old but changed interfaces
- [x] verify correct explanations in module-level docs
- [x] verify content of relevant guides