### PR TITLE
feat: add `order_terms` for user-controlled term ordering

### DIFF
--- a/python/qiskit_fermions/operators/terms/__init__.py
+++ b/python/qiskit_fermions/operators/terms/__init__.py
@@ -60,6 +60,9 @@ resulting operators are mathematically identical, the term order can have
 significant implications on algorithm behavior at runtime, due to the term
 iteration order.
 
+.. note::
+   Unlike :func:`canonical_order`, :func:`order_terms` has no counterpart in the C API.
+
 Members
 ^^^^^^^
 
@@ -67,14 +70,16 @@ Members
    :toctree: ../stubs/
 
    canonical_order
+   order_terms
 """
 
 from .filtering import filter_diagonal_terms
 from .grouping import group_terms_by_electronic_structure
-from .ordering import canonical_order
+from .ordering import canonical_order, order_terms
 
 __all__ = [
     "canonical_order",
     "filter_diagonal_terms",
     "group_terms_by_electronic_structure",
+    "order_terms",
 ]

--- a/python/qiskit_fermions/operators/terms/ordering/__init__.py
+++ b/python/qiskit_fermions/operators/terms/ordering/__init__.py
@@ -16,6 +16,9 @@ from qiskit_fermions._lib.operators.operators_terms.ordering.canonical import (
     canonical_order,
 )
 
+from .callable import order_terms
+
 __all__ = [
     "canonical_order",
+    "order_terms",
 ]

--- a/python/qiskit_fermions/operators/terms/ordering/callable.py
+++ b/python/qiskit_fermions/operators/terms/ordering/callable.py
@@ -1,0 +1,81 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Ordering the terms of an operator by a user-provided key."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from qiskit_fermions.operators.protocol import OperatorTrait
+
+
+def order_terms(
+    op: OperatorTrait,
+    key: Callable[[tuple], Any],
+    *,
+    reverse: bool = False,
+) -> OperatorTrait:
+    """Returns a copy of an operator with its terms reordered by a user-provided key.
+
+    Unlike :func:`.canonical_order`, which imposes a single fixed, coefficient-independent order,
+    this function lets you sort the terms by any criterion you like: the ``key`` function is applied
+    to each term exactly as :func:`sorted` would, and the terms are rebuilt into a new operator of
+    the same type in the resulting order. This is useful whenever the *order* of the terms matters
+    for a downstream computation (e.g. randomized product-formula sampling), since it gives you a
+    deterministic, reproducible order independent of how the operator happened to be assembled.
+
+    The terms themselves are left untouched -- this only reorders them, it does not simplify or
+    normal-order the operator. This works for any of the built-in operator types implementing the
+    :class:`~qiskit_fermions.operators.OperatorTrait` protocol; the returned operator is of the same
+    type as the input.
+
+    .. note::
+       The ``key`` receives each term as the same tuple that the operator's
+       :meth:`~qiskit_fermions.operators.OperatorTrait.iter_terms` yields -- or, when the operator
+       tracks groups (see :attr:`~qiskit_fermions.operators.OperatorTrait.groups`), the longer tuple
+       from :meth:`~qiskit_fermions.operators.OperatorTrait.iter_terms_with_groups`, whose trailing
+       element is the term's group index. The exact layout of the term itself depends on the
+       operator type. Group indices are preserved -- each term carries its group index along as it
+       moves -- and if the input tracks no groups, neither does the result.
+
+    .. doctest::
+
+        >>> from qiskit_fermions.operators import FermionOperator
+        >>> from qiskit_fermions.operators.terms.ordering import order_terms
+        >>> op = FermionOperator.from_dict(
+        ...     {
+        ...         ((True, 1), (False, 0)): 1.0,  # a†_1 a_0, |coeff| = 1
+        ...         ((True, 0), (False, 1)): 3.0,  # a†_0 a_1, |coeff| = 3
+        ...     }
+        ... )
+        >>> ordered = order_terms(op, key=lambda term: abs(term[1]), reverse=True)
+        >>> list(ordered.iter_terms())
+        [([(True, 0), (False, 1)], (3+0j)), ([(True, 1), (False, 0)], (1+0j))]
+
+    Args:
+        op: the operator whose terms to reorder.
+        key: a function of a single term, used exactly as the ``key`` argument of :func:`sorted`. It
+            receives each term as the tuple described in the note above.
+        reverse: if ``True``, the terms are sorted in descending order of ``key``.
+
+    Returns:
+        A new operator of the same type with its terms in the requested order.
+    """
+    if op.groups is None:
+        terms = sorted(op.iter_terms(), key=key, reverse=reverse)
+        return op.__class__.from_terms(terms)
+
+    terms = sorted(op.iter_terms_with_groups(), key=key, reverse=reverse)
+    return op.__class__.from_terms_with_groups(terms)

--- a/tests/python/operators/terms/ordering/test_callable.py
+++ b/tests/python/operators/terms/ordering/test_callable.py
@@ -1,0 +1,111 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for ordering the terms of an operator by a user-provided key."""
+
+from __future__ import annotations
+
+from qiskit_fermions.operators import FermionOperator, MajoranaOperator
+from qiskit_fermions.operators.terms.ordering import order_terms
+
+
+def test_order_terms_sorts_by_custom_key():
+    # Two terms whose coefficient magnitudes fix the requested order.
+    op = FermionOperator.from_dict(
+        {
+            ((True, 1), (False, 0)): 1.0,  # |coeff| = 1
+            ((True, 0), (False, 1)): 3.0,  # |coeff| = 3
+        }
+    )
+
+    ordered = order_terms(op, key=lambda term: abs(term[1]))
+
+    # A new operator is returned; the input is untouched.
+    assert ordered is not op
+    assert op.equiv(ordered)
+    # Ascending |coeff|: the magnitude-1 term comes first, carrying its own coefficient.
+    assert list(ordered.iter_terms()) == [
+        ([(True, 1), (False, 0)], 1 + 0j),
+        ([(True, 0), (False, 1)], 3 + 0j),
+    ]
+
+
+def test_order_terms_reverse():
+    op = FermionOperator.from_dict(
+        {
+            ((True, 1), (False, 0)): 1.0,
+            ((True, 0), (False, 1)): 3.0,
+        }
+    )
+
+    ordered = order_terms(op, key=lambda term: abs(term[1]), reverse=True)
+
+    # Descending |coeff|: the magnitude-3 term comes first.
+    assert op.equiv(ordered)
+    assert list(ordered.iter_terms()) == [
+        ([(True, 0), (False, 1)], 3 + 0j),
+        ([(True, 1), (False, 0)], 1 + 0j),
+    ]
+
+
+def test_order_terms_preserves_groups():
+    op = FermionOperator.from_dict(
+        {
+            ((True, 1), (False, 0)): 1.0,
+            ((True, 0), (False, 1)): 3.0,
+        }
+    )
+    # Give the two terms distinct group tags; the term<->tag association must survive reordering.
+    op.groups = [0, 1]
+    before = {tuple(term): group for term, _, group in op.iter_terms_with_groups()}
+
+    ordered = order_terms(op, key=lambda term: abs(term[1]), reverse=True)
+
+    # Groups are preserved, and each term still carries the same group tag it had before.
+    assert ordered.groups is not None
+    after = {tuple(term): group for term, _, group in ordered.iter_terms_with_groups()}
+    assert after == before
+
+
+def test_order_terms_key_on_group():
+    op = FermionOperator.from_dict(
+        {
+            ((True, 0), (False, 1)): 3.0,
+            ((True, 1), (False, 0)): 1.0,
+        }
+    )
+    # Assign group tags so the stored term order (see iter_terms below) starts out group-descending;
+    # a group-keyed ascending sort must therefore reorder. `from_dict` does not preserve dict order,
+    # so tag by the actual stored positions: term 0 -> group 1, term 1 -> group 0.
+    op.groups = [1, 0]
+    # Record each term's group tag so we can assert the association survives reordering.
+    before = {tuple(term): group for term, _, group in op.iter_terms_with_groups()}
+
+    ordered = order_terms(op, key=lambda term: term[2])
+
+    # Sorted by ascending group index; each term keeps the tag it started with.
+    assert op.equiv(ordered)
+    assert [group for _, _, group in ordered.iter_terms_with_groups()] == [0, 1]
+    after = {tuple(term): group for term, _, group in ordered.iter_terms_with_groups()}
+    assert after == before
+
+
+def test_order_terms_supports_non_fermion_operators():
+    # Works for any operator implementing the OperatorTrait protocol, not just FermionOperator.
+    op = MajoranaOperator.from_dict({(2, 3): 1.0, (0, 1): 2.0})
+
+    ordered = order_terms(op, key=lambda term: term[0])
+
+    assert isinstance(ordered, MajoranaOperator)
+    assert op.equiv(ordered)
+    # Sorted lexicographically by the Majorana actions.
+    assert list(ordered.iter_terms()) == [([0, 1], 2 + 0j), ([2, 3], 1 + 0j)]


### PR DESCRIPTION
This is the follow-up promised in #183

Closes #164 