### PR TITLE
fix: ensure __init__ docstrings are included

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,7 @@ rst_prolog = f"""
 # Options for autodoc. These reflect the values from Qiskit SDK and Runtime.
 autosummary_generate = True
 autosummary_generate_overwrite = False
-autoclass_content = "class"
+autoclass_content = "both"
 autodoc_typehints = "description"
 autodoc_class_signature = "separated"
 autodoc_default_options = {

--- a/python/qiskit_fermions/circuit/fermionic_circuit.py
+++ b/python/qiskit_fermions/circuit/fermionic_circuit.py
@@ -37,7 +37,7 @@ class FermionicCircuit:
     """
 
     def __init__(self, num_modes: int) -> None:
-        """Initializes a FermionicCircuit instance.
+        """Initializing a circuit instance can be done with the arguments listed below.
 
         Args:
             num_modes: the number of fermionic modes on which this circuit acts.

--- a/python/qiskit_fermions/circuit/fermionic_gate.py
+++ b/python/qiskit_fermions/circuit/fermionic_gate.py
@@ -34,7 +34,7 @@ class FermionicGate(Gate):
        this `re-interpretation`. You have been warned.
     """
 
-    def __init__(
+    def __init__(  # noqa: D107
         self,
         name: str,
         num_modes: int,
@@ -43,7 +43,6 @@ class FermionicGate(Gate):
         *,
         label: str | None = None,
     ) -> None:
-        """Initializes a FermionicGate instance."""
         if params is None:
             params = []
         super().__init__(name, num_modes, params, label)

--- a/python/qiskit_fermions/circuit/library/evolution.py
+++ b/python/qiskit_fermions/circuit/library/evolution.py
@@ -23,7 +23,7 @@ class Evolution(FermionicGate):
     """Implements the time evolution of an operator."""
 
     def __init__(self, num_modes: int, operator: OperatorTrait, time: float = 1.0) -> None:
-        """Initializes an Evolution gate.
+        """Initializing an instance of this gate can be done with the arguments listed below.
 
         Args:
             num_modes: the number of fermionic modes on which this gate acts.

--- a/python/qiskit_fermions/circuit/library/initialize_modes.py
+++ b/python/qiskit_fermions/circuit/library/initialize_modes.py
@@ -30,7 +30,7 @@ class InitializeModes(FermionicGate):
     """
 
     def __init__(self, occupation: Sequence[bool]) -> None:
-        """Initializes the modes of a :class:`.FermionicRegister` with the provided occupation.
+        """Initializing an instance of this gate can be done with the arguments listed below.
 
         Args:
             occupation: a sequence of booleans indicating the occupation for each mode in the

--- a/python/qiskit_fermions/circuit/library/orbital_rotation.py
+++ b/python/qiskit_fermions/circuit/library/orbital_rotation.py
@@ -23,7 +23,7 @@ class OrbitalRotation(FermionicGate):
     """Implements an orbital rotation."""
 
     def __init__(self, rotation_unitary: np.ndarray) -> None:
-        """Initializes the orbital rotation.
+        """Initializing an instance of this gate can be done with the arguments listed below.
 
         Args:
             rotation_unitary: the unitary matrix representing the orbital rotation coefficients.

--- a/python/qiskit_fermions/transpiler/passes/layout/custom.py
+++ b/python/qiskit_fermions/transpiler/passes/layout/custom.py
@@ -32,7 +32,7 @@ class CustomF2QLayout(FermionicDAGCircuitPass):
     """
 
     def __init__(self, layout: F2QLayout) -> None:
-        """Initializes the transpiler pass.
+        """Initializing this transpiler pass can be done with the arguments listed below.
 
         Args:
             layout: the custom ``f2q_layout`` to use.

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -40,7 +40,7 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
         filter_diagonal_terms: bool = False,
         rng: np.random.Generator | int | None = None,
     ) -> None:
-        """Initializes the transpiler pass.
+        """Initializing this transpiler pass can be done with the arguments listed below.
 
         Args:
             num_terms: the number of terms to include in the qDRIFT Trotterization.

--- a/python/qiskit_fermions/transpiler/passes/optimization/relabel_modes.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/relabel_modes.py
@@ -51,8 +51,7 @@ def _sliding_window(iterable: Iterable[Any], n: int) -> Generator[tuple[Any, ...
 class RelabelModes(FermionicDAGCircuitPass):
     """A transpilation pass to relabel the fermionic modes.
 
-    Post-processing
-    ^^^^^^^^^^^^^^^
+    .. rubric:: Post-processing
 
     The :class:`.FermionicDAGCircuit` returned by this transpiler pass will have a new field in its
     :attr:`~qiskit.dagcircuit.DAGCircuit.metadata` called ``permutation`` which will contain the
@@ -119,7 +118,7 @@ class RelabelModes(FermionicDAGCircuitPass):
         solver: pyomo.opt.SolverFactory | None = None,
         **kwargs,
     ) -> None:
-        """Initializes the transpiler pass.
+        """Initializing this transpiler pass can be done with the arguments listed below.
 
         Args:
             permutation: the index permutation used to relabel the fermionic mode indices. When this

--- a/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
@@ -33,7 +33,7 @@ class EvolutionSynthesis:
     """A :class:`.F2QSynthesisPlugin` for transpiling a :class:`.Evolution`."""
 
     def __init__(self, mapper_fn: MapperFunction) -> None:
-        """Initializes the transpilation plugin.
+        """Initializing this transpiler pass plugin can be done with the arguments listed below.
 
         Args:
             mapper_fn: the fermion-to-qubit operator mapping function.

--- a/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
@@ -57,8 +57,7 @@ class F2QSynthesis(GenericPass[FermionicDAGCircuit, DAGCircuit]):
     :class:`~qiskit_fermions.transpiler.F2QLayout` setting.
     """
 
-    def __init__(self) -> None:
-        """Initializes the transpiler pass."""
+    def __init__(self) -> None:  # noqa: D107
         super().__init__()
 
         self.plugins: dict[type[DAGOpNode], F2QSynthesisPlugin] = {}


### PR DESCRIPTION
Prior to this PR, the content of the `__init__` docstrings never made it into the rendered docs. As a result of that, none of the input parameters were being documented. This addresses that.

As a convention, we should now ensure that the beginning of our `__init__` docstrings read as though they are the continuation of the class-level docstring.

---

This also makes a minor stylistic update to the `Post-processing` rubric in the `RelabelModes` docstring, which would otherwise result in wrong formatting of the `Parameters` list.