### PR TITLE
fix: prefix cext FermionOperator term functions with qf_ferm_op_

### DIFF
--- a/crates/cext/src/operators/terms/filtering/diagonal.rs
+++ b/crates/cext/src/operators/terms/filtering/diagonal.rs
@@ -54,13 +54,13 @@ use qiskit_fermions_core::operators::terms::filtering::diagonal::filter_diagonal
 ///     QfFCIDump *fcidump = qf_fcidump_from_file("molecule.fcidump");
 ///     QfFermionOperator *op = qf_ferm_op_from_fcidump(fcidump);
 ///
-///     QfFermionOperator *normal = qf_ferm_op_normal_ordered(op);
+///     QfFermionOperator *normal = qf_ferm_op_normal_ordered(op, NULL);
 ///
-///     qf_filter_diagonal_terms(normal);
+///     qf_ferm_op_filter_diagonal_terms(normal);
 ///
 /// @endrst
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qf_filter_diagonal_terms(op: *mut FermionOperator) {
+pub unsafe extern "C" fn qf_ferm_op_filter_diagonal_terms(op: *mut FermionOperator) {
     let op = unsafe { mut_ptr_as_ref(op) };
 
     filter_diagonal_terms(op);

--- a/crates/cext/src/operators/terms/grouping/electronic_structure.rs
+++ b/crates/cext/src/operators/terms/grouping/electronic_structure.rs
@@ -60,15 +60,15 @@ use qiskit_fermions_core::operators::terms::grouping::electronic_structure::grou
 ///     QfFCIDump *fcidump = qf_fcidump_from_file("molecule.fcidump");
 ///     QfFermionOperator *op = qf_ferm_op_from_fcidump(fcidump);
 ///
-///     uint32_t num_modes = 2 * fcidump.norb;
+///     uint32_t num_modes = 2 * qf_fcidump_norb(fcidump);
 ///
-///     QfFermionOperator *normal = qf_ferm_op_normal_ordered(op);
+///     QfFermionOperator *normal = qf_ferm_op_normal_ordered(op, NULL);
 ///
-///     QfExitCode exit = qf_group_terms_by_electronic_structure(normal, num_modes, false);
+///     QfExitCode exit = qf_ferm_op_group_terms_by_electronic_structure(normal, num_modes, false);
 ///
 /// @endrst
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qf_group_terms_by_electronic_structure(
+pub unsafe extern "C" fn qf_ferm_op_group_terms_by_electronic_structure(
     op: *mut FermionOperator,
     num_modes: u32,
     two_body_physicist_order: bool,

--- a/docs/cdoc/qf-operators-terms.rst
+++ b/docs/cdoc/qf-operators-terms.rst
@@ -29,9 +29,9 @@ information automatically.
 
 .. table::
 
-  ================================================ ==============================================================
-  :c:func:`qf_group_terms_by_electronic_structure` Groups the terms of an operator by their electronic structure.
-  ================================================ ==============================================================
+  ======================================================== ==============================================================
+  :c:func:`qf_ferm_op_group_terms_by_electronic_structure` Groups the terms of an operator by their electronic structure.
+  ======================================================== ==============================================================
 
 Filtering
 ---------
@@ -44,9 +44,9 @@ Members
 
 .. table::
 
-  ================================== =======================================================
-  :c:func:`qf_filter_diagonal_terms` Filters out the terms of an operator that are diagonal.
-  ================================== =======================================================
+  ============================================= =======================================================
+  :c:func:`qf_ferm_op_filter_diagonal_terms`    Filters out the terms of an operator that are diagonal.
+  ============================================= =======================================================
 
 .. doxygengroup:: qf_operator_terms
    :content-only:

--- a/docs/guides/sqdrift.rst
+++ b/docs/guides/sqdrift.rst
@@ -73,7 +73,7 @@ detail in :ref:`this guide <grouping_explanation>`.
 
     .. code-block:: c
 
-       QfExitCode exit = qf_group_terms_by_electronic_structure(normal, num_modes, false);
+       QfExitCode exit = qf_ferm_op_group_terms_by_electronic_structure(normal, num_modes, false);
 
 3. Prepare the time evolution circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/c/test_filtering.c
+++ b/tests/c/test_filtering.c
@@ -30,7 +30,7 @@ static int test_filter_drops_constant_number_and_products(void) {
     QfFermionOperator *op =
         qf_ferm_op_new(num_terms, num_actions, coeffs, actions, modes, boundaries);
 
-    qf_filter_diagonal_terms(op);
+    qf_ferm_op_filter_diagonal_terms(op);
 
     // Only the off-diagonal hopping term a†_0 a_1 must survive.
     QfFermionOperator *expected = qf_ferm_op_zero();
@@ -64,7 +64,7 @@ static int test_filter_keeps_off_diagonal_hopping(void) {
     QfFermionOperator *expected =
         qf_ferm_op_new(num_terms, num_actions, coeffs, actions, modes, boundaries);
 
-    qf_filter_diagonal_terms(op);
+    qf_ferm_op_filter_diagonal_terms(op);
 
     bool is_equal = qf_ferm_op_equal(op, expected);
 
@@ -89,7 +89,7 @@ static int test_filter_electronic_structure_hamiltonian(void) {
     uint64_t num_terms_before;
     qf_ferm_op_get_coeffs(normal, &coeffs_before, &num_terms_before);
 
-    qf_filter_diagonal_terms(normal);
+    qf_ferm_op_filter_diagonal_terms(normal);
 
     QkComplex64 *coeffs_after;
     uint64_t num_terms_after;

--- a/tests/c/test_grouping.c
+++ b/tests/c/test_grouping.c
@@ -25,7 +25,7 @@ static int test_grouping_error(void) {
     QfFermionOperator *op =
         qf_ferm_op_new(num_terms, num_actions, coeffs, actions, modes, boundaries);
 
-    QfExitCode exit = qf_group_terms_by_electronic_structure(op, 2, false);
+    QfExitCode exit = qf_ferm_op_group_terms_by_electronic_structure(op, 2, false);
 
     qf_ferm_op_free(op);
 
@@ -43,7 +43,7 @@ static int test_group_terms_by_electronic_structure(void) {
     QfFermionOperator *normal = qf_ferm_op_normal_ordered(op, NULL);
     qf_ferm_op_free(op);
 
-    QfExitCode exit = qf_group_terms_by_electronic_structure(normal, 4, false);
+    QfExitCode exit = qf_ferm_op_group_terms_by_electronic_structure(normal, 4, false);
     qf_ferm_op_free(normal);
 
     if (exit != QfExitCode_Success) {


### PR DESCRIPTION
:warning: This is a *breaking change* to the C API!

---

Two FermionOperator in-place mutators lacked the qf_ferm_op_ prefix that signals type coupling in the flat C namespace:

  qf_filter_diagonal_terms
    -> qf_ferm_op_filter_diagonal_terms
  qf_group_terms_by_electronic_structure
    -> qf_ferm_op_group_terms_by_electronic_structure