### PR TITLE
Remove the need for build-isolation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -79,7 +79,7 @@ jobs:
         shell: bash
         run: |
           pip install --group build --group coverage qiskit
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e ".[all]"
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e ".[all]"
 
       - name: Python coverage
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
         run: |
           pip install --group build --group docs qiskit
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e ".[all]"
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e ".[all]"
 
       - name: Build docs
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash
         run: |
           pip install --group build --group lint qiskit
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e ".[all]"
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e ".[all]"
 
       - name: Run lint check
         shell: bash

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -82,7 +82,7 @@ jobs:
         shell: bash
         run: |
           pip install --group build --group test "qiskit @ file:$(echo build/qiskit/dist/*.whl)"
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e .
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e .
 
       - name: Python tests
         shell: bash
@@ -92,7 +92,7 @@ jobs:
       - name: Optional tests
         shell: bash
         run: |
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e ".[all]"
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e ".[all]"
           make testoptional
 
       - name: Documentation tests

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -110,7 +110,7 @@ jobs:
         shell: bash
         run: |
           pip install --group build --group test qiskit
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e .
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e .
 
       - name: Python tests
         shell: bash
@@ -120,7 +120,7 @@ jobs:
       - name: Optional tests
         shell: bash
         run: |
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e ".[all]"
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e ".[all]"
           make testoptional
 
       - name: Documentation tests

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install Python package
         shell: bash
         run: |
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e .
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e .
 
       - name: Python tests
         shell: bash
@@ -98,7 +98,7 @@ jobs:
       - name: Optional tests
         shell: bash
         run: |
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e ".[all]"
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e ".[all]"
           make testoptional
 
       - name: Documentation tests

--- a/docs/install-py.rst
+++ b/docs/install-py.rst
@@ -31,12 +31,11 @@ simple:
 
       $ pip install --group build
 
-3. Install the ``qiskit-fermions`` Python package into your environment with
-   ``--no-build-isolation`` to ensure that ``qiskit`` is available:
+3. Install the ``qiskit-fermions`` Python package into your environment:
 
    .. code:: console
 
-      $ pip install --no-build-isolation .
+      $ pip install .
 
    .. hint::
 
@@ -45,7 +44,7 @@ simple:
 
       .. code:: console
 
-         $ SETUPTOOLS_RUST_CARGO_PROFILE=release pip install --no-build-isolation -e .
+         $ SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e .
 
 4. (optional) You may wish to generate the Python type stub files to have better
    integration with coding tools (e.g. for tab completion). You can do that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@
 requires = [
     "setuptools>=77.0.1",
     "setuptools-rust",
+    "qiskit>=2.5",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -45,6 +46,7 @@ optimization = [
 build = [
     "setuptools>=77.0.1",
     "setuptools-rust",
+    "qiskit>=2.5",
 ]
 style = [
     "ruff==0.15.8",
@@ -161,8 +163,3 @@ iz = "iz"
 
 [tool.typos.files]
 extend-exclude = ["crates/qiskit-pyo3-ffi"]
-
-# While we don't mandate the use of uv, we use it during CI for handling package
-# resolution and thus are configuring components of it below.
-[tool.uv.extra-build-dependencies]
-qiskit-fermions = ["qiskit"]


### PR DESCRIPTION
Since #150 we can link against Qiskit dynamically through the `qiskit-pyo3-ffi` crate, and we no longer require to build our wheels with `--no-build-isolation`.

Closes #162 