### PR TITLE
feat: properly expose synthesis plugin via entry-points

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ autosummary_generate = True
 autosummary_generate_overwrite = False
 autoclass_content = "both"
 autodoc_typehints = "description"
-autodoc_class_signature = "separated"
+autodoc_class_signature = "mixed"
 autodoc_default_options = {
     "inherited-members": None,
     "show-inheritance": True,

--- a/docs/pydoc/index.rst
+++ b/docs/pydoc/index.rst
@@ -48,6 +48,7 @@ Transpiler
 
    qiskit_fermions.transpiler
    qiskit_fermions.transpiler.passes
+   qiskit_fermions.transpiler.passes.plugins
    qiskit_fermions.transpiler.passes.utils
    qiskit_fermions.transpiler.presets
 

--- a/docs/pydoc/qiskit_fermions.transpiler.passes.plugins.rst
+++ b/docs/pydoc/qiskit_fermions.transpiler.passes.plugins.rst
@@ -1,0 +1,52 @@
+.. _qiskit_fermions-transpiler-passes-synthesis-plugins:
+
+=======================
+Transpiler Pass Plugins
+=======================
+
+.. currentmodule:: qiskit_fermions.transpiler.passes.synthesis
+
+The :class:`.F2QSynthesis` transpiler pass exposes a `plugin interface` (see
+:class:`.F2QSynthesisPlugin`) through which implementations for mapping fermion-based instructions
+to qubit-based ones can be registered.
+
+The available plugins are managed by the :class:`.F2QSynthesisPluginManager`. Choosing the right
+combination of synthesis plugins is crucial and the :class:`.F2QSynthesis` transpilation pass does
+**not** have any default plugins defined! For this, refer to the transpiler
+:mod:`~qiskit_fermions.transpiler.presets`.
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   F2QSynthesisPlugin
+   F2QSynthesisPluginManager
+
+The plugins to use at runtime have to be registered in the :attr:`.F2QSynthesis.methods` attribute.
+This can be done easily through the ``config`` argument of :class:`.F2QSynthesis` which specifies
+the plugins to use from the :class:`.F2QSynthesisPluginManager` or it can be done manually by
+writing into :attr:`.F2QSynthesis.methods` directly.
+
+The table below lists the builtin synthesis plugins, organized by the :class:`.FermionicGate` that
+they act upon:
+
+.. _builtin_synthesis_plugins:
+
+.. table:: An overview of the builtin ``qiskit_fermions.transpiler.synthesis`` entry-points.
+
+   +---------------------------+-------------------------+------------------------------------------------------+
+   | Circuit instruction name  | Plugin method name      | Reference                                            |
+   +===========================+=========================+======================================================+
+   | :class:`.Evolution`       | ``MapperFn``            | :class:`MapperFnEvolutionSynthesis`                  |
+   +---------------------------+-------------------------+------------------------------------------------------+
+   | :class:`.InitializeModes` | ``TrivialOccupation``   | :class:`TrivialOccupationInitializeModesSynthesis`   |
+   +---------------------------+-------------------------+------------------------------------------------------+
+   | :class:`.OrbitalRotation` | ``GivensDecomposition`` | :class:`GivensDecompositionOrbitalRotationSynthesis` |
+   +---------------------------+-------------------------+------------------------------------------------------+
+
+.. autosummary::
+   :toctree: ../stubs/
+   :class: sd-d-none
+
+   GivensDecompositionOrbitalRotationSynthesis
+   MapperFnEvolutionSynthesis
+   TrivialOccupationInitializeModesSynthesis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     "qiskit>=2.5.0, <3",
+    "stevedore>=3.0.0",
     "typing-extensions",
 ]
 
@@ -95,6 +96,11 @@ dev = [
     {include-group = "coverage"},
     "tox>=4.28.0",
 ]
+
+[project.entry-points."qiskit_fermions.transpiler.synthesis"]
+"Evolution.MapperFn" = "qiskit_fermions.transpiler.passes.synthesis:MapperFnEvolutionSynthesis"
+"InitializeModes.TrivialOccupation" = "qiskit_fermions.transpiler.passes.synthesis:TrivialOccupationInitializeModesSynthesis"
+"OrbitalRotation.GivensDecomposition" = "qiskit_fermions.transpiler.passes.synthesis:GivensDecompositionOrbitalRotationSynthesis"
 
 [tool.setuptools]
 include-package-data = true

--- a/python/qiskit_fermions/transpiler/__init__.py
+++ b/python/qiskit_fermions/transpiler/__init__.py
@@ -87,6 +87,7 @@ Therefore, the user-provided fermion-to-qubit layout (:type:`F2QLayout`) associa
 
 .. autosummary::
    :toctree: ../stubs/
+   :template: autosummary/typealias.rst
 
    F2QLayout
 

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -68,45 +68,81 @@ The main logic for mapping a :class:`.FermionicDAGCircuit` to a
    :toctree: ../stubs/
 
    F2QSynthesis
+   ~synthesis.synthesis.F2QSynthesisConfig
 
 .. _qiskit_fermions-transpiler-passes-synthesis-plugins:
 
 Plugins
 ^^^^^^^
 
-As mentioned above, the :class:`.F2QSynthesis` transpiler pass exposes a `plugin interface` through
-which implementations for mapping fermion-based instructions to qubit-based ones can be registered.
-For more details on how to implement your own plugin, refer to :attr:`.F2QSynthesis.plugins`.
+As mentioned above, the :class:`.F2QSynthesis` transpiler pass exposes a `plugin interface` (see
+:class:`.F2QSynthesisPlugin`) through which implementations for mapping fermion-based instructions
+to qubit-based ones can be registered.
 
-For most common gates provided by :mod:`qiskit_fermions.circuit.library`, this module already
-provides builtin plugins:
+The available plugins are managed by the :class:`.F2QSynthesisPluginManager`. Choosing the right
+combination of synthesis plugins is crucial and the :class:`.F2QSynthesis` transpilation pass does
+**not** have any default plugins defined! For this, refer to the transpiler
+:mod:`~qiskit_fermions.transpiler.presets`.
 
 .. autosummary::
    :toctree: ../stubs/
 
-   EvolutionSynthesis
-   InitializeModesSynthesis
-   OrbitalRotationSynthesis
+   F2QSynthesisPlugin
+   F2QSynthesisPluginManager
+
+The plugins to use at runtime have to be registered in the :attr:`.F2QSynthesis.methods` attribute.
+This can be done easily through the ``config`` argument of :class:`.F2QSynthesis` which specifies
+the plugins to use from the :class:`.F2QSynthesisPluginManager` or it can be done manually by
+writing into :attr:`.F2QSynthesis.methods` directly.
+
+The table below lists the builtin synthesis plugins, organized by the :class:`.FermionicGate` that
+they act upon:
+
+.. _builtin_synthesis_plugins:
+
+.. table:: An overview of the builtin ``qiskit_fermions.transpiler.synthesis`` entry-points.
+
+   +---------------------------+-------------------------+------------------------------------------------------+
+   | Circuit instruction name  | Plugin method name      | Reference                                            |
+   +===========================+=========================+======================================================+
+   | :class:`.Evolution`       | ``MapperFn``            | :class:`MapperFnEvolutionSynthesis`                  |
+   +---------------------------+-------------------------+------------------------------------------------------+
+   | :class:`.InitializeModes` | ``TrivialOccupation``   | :class:`TrivialOccupationInitializeModesSynthesis`   |
+   +---------------------------+-------------------------+------------------------------------------------------+
+   | :class:`.OrbitalRotation` | ``GivensDecomposition`` | :class:`GivensDecompositionOrbitalRotationSynthesis` |
+   +---------------------------+-------------------------+------------------------------------------------------+
+
+.. autosummary::
+   :toctree: ../stubs/
+   :class: sd-d-none
+
+   GivensDecompositionOrbitalRotationSynthesis
+   MapperFnEvolutionSynthesis
+   TrivialOccupationInitializeModesSynthesis
 """
 
 from .layout import CustomF2QLayout, TrivialF2QLayout
 from .optimization import QDriftTrotterization, RelabelModes
 from .synthesis import (
-    EvolutionSynthesis,
     F2QSynthesis,
+    F2QSynthesisConfig,
     F2QSynthesisPlugin,
-    InitializeModesSynthesis,
-    OrbitalRotationSynthesis,
+    F2QSynthesisPluginManager,
+    GivensDecompositionOrbitalRotationSynthesis,
+    MapperFnEvolutionSynthesis,
+    TrivialOccupationInitializeModesSynthesis,
 )
 
 __all__ = [
     "CustomF2QLayout",
-    "EvolutionSynthesis",
     "F2QSynthesis",
+    "F2QSynthesisConfig",
     "F2QSynthesisPlugin",
-    "InitializeModesSynthesis",
-    "OrbitalRotationSynthesis",
+    "F2QSynthesisPluginManager",
+    "GivensDecompositionOrbitalRotationSynthesis",
+    "MapperFnEvolutionSynthesis",
     "QDriftTrotterization",
     "RelabelModes",
     "TrivialF2QLayout",
+    "TrivialOccupationInitializeModesSynthesis",
 ]

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -12,9 +12,9 @@
 
 # ruff: noqa: D205,D212,D415
 """
-====================
-Transpilation Passes
-====================
+=================
+Transpiler Passes
+=================
 
 .. currentmodule:: qiskit_fermions.transpiler.passes
 
@@ -69,56 +69,6 @@ The main logic for mapping a :class:`.FermionicDAGCircuit` to a
 
    F2QSynthesis
    ~synthesis.synthesis.F2QSynthesisConfig
-
-.. _qiskit_fermions-transpiler-passes-synthesis-plugins:
-
-Plugins
-^^^^^^^
-
-As mentioned above, the :class:`.F2QSynthesis` transpiler pass exposes a `plugin interface` (see
-:class:`.F2QSynthesisPlugin`) through which implementations for mapping fermion-based instructions
-to qubit-based ones can be registered.
-
-The available plugins are managed by the :class:`.F2QSynthesisPluginManager`. Choosing the right
-combination of synthesis plugins is crucial and the :class:`.F2QSynthesis` transpilation pass does
-**not** have any default plugins defined! For this, refer to the transpiler
-:mod:`~qiskit_fermions.transpiler.presets`.
-
-.. autosummary::
-   :toctree: ../stubs/
-
-   F2QSynthesisPlugin
-   F2QSynthesisPluginManager
-
-The plugins to use at runtime have to be registered in the :attr:`.F2QSynthesis.methods` attribute.
-This can be done easily through the ``config`` argument of :class:`.F2QSynthesis` which specifies
-the plugins to use from the :class:`.F2QSynthesisPluginManager` or it can be done manually by
-writing into :attr:`.F2QSynthesis.methods` directly.
-
-The table below lists the builtin synthesis plugins, organized by the :class:`.FermionicGate` that
-they act upon:
-
-.. _builtin_synthesis_plugins:
-
-.. table:: An overview of the builtin ``qiskit_fermions.transpiler.synthesis`` entry-points.
-
-   +---------------------------+-------------------------+------------------------------------------------------+
-   | Circuit instruction name  | Plugin method name      | Reference                                            |
-   +===========================+=========================+======================================================+
-   | :class:`.Evolution`       | ``MapperFn``            | :class:`MapperFnEvolutionSynthesis`                  |
-   +---------------------------+-------------------------+------------------------------------------------------+
-   | :class:`.InitializeModes` | ``TrivialOccupation``   | :class:`TrivialOccupationInitializeModesSynthesis`   |
-   +---------------------------+-------------------------+------------------------------------------------------+
-   | :class:`.OrbitalRotation` | ``GivensDecomposition`` | :class:`GivensDecompositionOrbitalRotationSynthesis` |
-   +---------------------------+-------------------------+------------------------------------------------------+
-
-.. autosummary::
-   :toctree: ../stubs/
-   :class: sd-d-none
-
-   GivensDecompositionOrbitalRotationSynthesis
-   MapperFnEvolutionSynthesis
-   TrivialOccupationInitializeModesSynthesis
 """
 
 from .layout import CustomF2QLayout, TrivialF2QLayout

--- a/python/qiskit_fermions/transpiler/passes/optimization/relabel_modes.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/relabel_modes.py
@@ -72,14 +72,15 @@ class RelabelModes(FermionicDAGCircuitPass):
        >>> from qiskit_fermions.circuit.library import InitializeModes
        >>> from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
        >>> from qiskit_fermions.transpiler.passes import (
-       ...     F2QSynthesis, InitializeModesSynthesis, RelabelModes, TrivialF2QLayout,
+       ...     F2QSynthesis, F2QSynthesisPluginManager, RelabelModes, TrivialF2QLayout,
        ... )
        >>>
        >>> circ = FermionicCircuit(4)
        >>> circ.append(InitializeModes([1, 1, 0, 0]), circ.modes)
        >>>
+       >>> synth_plugins = F2QSynthesisPluginManager()
        >>> synth = F2QSynthesis()
-       >>> synth.plugins[InitializeModes] = InitializeModesSynthesis()
+       >>> synth.methods["InitializeModes"] = synth_plugins.method("InitializeModes", "TrivialOccupation")()
        >>>
        >>> relabel = RelabelModes(permutation=[0, 2, 1, 3])
        >>>

--- a/python/qiskit_fermions/transpiler/passes/synthesis/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/__init__.py
@@ -12,15 +12,18 @@
 
 """Synthesis passes."""
 
-from .evolution import EvolutionSynthesis
-from .initialize_modes import InitializeModesSynthesis
-from .orbital_rotation import OrbitalRotationSynthesis
-from .synthesis import F2QSynthesis, F2QSynthesisPlugin
+from .evolution import MapperFnEvolutionSynthesis
+from .initialize_modes import TrivialOccupationInitializeModesSynthesis
+from .orbital_rotation import GivensDecompositionOrbitalRotationSynthesis
+from .plugin import F2QSynthesisPlugin, F2QSynthesisPluginManager
+from .synthesis import F2QSynthesis, F2QSynthesisConfig
 
 __all__ = [
-    "EvolutionSynthesis",
     "F2QSynthesis",
+    "F2QSynthesisConfig",
     "F2QSynthesisPlugin",
-    "InitializeModesSynthesis",
-    "OrbitalRotationSynthesis",
+    "F2QSynthesisPluginManager",
+    "GivensDecompositionOrbitalRotationSynthesis",
+    "MapperFnEvolutionSynthesis",
+    "TrivialOccupationInitializeModesSynthesis",
 ]

--- a/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
@@ -29,8 +29,8 @@ MapperFunction = Callable[[OperatorTrait, int], SparseObservable]
 """The function signature for :attr:`mapper_fn`."""
 
 
-class EvolutionSynthesis:
-    """A :class:`.F2QSynthesisPlugin` for transpiling a :class:`.Evolution`."""
+class MapperFnEvolutionSynthesis:
+    """A :class:`.F2QSynthesisPlugin` for transpiling :class:`.Evolution` under a custom mapping."""
 
     def __init__(self, mapper_fn: MapperFunction) -> None:
         """Initializing this transpiler pass plugin can be done with the arguments listed below.

--- a/python/qiskit_fermions/transpiler/passes/synthesis/initialize_modes.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/initialize_modes.py
@@ -22,19 +22,15 @@ from ... import F2QLayout
 from ..utils import map_node_single_register
 
 
-class InitializeModesSynthesis:
-    """A :class:`.F2QSynthesisPlugin` for transpiling a :class:`.InitializeModes`.
-
-    .. caution::
-       This is an early development prototype. Beware of changes to its interface without warning
-       during the pre-release development of this package.
+class TrivialOccupationInitializeModesSynthesis:
+    """A :class:`.F2QSynthesisPlugin` for transpiling :class:`.InitializeModes` with trivial occupation.
 
     .. warning::
-       This transpilation pass plugin is known to have certain limitations, including:
+       This transpilation pass plugin makes the following assumptions:
 
-       - assuming an occupation-basis encoding (like Jordan-Wigner)
-       - assuming a trivial fermion-to-qubit layout (i.e. no change in their register lengths)
-       - assuming a 1-to-1 mapping of fermionic mode indices to qubit indices
+       - an occupation-basis encoding (like Jordan-Wigner)
+       - a trivial fermion-to-qubit layout (i.e. no change in their register lengths)
+       - a 1-to-1 mapping of fermionic mode indices to qubit indices
     """
 
     def run(self, in_node: DAGOpNode, out_dag: DAGCircuit, *, f2q_layout: F2QLayout) -> None:

--- a/python/qiskit_fermions/transpiler/passes/synthesis/orbital_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/orbital_rotation.py
@@ -29,15 +29,15 @@ from ... import F2QLayout
 from ..utils import map_node_single_register
 
 
-class OrbitalRotationSynthesis:
-    """A :class:`.F2QSynthesisPlugin` for transpiling a :class:`.OrbitalRotation`.
+class GivensDecompositionOrbitalRotationSynthesis:
+    """A :class:`.F2QSynthesisPlugin` for transpiling :class:`.OrbitalRotation` into Givens rotations.
 
     .. warning::
-       This transpilation pass plugin is known to have certain limitations, including:
+       This transpilation pass plugin makes the following assumptions:
 
-       - assuming an occupation-basis encoding (like Jordan-Wigner)
-       - assuming a trivial fermion-to-qubit layout (i.e. no change in their register lengths)
-       - assuming a 1-to-1 mapping of fermionic mode indices to qubit indices
+       - an occupation-basis encoding (like Jordan-Wigner)
+       - a trivial fermion-to-qubit layout (i.e. no change in their register lengths)
+       - a 1-to-1 mapping of fermionic mode indices to qubit indices
     """
 
     def run(self, in_node: DAGOpNode, out_dag: DAGCircuit, *, f2q_layout: F2QLayout) -> None:

--- a/python/qiskit_fermions/transpiler/passes/synthesis/plugin.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/plugin.py
@@ -1,0 +1,108 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Fermion-to-qubit circuit synthesis pass plugin management."""
+
+from __future__ import annotations
+
+from typing import Protocol, cast
+
+from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+from stevedore import ExtensionManager
+
+from ... import F2QLayout
+
+
+class F2QSynthesisPlugin(Protocol):
+    """The protocol for plugins to the :class:`.F2QSynthesis` transpiler pass."""
+
+    def run(self, in_node: DAGOpNode, out_dag: DAGCircuit, *, f2q_layout: F2QLayout) -> None:
+        """Translates the provided fermion-based circuit instruction to a qubit-based one.
+
+        Args:
+            in_node: a fermion-based circuit instruction stored in a
+                :class:`~qiskit.dagcircuit.DAGOpNode`. Specifically, this guarantees that
+                :attr:`~qiskit.dagcircuit.DAGOpNode.op` is of type :class:`.FermionicGate`.
+            out_dag: the qubit-based :class:`~qiskit.dagcircuit.DAGCircuit` into which this plugin
+                must insert the translated circuit instruction.
+            f2q_layout: the :type:`~qiskit_fermions.transpiler.F2QLayout` setting that is global to
+                the transpilation process. It is the plugin's responsibility to respect this mapping
+                of :type:`~qiskit_fermions.circuit.FermionicRegister` to
+                :class:`~qiskit.circuit.QuantumRegister`.
+        """
+        ...
+
+
+class F2QSynthesisPluginManager:
+    """A simple manager of the installed fermion-to-qubit synthesis plugins.
+
+    All plugins that are registered under the ``qiskit_fermions.transpiler.synthesis``
+    `entry-point <https://setuptools.pypa.io/en/latest/userguide/entry_point.html>`_ will be
+    available to this class and get exposed by the :attr:`plugins` attribute. Below is an example
+    from the ``pyproject.toml`` of this package itself:
+
+    .. literalinclude:: ../../pyproject.toml
+       :language: toml
+       :start-at: entry-points
+       :end-before: setuptools
+
+    An overview of all builtin plugins is given in :ref:`this table <builtin_synthesis_plugins>`.
+    """
+
+    def __init__(self) -> None:  # noqa: D107
+        self._manager = ExtensionManager(
+            "qiskit_fermions.transpiler.synthesis",
+            invoke_on_load=False,
+            propagate_map_exceptions=True,
+        )
+
+        self.plugins: dict[str, list[str]] = {}
+        """A dictionary mapping circuit instruction names to their synthesis methods.
+
+        The keys of this dictionary are names of :class:`.FermionicGate` classes. The values are the
+        list of installed :class:`.F2QSynthesisPlugin` methods that may be used to synthesize the
+        instances of that particular gate to its qubit form.
+        """
+
+        for plugin_name in self._manager.names():
+            op_name, method_name = plugin_name.split(".")
+            if op_name not in self.plugins:
+                self.plugins[op_name] = []
+            self.plugins[op_name].append(method_name)
+
+    def method_names(self, op_name: str) -> list[str]:
+        """Returns the names of all installed plugin methods for a given circuit instruction.
+
+        Args:
+            op_name: the name of the operation whose synthesis methods to return.
+
+        Returns:
+            The list of installed plugin method names.
+        """
+        return self.plugins.get(op_name, [])
+
+    def method(self, op_name: str, method_name: str) -> type[F2QSynthesisPlugin]:
+        """Returns the requested :class:`.F2QSynthesisPlugin` type.
+
+        Args:
+            op_name: the name of the operation whose plugin to return.
+            method_name: the name of the synthesis plugin.
+
+        Returns:
+            The :class:`.F2QSynthesisPlugin` class.
+        """
+        plugin_name = op_name + "." + method_name
+        return cast(type[F2QSynthesisPlugin], self._manager[plugin_name].plugin)
+
+    def op_names(self) -> list[str]:
+        """Returns the names of all circuit instructions for which any plugin is installed."""
+        return list(self.plugins.keys())

--- a/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/synthesis.py
@@ -14,34 +14,36 @@
 
 from __future__ import annotations
 
-from typing import Protocol, cast
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeAlias, cast
 
-from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+from qiskit.dagcircuit import DAGCircuit
 from qiskit.passmanager import GenericPass
 
 from qiskit_fermions.circuit import FermionicDAGCircuit, FermionicGate
 
 from ... import F2QLayout
+from .plugin import F2QSynthesisPlugin, F2QSynthesisPluginManager
 
+F2QSynthesisConfig: TypeAlias = dict[
+    str, str | tuple[str, Sequence[Any]] | tuple[str, Sequence[Any], Mapping[str, Any]]
+]
+"""The dictionary type used to configure the :attr:`.F2QSynthesis.methods`.
 
-class F2QSynthesisPlugin(Protocol):
-    """The protocol for plugins to the :class:`.F2QSynthesis` transpiler pass."""
+The keys of this dictionary must be names of :class:`.FermionicGate` circuit instructions.
+The values can be one of three types:
 
-    def run(self, in_node: DAGOpNode, out_dag: DAGCircuit, *, f2q_layout: F2QLayout) -> None:
-        """Translates the provided fermion-based circuit instruction to a qubit-based one.
-
-        Args:
-            in_node: a fermion-based circuit instruction stored in a
-                :class:`~qiskit.dagcircuit.DAGOpNode`. Specifically, this guarantees that
-                :attr:`~qiskit.dagcircuit.DAGOpNode.op` is of type :class:`.FermionicGate`.
-            out_dag: the qubit-based :class:`~qiskit.dagcircuit.DAGCircuit` into which this plugin
-                must insert the translated circuit instruction.
-            f2q_layout: the :type:`~qiskit_fermions.transpiler.F2QLayout` setting that is global to
-                the transpilation process. It is the plugin's responsibility to respect this mapping
-                of :type:`~qiskit_fermions.circuit.FermionicRegister` to
-                :class:`~qiskit.circuit.QuantumRegister`.
-        """
-        ...
+1. ``str``: the simplest scenario simply specifies the name of the plugin method to use for the
+   corresponding key in this dictionary. The plugin is extracted from the
+   :class:`.F2QSynthesisPluginManager` and it's ``__init__`` method may **not** require any
+   arguments.
+2. ``tuple[str, Sequence[Any]]``: the first ``str`` is the same as the above, and the second
+   ``Sequence[Any]`` can be used to provide any positional arguments to the plugin's ``__init__``
+   method.
+3. ``tuple[str, Sequence[Any], Mapping[str, Any]]``: the first two fields are the same as in 2. and
+   the third ``Mapping[str, Any]`` can be used to provide any keyword arguments to the plugin's
+   ``__init__`` method.
+"""
 
 
 class F2QSynthesis(GenericPass[FermionicDAGCircuit, DAGCircuit]):
@@ -49,27 +51,92 @@ class F2QSynthesis(GenericPass[FermionicDAGCircuit, DAGCircuit]):
 
     This transpilation pass works similarly to Qiskit's
     :class:`~qiskit.transpiler.passes.HighLevelSynthesis` pass; given an input
-    :class:`~qiskit.dagcircuit.DAGCircuit` with :class:`.FermionicGate` instructions, it iterates them
-    and delegates the translation to qubit-based instructions to matching :attr:`plugins`.
-    The insertion of the qubit-based circuit instructions into the output
-    :class:`~qiskit.dagcircuit.DAGCircuit` is also left to the plugin. This pass will merely have
-    prepared the :class:`~qiskit.circuit.QuantumRegister` according to the global transpilation
+    :class:`.FermionicDAGCircuit`, it iterates the contained instructions and delegates the
+    translation to qubit-based instructions to matching :attr:`methods`. The insertion of the
+    qubit-based circuit instructions into the output :class:`~qiskit.dagcircuit.DAGCircuit` is also
+    left to the plugin method. This pass will merely have prepared the
+    :class:`~qiskit.circuit.QuantumRegister` according to the global transpilation
     :class:`~qiskit_fermions.transpiler.F2QLayout` setting.
+
+    .. rubric:: Usage
+
+    There are two ways to configure the plugins used by this transpiler pass. The examples below
+    show the equivalent configuration to the :func:`.generate_preset_jw_pass_manager`.
+
+    1. Providing a ``config`` during initialization:
+
+       .. doctest::
+
+          >>> from qiskit_fermions.mappers.library import jordan_wigner
+          >>> from qiskit_fermions.transpiler import passes
+          >>>
+          >>> config = {
+          ...     "Evolution": ("MapperFn", (jordan_wigner,)),
+          ...     "InitializeModes": "TrivialOccupation",
+          ...     "OrbitalRotation": "GivensDecomposition",
+          ... }
+          >>> synth = passes.F2QSynthesis(config)
+
+    2. Manually populating the :attr:`methods` attribute:
+
+       .. doctest::
+
+          >>> from qiskit_fermions.mappers.library import jordan_wigner
+          >>> from qiskit_fermions.transpiler import passes
+          >>>
+          >>> synth = passes.F2QSynthesis()
+          >>> synth.methods["Evolution"] = passes.MapperFnEvolutionSynthesis(jordan_wigner)
+          >>> synth.methods["InitializeModes"] = passes.TrivialOccupationInitializeModesSynthesis()
+          >>> synth.methods["OrbitalRotation"] = passes.GivensDecompositionOrbitalRotationSynthesis()
+
+       Through this manual approach it is also possible to inject custom
+       :class:`.F2QSynthesisPlugin` implementations without requiring them to be registered through
+       an `entry-point <https://setuptools.pypa.io/en/latest/userguide/entry_point.html>`_.
+
     """
 
-    def __init__(self) -> None:  # noqa: D107
+    def __init__(self, config: F2QSynthesisConfig | None = None) -> None:
+        """Initializing this transpiler pass can be done with the arguments listed below.
+
+        Args:
+            config: an optional dictionary to pre-populate the :attr:`methods` with plugins provided
+                by the :class:`.F2QSynthesisPluginManager`.
+        """
         super().__init__()
 
-        self.plugins: dict[type[DAGOpNode], F2QSynthesisPlugin] = {}
-        """A dictionary of fermion-to-qubit circuit instruction transpilation plugins.
+        self.methods: dict[str, F2QSynthesisPlugin] = {}
+        """A dictionary of fermion-to-qubit circuit instruction transpilation methods.
 
-        .. autoclass:: F2QSynthesisPlugin
-           :show-inheritance:
-           :members:
-           :exclude-members: __init__
-           :no-inherited-members:
-           :no-special-members:
+        For this transpilation pass to have any effect, this dictionary must be populated with
+        instances of the :class:`.F2QSynthesisPlugin` protocol. The keys of this dictionary
+        correspond to the ``__name__`` of a circuit instruction.
+
+        All available transpilation plugins are managed by the :class:`.F2QSynthesisPluginManager`.
+
+        .. note::
+           This dictionary is **empty** by default! You can pre-populate it with plugins provided by
+           the :class:`.F2QSynthesisPluginManager` by providing a ``config`` argument during
+           initialization of this transpiler pass instance.
         """
+
+        if config is not None:
+            pm = F2QSynthesisPluginManager()
+            for op_name, method_spec in config.items():
+                init_args: Sequence[Any] = ()
+                init_kwargs: Mapping[str, Any] = {}
+                match method_spec:
+                    case str():
+                        method_name = method_spec
+                    case (name, args):
+                        method_name = name
+                        init_args = args
+                    case (name, args, kwargs):
+                        method_name = name
+                        init_args = args
+                        init_kwargs = kwargs
+
+                method = pm.method(op_name, method_name)
+                self.methods[op_name] = method(*init_args, **init_kwargs)
 
     def run(self, dag: FermionicDAGCircuit) -> DAGCircuit:
         """Runs this transpilation pass.
@@ -86,7 +153,7 @@ class F2QSynthesis(GenericPass[FermionicDAGCircuit, DAGCircuit]):
             ValueError: when a :class:`~qiskit.dagcircuit.DAGOpNode` is encountered whose
                 :attr:`~qiskit.dagcircuit.DAGOpNode.op` is not of type :class:`.FermionicGate`.
             TypeError: when a :class:`.FermionicGate` type is encountered for which no translation
-                plugin is present in :attr:`plugins`.
+                plugin is present in :attr:`methods`.
         """
         f2q_layout = cast(F2QLayout, self.property_set["f2q_layout"])
 
@@ -102,7 +169,7 @@ class F2QSynthesis(GenericPass[FermionicDAGCircuit, DAGCircuit]):
             if not isinstance(node.op, FermionicGate):
                 raise ValueError("Encountered an unsupported circuit instruction type: {}", op_type)
 
-            plugin = self.plugins.get(op_type, None)
+            plugin = self.methods.get(op_type.__name__, None)
             if plugin is None:
                 raise TypeError(
                     "No plugin registered for transpiling a circuit instruction of type: {}",

--- a/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
+++ b/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
@@ -15,17 +15,10 @@
 from qiskit.passmanager import MultiStagePassManager
 from qiskit.transpiler import generate_preset_pass_manager
 
-from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
 from qiskit_fermions.mappers.library import jordan_wigner
 
 from .. import FermionicCircuitToDAG, FermionicPassManager, QuantumDAGToCircuit
-from ..passes import (
-    EvolutionSynthesis,
-    F2QSynthesis,
-    InitializeModesSynthesis,
-    OrbitalRotationSynthesis,
-    TrivialF2QLayout,
-)
+from ..passes import F2QSynthesis, F2QSynthesisConfig, TrivialF2QLayout
 
 
 def generate_preset_jw_pass_manager(**kwargs) -> MultiStagePassManager:
@@ -43,10 +36,12 @@ def generate_preset_jw_pass_manager(**kwargs) -> MultiStagePassManager:
 
     layout = FermionicPassManager(TrivialF2QLayout())
 
-    synth = F2QSynthesis()
-    synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)  # type: ignore[arg-type]
-    synth.plugins[InitializeModes] = InitializeModesSynthesis()
-    synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
+    config: F2QSynthesisConfig = {
+        "Evolution": ("MapperFn", (jordan_wigner,)),
+        "InitializeModes": "TrivialOccupation",
+        "OrbitalRotation": "GivensDecomposition",
+    }
+    synth = F2QSynthesis(config)
 
     pm = MultiStagePassManager(
         input=FermionicCircuitToDAG(),

--- a/tests/python/transpiler/passes/test_custom_layout.py
+++ b/tests/python/transpiler/passes/test_custom_layout.py
@@ -24,7 +24,11 @@ from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.operators import MajoranaOperator
 from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
-from qiskit_fermions.transpiler.passes import CustomF2QLayout, EvolutionSynthesis, F2QSynthesis
+from qiskit_fermions.transpiler.passes import (
+    CustomF2QLayout,
+    F2QSynthesis,
+    MapperFnEvolutionSynthesis,
+)
 
 
 # NOTE: this is a very specific implementation of the Fermi-Hubbard model on a square lattice. It is
@@ -329,7 +333,7 @@ def test_custom_layout():
     layout = CustomF2QLayout({circ.register: QuantumRegister(num_qubits)})
 
     synth = F2QSynthesis()
-    synth.plugins[Evolution] = EvolutionSynthesis(mapper_fn)
+    synth.methods["Evolution"] = MapperFnEvolutionSynthesis(mapper_fn)
 
     pm = MultiStagePassManager(
         input=FermionicCircuitToDAG(),

--- a/tests/python/transpiler/passes/test_evolution_synthesis.py
+++ b/tests/python/transpiler/passes/test_evolution_synthesis.py
@@ -21,7 +21,11 @@ from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
-from qiskit_fermions.transpiler.passes import EvolutionSynthesis, F2QSynthesis, TrivialF2QLayout
+from qiskit_fermions.transpiler.passes import (
+    F2QSynthesis,
+    MapperFnEvolutionSynthesis,
+    TrivialF2QLayout,
+)
 
 
 def test_evolution_gate_synthesis():
@@ -40,7 +44,7 @@ def test_evolution_gate_synthesis():
     circ.append(evo, circ.modes)
 
     synth = F2QSynthesis()
-    synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
+    synth.methods["Evolution"] = MapperFnEvolutionSynthesis(jordan_wigner)
 
     pm = MultiStagePassManager(
         input=FermionicCircuitToDAG(),
@@ -81,7 +85,7 @@ def test_custom_qubit_ordering():
         return jordan_wigner(relabeled, num_qubits)
 
     synth = F2QSynthesis()
-    synth.plugins[Evolution] = EvolutionSynthesis(custom_qubit_ordering_mapper_fn)
+    synth.methods["Evolution"] = MapperFnEvolutionSynthesis(custom_qubit_ordering_mapper_fn)
 
     pm = MultiStagePassManager(
         input=FermionicCircuitToDAG(),

--- a/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
+++ b/tests/python/transpiler/passes/test_initialize_modes_synthesis.py
@@ -22,8 +22,8 @@ from qiskit_fermions.circuit.library import InitializeModes
 from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
 from qiskit_fermions.transpiler.passes import (
     F2QSynthesis,
-    InitializeModesSynthesis,
     TrivialF2QLayout,
+    TrivialOccupationInitializeModesSynthesis,
 )
 
 
@@ -35,7 +35,7 @@ def test_initialize_modes_global_gate_synthesis():
     circ.append(init, circ.modes)
 
     synth = F2QSynthesis()
-    synth.plugins[InitializeModes] = InitializeModesSynthesis()
+    synth.methods["InitializeModes"] = TrivialOccupationInitializeModesSynthesis()
 
     pm = MultiStagePassManager(
         input=FermionicCircuitToDAG(),
@@ -61,7 +61,7 @@ def test_initialize_modes_local_gate_synthesis():
     circ.append(init, circ.modes[1:3])
 
     synth = F2QSynthesis()
-    synth.plugins[InitializeModes] = InitializeModesSynthesis()
+    synth.methods["InitializeModes"] = TrivialOccupationInitializeModesSynthesis()
 
     pm = MultiStagePassManager(
         input=FermionicCircuitToDAG(),

--- a/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
+++ b/tests/python/transpiler/passes/test_orbital_rotation_synthesis.py
@@ -20,7 +20,7 @@ from qiskit_fermions.circuit.library import OrbitalRotation
 from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
 from qiskit_fermions.transpiler.passes import (
     F2QSynthesis,
-    OrbitalRotationSynthesis,
+    GivensDecompositionOrbitalRotationSynthesis,
     TrivialF2QLayout,
 )
 
@@ -35,7 +35,7 @@ def test_orbital_rotation_global_gate_synthesis():
     circ.append(rot, circ.modes)
 
     synth = F2QSynthesis()
-    synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
+    synth.methods["OrbitalRotation"] = GivensDecompositionOrbitalRotationSynthesis()
 
     pm = MultiStagePassManager(
         input=FermionicCircuitToDAG(),
@@ -61,7 +61,7 @@ def test_initialize_modes_local_gate_synthesis():
     circ.append(rot_b, circ.modes[3:])
 
     synth = F2QSynthesis()
-    synth.plugins[OrbitalRotation] = OrbitalRotationSynthesis()
+    synth.methods["OrbitalRotation"] = GivensDecompositionOrbitalRotationSynthesis()
 
     pm = MultiStagePassManager(
         input=FermionicCircuitToDAG(),

--- a/tests/python/transpiler/passes/test_relabel_modes.py
+++ b/tests/python/transpiler/passes/test_relabel_modes.py
@@ -23,11 +23,11 @@ from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
 from qiskit_fermions.transpiler.passes import (
-    EvolutionSynthesis,
     F2QSynthesis,
-    InitializeModesSynthesis,
+    MapperFnEvolutionSynthesis,
     RelabelModes,
     TrivialF2QLayout,
+    TrivialOccupationInitializeModesSynthesis,
 )
 from qiskit_fermions.utils.optionals import HAS_PYOMO
 
@@ -55,8 +55,8 @@ def test_relabel_modes_fixed_permutation():
     circ.append(evo, circ.modes)
 
     synth = F2QSynthesis()
-    synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
-    synth.plugins[InitializeModes] = InitializeModesSynthesis()
+    synth.methods["Evolution"] = MapperFnEvolutionSynthesis(jordan_wigner)
+    synth.methods["InitializeModes"] = TrivialOccupationInitializeModesSynthesis()
 
     permutation = [0, 2, 1, 3]
     relabel = RelabelModes(permutation)
@@ -99,8 +99,8 @@ def test_relabel_modes_local_indices():
     circ.append(evo, circ.modes[:num_modes])
 
     synth = F2QSynthesis()
-    synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
-    synth.plugins[InitializeModes] = InitializeModesSynthesis()
+    synth.methods["Evolution"] = MapperFnEvolutionSynthesis(jordan_wigner)
+    synth.methods["InitializeModes"] = TrivialOccupationInitializeModesSynthesis()
 
     permutation = [0, 2, 1, 3, 4, 5, 6, 7]
     relabel = RelabelModes(permutation)
@@ -136,7 +136,7 @@ def test_relabel_modes_pyomo_optimization():
     circ.append(evo, circ.modes)
 
     synth = F2QSynthesis()
-    synth.plugins[Evolution] = EvolutionSynthesis(jordan_wigner)
+    synth.methods["Evolution"] = MapperFnEvolutionSynthesis(jordan_wigner)
 
     solver = SolverFactory("appsi_highs")
     solver.options["time_limit"] = 60


### PR DESCRIPTION
Closes #106 

:warning: This is a **breaking change** to the `main` development branch!

Specifically, the `F2QSynthesis.plugins` attribute has been renamed to `F2QSynthesis.methods`. It no longer uses `type[FermionicGate]` as keys but simple `str` matching the gate names.

A new `F2QSynthesisPluginManager` object is being introduced to simplify the handling of these plugins at runtime.