### PR TITLE
fix: raise on too-small num_qubits in jordan_wigner

### DIFF
--- a/crates/cext/src/mappers/library/jordan_wigner.rs
+++ b/crates/cext/src/mappers/library/jordan_wigner.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use crate::exit_codes::ExitCode;
 use crate::pointers::const_ptr_as_ref;
 
 use qiskit_fermions_core::mappers::library::jordan_wigner::jordan_wigner;
@@ -20,9 +21,14 @@ use qiskit_fermions_core::operators::fermion_operator::FermionOperator;
 /// @brief Applies the Jordan-Wigner transformation to an operator.
 ///
 /// @param op A pointer to the fermionic operator to be mapped.
-/// @param num_qubits The number of qubits of the resulting operator.
+/// @param num_qubits The number of qubits of the resulting operator. This must be strictly greater
+///        than the largest mode index acted upon by ``op``.
+/// @param out A pointer to where the created qubit operator will be written on success. It is left
+///        untouched if the transformation fails.
 ///
-/// @return A pointer to the created qubit operator.
+/// @return An exit code. This is ``>0`` if an error occurred. In particular, a
+///         ``QfExitCode_ValueError`` is returned if ``num_qubits`` is too small to hold the
+///         operator's support.
 ///
 /// @rst
 ///
@@ -63,16 +69,27 @@ use qiskit_fermions_core::operators::fermion_operator::FermionOperator;
 ///     QfFermionOperator *hamil = qf_ferm_op_one();
 ///
 ///     // and map it to a qubit operator
-///     QkObs *result = qf_jordan_wigner(hamil, 4);
+///     QkObs *result;
+///     QfExitCode exit = qf_jordan_wigner(hamil, 4, &result);
+///
+///     assert(exit == QfExitCode_Success);
 ///
 /// @endrst
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qf_jordan_wigner(
     op: *const FermionOperator,
     num_qubits: u32,
-) -> *mut qiskit_sys::QkObs {
+    out: *mut *mut qiskit_sys::QkObs,
+) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let op = unsafe { const_ptr_as_ref(op) };
 
-    jordan_wigner(op, num_qubits)
+    match jordan_wigner(op, num_qubits) {
+        Ok(obs) => {
+            // SAFETY: Per documentation, `out` is non-null and aligned.
+            unsafe { out.write(obs) };
+            ExitCode::Success
+        }
+        Err(_) => ExitCode::ValueError,
+    }
 }

--- a/crates/core/src/mappers/library/jordan_wigner.rs
+++ b/crates/core/src/mappers/library/jordan_wigner.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use crate::operators::CoherenceError;
 use crate::operators::fermion_operator::{FermionAction, FermionOperator};
 use rayon::prelude::*;
 use std::sync::{Arc, Mutex};
@@ -77,7 +78,22 @@ unsafe impl Send for Wrapper {}
 
 // TODO: can we clean up the coding pattern of overwriting a data structure in-place to avoid the
 // repetitive re-allocations?
-pub fn jordan_wigner(fer_op: &FermionOperator, num_qubits: u32) -> *mut ffi::QkObs {
+pub fn jordan_wigner(
+    fer_op: &FermionOperator,
+    num_qubits: u32,
+) -> Result<*mut ffi::QkObs, CoherenceError> {
+    // Each mode index `j` maps onto qubit `j`, so the operator's largest mode index must fit
+    // within `num_qubits`. Without this check, the underlying `qk_obs_*` calls receive an
+    // out-of-range qubit index and abort the process with a non-unwinding panic.
+    if let Some(&max_mode) = fer_op.modes.iter().max()
+        && max_mode >= num_qubits
+    {
+        return Err(CoherenceError::NumQubitsTooSmall {
+            num_qubits,
+            max_mode,
+        });
+    }
+
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(0)
         .build()
@@ -157,7 +173,7 @@ pub fn jordan_wigner(fer_op: &FermionOperator, num_qubits: u32) -> *mut ffi::QkO
             },
         );
 
-    mapped_operator.ptr
+    Ok(mapped_operator.ptr)
 }
 
 #[cfg(test)]
@@ -243,7 +259,7 @@ mod tests {
             ],
             groups: None,
         };
-        let qb_op = jordan_wigner(&fer_op, 4);
+        let qb_op = jordan_wigner(&fer_op, 4).unwrap();
 
         let mut coeffs: Vec<QkComplex64> = vec![
             QkComplex64 {
@@ -348,5 +364,30 @@ mod tests {
         let equal = unsafe { ffi::qk_obs_equal(diff, zero) };
 
         assert!(equal)
+    }
+
+    #[test]
+    fn test_jordan_wigner_num_qubits_too_small() {
+        // an operator acting on mode index 3 requires at least 4 qubits
+        let fer_op = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0)],
+            actions: vec![true],
+            modes: vec![3],
+            boundaries: vec![0, 1],
+            groups: None,
+        };
+
+        // too few qubits must be reported instead of aborting the process
+        let err = jordan_wigner(&fer_op, 3).unwrap_err();
+        assert!(matches!(
+            err,
+            CoherenceError::NumQubitsTooSmall {
+                num_qubits: 3,
+                max_mode: 3
+            }
+        ));
+
+        // exactly enough qubits succeeds
+        assert!(jordan_wigner(&fer_op, 4).is_ok());
     }
 }

--- a/crates/core/src/operators/mod.rs
+++ b/crates/core/src/operators/mod.rs
@@ -23,6 +23,10 @@ pub enum CoherenceError {
     DuplicateIndices,
     #[error("the provided index mapping does not account for the entire length of the operator")]
     IndexMapTooSmall,
+    #[error(
+        "num_qubits ({num_qubits}) is too small for an operator acting on mode index {max_mode}"
+    )]
+    NumQubitsTooSmall { num_qubits: u32, max_mode: u32 },
 }
 
 pub trait OperatorTrait {

--- a/crates/pyext/src/mappers/library/jordan_wigner.rs
+++ b/crates/pyext/src/mappers/library/jordan_wigner.rs
@@ -11,6 +11,7 @@
 // that they have been altered from the originals.
 
 use crate::operators::fermion_operator::PyFermionOperator;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
 use qiskit_fermions_core::mappers::library::jordan_wigner::jordan_wigner;
@@ -34,10 +35,9 @@ use qiskit_pyo3_ffi as ffi;
 ///     The mapped qubit operator. The result is `not` simplified; call
 ///     :meth:`~qiskit.quantum_info.SparseObservable.simplify` to combine duplicate terms.
 ///
-/// .. warning::
-///    Passing a ``num_qubits`` that is too small to hold the operator's support aborts the process
-///    rather than raising a Python exception. Ensure ``num_qubits`` exceeds the largest mode index
-///    before calling.
+/// Raises:
+///     ValueError: if ``num_qubits`` is too small to hold the operator's support, i.e. if it is
+///         not larger than the largest mode index acted upon by ``op``.
 ///
 /// Definition
 /// ==========
@@ -85,12 +85,13 @@ use qiskit_pyo3_ffi as ffi;
 #[gen_stub_pyfunction(module = "qiskit_fermions.mappers.library.jordan_wigner")]
 #[pyfunction(name = "jordan_wigner")]
 #[gen_stub(override_return_type(type_repr="qiskit.quantum_info.SparseObservable", imports=("qiskit.quantum_info")))]
-pub fn py_jordan_wigner(op: PyFermionOperator, num_qubits: u32) -> Py<PyAny> {
-    let obs = jordan_wigner(&op.inner, num_qubits);
+pub fn py_jordan_wigner(op: PyFermionOperator, num_qubits: u32) -> PyResult<Py<PyAny>> {
+    let obs =
+        jordan_wigner(&op.inner, num_qubits).map_err(|e| PyValueError::new_err(e.to_string()))?;
     unsafe {
         let py = Python::assume_attached();
         let py_obs = ffi::qk_obs_to_python(obs);
-        Bound::from_owned_ptr(py, py_obs).into()
+        Ok(Bound::from_owned_ptr(py, py_obs).into())
     }
 }
 

--- a/tests/c/test_jordan_wigner.c
+++ b/tests/c/test_jordan_wigner.c
@@ -47,7 +47,11 @@ static int test_mapping(void) {
         qf_ferm_op_add_term(hamil, 4, action_2body + 4 * i, indices_2body + 4 * i, &coeff_2body[i]);
     }
 
-    QkObs *result = qf_jordan_wigner(hamil, 4);
+    QkObs *result;
+    if (qf_jordan_wigner(hamil, 4, &result) != QfExitCode_Success) {
+        qf_ferm_op_free(hamil);
+        return RuntimeError;
+    }
 
     QkComplex64 coeffs[15] = {
         {-0.8105479805373266, 0.0}, {0.1721839326191555, 0.0},   {-0.22575349222402474, 0.0},
@@ -89,9 +93,33 @@ static int test_mapping(void) {
     return Ok;
 }
 
+static int test_num_qubits_too_small(void) {
+    // an operator acting on mode index 3 requires at least 4 qubits
+    QfFermionOperator *op = qf_ferm_op_zero();
+    QkComplex64 coeff = {1.0, 0.0};
+    bool action[1] = {true};
+    uint32_t index[1] = {3};
+    qf_ferm_op_add_term(op, 1, action, index, &coeff);
+
+    // too few qubits must be reported instead of aborting the process
+    QkObs *result = NULL;
+    QfExitCode exit = qf_jordan_wigner(op, 3, &result);
+
+    qf_ferm_op_free(op);
+
+    if (exit != QfExitCode_ValueError) {
+        return RuntimeError;
+    }
+    if (result != NULL) {
+        return NullptrError;
+    }
+    return Ok;
+}
+
 int test_jordan_wigner(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_mapping);
+    num_failed += RUN_TEST(test_num_qubits_too_small);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);

--- a/tests/python/mappers/library/test_jordan_wigner.py
+++ b/tests/python/mappers/library/test_jordan_wigner.py
@@ -10,6 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+import pytest
 from qiskit.quantum_info import SparseObservable
 from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
@@ -59,3 +60,14 @@ def test_jordan_wigner():
     )
     diff = (qop - expected).simplify()
     assert diff == SparseObservable.zero(num_qubits)
+
+
+def test_jordan_wigner_num_qubits_too_small():
+    # an operator acting on mode index 3 requires at least 4 qubits; too few qubits must raise a
+    # catchable ValueError instead of aborting the interpreter
+    op = FermionOperator.from_dict({((True, 3),): 1.0})
+    with pytest.raises(ValueError):
+        jordan_wigner(op, 3)
+
+    # exactly enough qubits succeeds
+    assert isinstance(jordan_wigner(op, 4), SparseObservable)


### PR DESCRIPTION
Mapping a FermionOperator whose largest mode index was >= num_qubits aborted the whole process with a non-unwinding panic from the underlying qk_obs_* calls, giving no catchable error. Add an up-front bounds check in the core jordan_wigner, which now returns Result and reports a new CoherenceError::NumQubitsTooSmall. The pyext wrapper maps this to a Python ValueError; the C API qf_jordan_wigner now writes its result through an out-parameter and returns a QkExitCode (ValueError on bad input). Adds regression tests at the core, Python, and C-API layers.

This commit was assisted by Claude Opus 4.8

---

:warning: This is a breaking C API change!