### PR TITLE
fix: make operator `__ne__` the negation of `__eq__`

### DIFF
--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -587,45 +587,13 @@ impl PyEdgeVertexOperator {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, _py: Python<'_>) -> PyResult<bool> {
+        let eq = self.inner.coeffs == other.inner.coeffs
+            && self.inner.left_indices == other.inner.left_indices
+            && self.inner.right_indices == other.inner.right_indices
+            && self.inner.boundaries == other.inner.boundaries;
         match op {
-            CompareOp::Eq => {
-                let coeffs_eq = self.inner.coeffs == other.inner.coeffs;
-                if !coeffs_eq {
-                    return Ok(false);
-                }
-                let left_indices_eq = self.inner.left_indices == other.inner.left_indices;
-                if !left_indices_eq {
-                    return Ok(false);
-                }
-                let right_indices_eq = self.inner.right_indices == other.inner.right_indices;
-                if !right_indices_eq {
-                    return Ok(false);
-                }
-                let boundaries_eq = self.inner.boundaries == other.inner.boundaries;
-                if !boundaries_eq {
-                    return Ok(false);
-                }
-                Ok(true)
-            }
-            CompareOp::Ne => {
-                let coeffs_neq = self.inner.coeffs != other.inner.coeffs;
-                if !coeffs_neq {
-                    return Ok(false);
-                }
-                let left_indices_neq = self.inner.left_indices != other.inner.left_indices;
-                if !left_indices_neq {
-                    return Ok(false);
-                }
-                let right_indices_neq = self.inner.right_indices != other.inner.right_indices;
-                if !right_indices_neq {
-                    return Ok(false);
-                }
-                let boundaries_neq = self.inner.boundaries != other.inner.boundaries;
-                if !boundaries_neq {
-                    return Ok(false);
-                }
-                Ok(true)
-            }
+            CompareOp::Eq => Ok(eq),
+            CompareOp::Ne => Ok(!eq),
             _ => Err(PyErr::new::<PyNotImplementedError, _>("")),
         }
     }

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -547,45 +547,13 @@ impl PyFermionOperator {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, _py: Python<'_>) -> PyResult<bool> {
+        let eq = self.inner.coeffs == other.inner.coeffs
+            && self.inner.actions == other.inner.actions
+            && self.inner.modes == other.inner.modes
+            && self.inner.boundaries == other.inner.boundaries;
         match op {
-            CompareOp::Eq => {
-                let coeffs_eq = self.inner.coeffs == other.inner.coeffs;
-                if !coeffs_eq {
-                    return Ok(false);
-                }
-                let actions_eq = self.inner.actions == other.inner.actions;
-                if !actions_eq {
-                    return Ok(false);
-                }
-                let modes_eq = self.inner.modes == other.inner.modes;
-                if !modes_eq {
-                    return Ok(false);
-                }
-                let boundaries_eq = self.inner.boundaries == other.inner.boundaries;
-                if !boundaries_eq {
-                    return Ok(false);
-                }
-                Ok(true)
-            }
-            CompareOp::Ne => {
-                let coeffs_neq = self.inner.coeffs != other.inner.coeffs;
-                if !coeffs_neq {
-                    return Ok(false);
-                }
-                let actions_neq = self.inner.actions != other.inner.actions;
-                if !actions_neq {
-                    return Ok(false);
-                }
-                let modes_neq = self.inner.modes != other.inner.modes;
-                if !modes_neq {
-                    return Ok(false);
-                }
-                let boundaries_neq = self.inner.boundaries != other.inner.boundaries;
-                if !boundaries_neq {
-                    return Ok(false);
-                }
-                Ok(true)
-            }
+            CompareOp::Eq => Ok(eq),
+            CompareOp::Ne => Ok(!eq),
             _ => Err(PyErr::new::<PyNotImplementedError, _>("")),
         }
     }

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -516,37 +516,12 @@ impl PyMajoranaOperator {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, _py: Python<'_>) -> PyResult<bool> {
+        let eq = self.inner.coeffs == other.inner.coeffs
+            && self.inner.modes == other.inner.modes
+            && self.inner.boundaries == other.inner.boundaries;
         match op {
-            CompareOp::Eq => {
-                let coeffs_eq = self.inner.coeffs == other.inner.coeffs;
-                if !coeffs_eq {
-                    return Ok(false);
-                }
-                let modes_eq = self.inner.modes == other.inner.modes;
-                if !modes_eq {
-                    return Ok(false);
-                }
-                let boundaries_eq = self.inner.boundaries == other.inner.boundaries;
-                if !boundaries_eq {
-                    return Ok(false);
-                }
-                Ok(true)
-            }
-            CompareOp::Ne => {
-                let coeffs_neq = self.inner.coeffs != other.inner.coeffs;
-                if !coeffs_neq {
-                    return Ok(false);
-                }
-                let modes_neq = self.inner.modes != other.inner.modes;
-                if !modes_neq {
-                    return Ok(false);
-                }
-                let boundaries_neq = self.inner.boundaries != other.inner.boundaries;
-                if !boundaries_neq {
-                    return Ok(false);
-                }
-                Ok(true)
-            }
+            CompareOp::Eq => Ok(eq),
+            CompareOp::Ne => Ok(!eq),
             _ => Err(PyErr::new::<PyNotImplementedError, _>("")),
         }
     }

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -592,45 +592,13 @@ impl PyTransferVertexOperator {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, _py: Python<'_>) -> PyResult<bool> {
+        let eq = self.inner.coeffs == other.inner.coeffs
+            && self.inner.left_indices == other.inner.left_indices
+            && self.inner.right_indices == other.inner.right_indices
+            && self.inner.boundaries == other.inner.boundaries;
         match op {
-            CompareOp::Eq => {
-                let coeffs_eq = self.inner.coeffs == other.inner.coeffs;
-                if !coeffs_eq {
-                    return Ok(false);
-                }
-                let left_indices_eq = self.inner.left_indices == other.inner.left_indices;
-                if !left_indices_eq {
-                    return Ok(false);
-                }
-                let right_indices_eq = self.inner.right_indices == other.inner.right_indices;
-                if !right_indices_eq {
-                    return Ok(false);
-                }
-                let boundaries_eq = self.inner.boundaries == other.inner.boundaries;
-                if !boundaries_eq {
-                    return Ok(false);
-                }
-                Ok(true)
-            }
-            CompareOp::Ne => {
-                let coeffs_neq = self.inner.coeffs != other.inner.coeffs;
-                if !coeffs_neq {
-                    return Ok(false);
-                }
-                let left_indices_neq = self.inner.left_indices != other.inner.left_indices;
-                if !left_indices_neq {
-                    return Ok(false);
-                }
-                let right_indices_neq = self.inner.right_indices != other.inner.right_indices;
-                if !right_indices_neq {
-                    return Ok(false);
-                }
-                let boundaries_neq = self.inner.boundaries != other.inner.boundaries;
-                if !boundaries_neq {
-                    return Ok(false);
-                }
-                Ok(true)
-            }
+            CompareOp::Eq => Ok(eq),
+            CompareOp::Ne => Ok(!eq),
             _ => Err(PyErr::new::<PyNotImplementedError, _>("")),
         }
     }

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -55,6 +55,34 @@ class TestEdgeVertexOperator:
         op = cls.one()
         assert op == cls.from_dict({(): 1})
 
+    def test_richcmp(self, subtests):
+        cls = self.get_class()
+
+        # two terms, each of length two (boundaries has len(coeffs) + 1 entries)
+        coeffs = [1, 2]
+        l_indices = [0, 1, 0, 1]
+        r_indices = [1, 2, 1, 2]
+        boundaries = [0, 2, 4]
+
+        op = cls(coeffs, l_indices, r_indices, boundaries)
+
+        with subtests.test("equal"):
+            other = cls(coeffs, l_indices, r_indices, boundaries)
+            # `!=` must be the exact negation of `==`
+            assert (op == other) is True
+            assert (op != other) is False
+
+        # each field differs individually: `!=` must be the negation of `==`.
+        for name, other in [
+            ("coeffs", cls([1, 3], l_indices, r_indices, boundaries)),
+            ("left_indices", cls(coeffs, [1, 0, 0, 1], r_indices, boundaries)),
+            ("right_indices", cls(coeffs, l_indices, [2, 1, 1, 2], boundaries)),
+            ("boundaries", cls(coeffs, l_indices, r_indices, [0, 1, 4])),
+        ]:
+            with subtests.test(name):
+                assert (op == other) is False
+                assert (op != other) is True
+
     def test_repr(self):
         cls = self.get_class()
         op = cls.from_dict(

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -57,6 +57,34 @@ class TestFermionOperator:
         op = cls.one()
         assert op == cls.from_dict({(): 1})
 
+    def test_richcmp(self, subtests):
+        cls = self.get_class()
+
+        # two terms, each of length two (boundaries has len(coeffs) + 1 entries)
+        coeffs = [1, 2]
+        actions = [True, False, True, False]
+        modes = [0, 1, 0, 1]
+        boundaries = [0, 2, 4]
+
+        op = cls(coeffs, actions, modes, boundaries)
+
+        with subtests.test("equal"):
+            other = cls(coeffs, actions, modes, boundaries)
+            # `!=` must be the exact negation of `==`
+            assert (op == other) is True
+            assert (op != other) is False
+
+        # each field differs individually: `!=` must be the negation of `==`.
+        for name, other in [
+            ("coeffs", cls([1, 3], actions, modes, boundaries)),
+            ("actions", cls(coeffs, [False, True, True, False], modes, boundaries)),
+            ("modes", cls(coeffs, actions, [1, 0, 0, 1], boundaries)),
+            ("boundaries", cls(coeffs, actions, modes, [0, 1, 4])),
+        ]:
+            with subtests.test(name):
+                assert (op == other) is False
+                assert (op != other) is True
+
     def test_repr(self):
         cls = self.get_class()
         op = cls.from_dict(

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -52,6 +52,32 @@ class TestMajoranaOperator:
         op = cls.one()
         assert op.equiv(cls.from_dict({(): 1}))
 
+    def test_richcmp(self, subtests):
+        cls = self.get_class()
+
+        # two terms, each of length two (boundaries has len(coeffs) + 1 entries)
+        coeffs = [1, 2]
+        modes = [0, 1, 0, 1]
+        boundaries = [0, 2, 4]
+
+        op = cls(coeffs, modes, boundaries)
+
+        with subtests.test("equal"):
+            other = cls(coeffs, modes, boundaries)
+            # `!=` must be the exact negation of `==`
+            assert (op == other) is True
+            assert (op != other) is False
+
+        # each field differs individually: `!=` must be the negation of `==`.
+        for name, other in [
+            ("coeffs", cls([1, 3], modes, boundaries)),
+            ("modes", cls(coeffs, [1, 0, 0, 1], boundaries)),
+            ("boundaries", cls(coeffs, modes, [0, 1, 4])),
+        ]:
+            with subtests.test(name):
+                assert (op == other) is False
+                assert (op != other) is True
+
     def test_repr(self):
         cls = self.get_class()
         op = cls.from_dict(

--- a/tests/python/operators/test_transfer_vertex_operator.py
+++ b/tests/python/operators/test_transfer_vertex_operator.py
@@ -55,6 +55,34 @@ class TestTransferVertexOperator:
         op = cls.one()
         assert op == cls.from_dict({(): 1})
 
+    def test_richcmp(self, subtests):
+        cls = self.get_class()
+
+        # two terms, each of length two (boundaries has len(coeffs) + 1 entries)
+        coeffs = [1, 2]
+        l_indices = [0, 1, 0, 1]
+        r_indices = [1, 2, 1, 2]
+        boundaries = [0, 2, 4]
+
+        op = cls(coeffs, l_indices, r_indices, boundaries)
+
+        with subtests.test("equal"):
+            other = cls(coeffs, l_indices, r_indices, boundaries)
+            # `!=` must be the exact negation of `==`
+            assert (op == other) is True
+            assert (op != other) is False
+
+        # each field differs individually: `!=` must be the negation of `==`.
+        for name, other in [
+            ("coeffs", cls([1, 3], l_indices, r_indices, boundaries)),
+            ("left_indices", cls(coeffs, [1, 0, 0, 1], r_indices, boundaries)),
+            ("right_indices", cls(coeffs, l_indices, [2, 1, 1, 2], boundaries)),
+            ("boundaries", cls(coeffs, l_indices, r_indices, [0, 1, 4])),
+        ]:
+            with subtests.test(name):
+                assert (op == other) is False
+                assert (op != other) is True
+
     def test_repr(self):
         cls = self.get_class()
         op = cls.from_dict(


### PR DESCRIPTION
The `CompareOp::Ne` branch in the four Python operator classes inverted the Eq short-circuit logic field-by-field instead of negating its result, so `a != b` was not `not (a == b)` — operators differing in a single field reported both `==` and `!=` as False. Compute equality once and return its negation for Ne. Adds per-field regression tests to each operator.

This commit was assisted by Claude Opus 4.8