### PR TITLE
feat(linalg): add rectangular Givens decomposition for Slater prep

### DIFF
--- a/crates/core/src/linalg/givens.rs
+++ b/crates/core/src/linalg/givens.rs
@@ -185,10 +185,73 @@ pub fn givens_decomposition(unitary: Array2<Complex64>) -> (Vec<GivensRotation>,
     (right_rotations, diagonal_phases)
 }
 
+/// Decomposes the occupied-orbital coefficients of a Slater determinant into Givens rotations.
+///
+/// This is the rectangular counterpart of [`givens_decomposition`], specialized for Slater
+/// determinant `state preparation`. The input `orbital_coeffs` is an :math:`m \times n` matrix whose
+/// :math:`m` rows are the occupied orbitals expressed in a basis of :math:`n` spatial orbitals
+/// (:math:`m \le n`); its rows are assumed to be orthonormal.
+///
+/// Applying the returned rotations, in order, to the reference configuration in which the first
+/// :math:`m` orbitals are occupied prepares the target Slater determinant. Because preparing a
+/// Slater determinant only requires realizing the :math:`m` occupied orbitals -- rather than a full
+/// :math:`n \times n` orbital rotation -- this uses at most :math:`m (n - m)` Givens rotations
+/// arranged in a diamond-shaped pattern (versus the brick-wall :math:`n (n - 1) / 2` of the square
+/// decomposition). The decomposition carries `no` diagonal phases: a global phase and any rotation
+/// within the occupied space leave the prepared Slater determinant unchanged, so both are discarded.
+///
+/// # Arguments
+///
+/// * `orbital_coeffs` - the :math:`m \times n` matrix of occupied-orbital coefficients.
+///
+/// # Returns
+///
+/// A vector of Givens rotations, each given as (real cosine, complex sine, index i, index j) acting
+/// on the adjacent indices i and j.
+pub fn givens_decomposition_slater(orbital_coeffs: Array2<Complex64>) -> Vec<GivensRotation> {
+    let m = orbital_coeffs.nrows();
+    let n = orbital_coeffs.ncols();
+    let mut matrix = orbital_coeffs;
+
+    // Zero out the top-right corner by rotating rows; this is a no-op on the prepared determinant
+    // (it mixes only unoccupied orbitals) but brings the matrix into the shape the column sweep
+    // below expects.
+    if n > m {
+        let n_minus_m = n - m;
+        for j in (n_minus_m + 1..n).rev() {
+            // zero out the entries in column j from the top down
+            for i in 0..(j - n_minus_m) {
+                if matrix[[i, j]].norm() > EPSILON {
+                    let (c, s) = zrotg(matrix[[i + 1, j]], matrix[[i, j]]);
+                    zrot(&mut matrix, &(c, s, i + 1, i), SliceType::Row);
+                }
+            }
+        }
+    }
+
+    // Decompose the matrix into Givens rotations, zeroing each row's trailing entries by rotating
+    // adjacent columns.
+    let mut rotations: Vec<GivensRotation> = Vec::new();
+    for i in 0..m {
+        let j_max = n - m + i;
+        for j in (i + 1..=j_max).rev() {
+            if matrix[[i, j]].norm() > EPSILON {
+                let (c, s) = zrotg(matrix[[i, j - 1]], matrix[[i, j]]);
+                rotations.push((c, s, j, j - 1));
+                zrot(&mut matrix, &(c, s, j - 1, j), SliceType::Column);
+            }
+        }
+    }
+
+    rotations.reverse();
+    rotations
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    use nalgebra::DMatrix;
     use ndarray::arr1;
 
     use crate::random::random_unitary;
@@ -233,6 +296,71 @@ mod tests {
                 matrices_approx_equal(&mat, &reconstructed, 1e-8),
                 "Givens decomposition and reconstruction failed for dimension {}",
                 dim
+            );
+        }
+    }
+
+    /// Reconstructs the `m x n` occupied-orbital coefficients from a Slater decomposition.
+    ///
+    /// Starting from the reference configuration (the first `m` of `n` orbitals occupied, i.e. the
+    /// `m x n` truncated identity), the rotations are applied in order to the columns. This is the
+    /// forward of the elimination performed by [`givens_decomposition_slater`].
+    fn reconstruct_slater(rotations: &[GivensRotation], m: usize, n: usize) -> Array2<Complex64> {
+        let mut reconstructed = Array2::eye(n);
+        reconstructed = reconstructed.slice(s![..m, ..]).to_owned();
+
+        for &(c, s, i, j) in rotations {
+            for row in 0..m {
+                let col_i = reconstructed[[row, i]];
+                let col_j = reconstructed[[row, j]];
+                reconstructed[[row, j]] = c * col_j - s * col_i;
+                reconstructed[[row, i]] = c * col_i + s.conj() * col_j;
+            }
+        }
+
+        reconstructed
+    }
+
+    /// Squared overlap `|det(A B^dagger)|^2` between two sets of occupied orbitals `A` and `B`.
+    ///
+    /// Both are `m x n` matrices with orthonormal rows; the overlap is 1 iff they span the same
+    /// occupied space (i.e. define the same Slater determinant up to a global phase).
+    fn slater_fidelity(a: &Array2<Complex64>, b: &Array2<Complex64>) -> f64 {
+        let m = a.nrows();
+        // gram = A * B^dagger, an m x m matrix
+        let gram = DMatrix::from_fn(m, m, |i, j| {
+            (0..a.ncols())
+                .map(|k| a[[i, k]] * b[[j, k]].conj())
+                .sum::<Complex64>()
+        });
+        gram.determinant().norm().powi(2)
+    }
+
+    #[test]
+    fn test_givens_decomposition_slater() {
+        for (n, m) in [(6, 3), (7, 2), (5, 4), (4, 4), (5, 1), (8, 4)] {
+            // draw a random unitary and take m of its columns (as rows) for the occupied orbitals
+            let unitary = random_unitary(n);
+            let target = unitary.t().slice(s![..m, ..]).to_owned();
+
+            let rotations = givens_decomposition_slater(target.clone());
+
+            assert!(
+                rotations.len() <= m * (n - m),
+                "Slater decomposition for (n={n}, m={m}) used {} rotations, exceeding the m(n-m)={} bound",
+                rotations.len(),
+                m * (n - m),
+            );
+            assert!(
+                rotations.iter().all(|&(_, _, i, j)| i.abs_diff(j) == 1),
+                "Slater decomposition for (n={n}, m={m}) contains a non-adjacent rotation",
+            );
+
+            let reconstructed = reconstruct_slater(&rotations, m, n);
+            let fidelity = slater_fidelity(&reconstructed, &target);
+            assert!(
+                (fidelity - 1.0).abs() < 1e-8,
+                "Slater decomposition for (n={n}, m={m}) reconstructed with fidelity {fidelity}",
             );
         }
     }

--- a/crates/pyext/src/linalg/givens.rs
+++ b/crates/pyext/src/linalg/givens.rs
@@ -14,7 +14,9 @@ use num_complex::Complex64;
 use numpy::PyReadonlyArray2;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
-use qiskit_fermions_core::linalg::givens::{GivensRotation, givens_decomposition};
+use qiskit_fermions_core::linalg::givens::{
+    GivensRotation, givens_decomposition, givens_decomposition_slater,
+};
 
 /// Decomposes a unitary matrix into Givens rotations and diagonal phases.
 ///
@@ -85,8 +87,90 @@ pub fn py_givens_decomposition(
     givens_decomposition(ndarray)
 }
 
+/// Decomposes the occupied orbitals of a Slater determinant into Givens rotations.
+///
+/// This is the rectangular counterpart of :func:`givens_decomposition`, specialized for Slater
+/// determinant `state preparation`. Given the coefficient matrix of the occupied orbitals of a
+/// Slater determinant, it returns a sequence of Givens rotations that, applied to the reference
+/// configuration :math:`\lvert 1 \cdots 1 0 \cdots 0 \rangle` (the first :math:`m` orbitals
+/// occupied), prepares the Slater determinant. Here ``orbital_coeffs`` is an :math:`m \times n`
+/// matrix whose rows are the :math:`m` occupied orbitals expressed in a basis of :math:`n` spatial
+/// orbitals (:math:`m \le n`); its rows are assumed to be orthonormal.
+///
+/// Unlike :func:`givens_decomposition`, this decomposition only needs to realize the :math:`m`
+/// occupied orbitals rather than a full :math:`n \times n` orbital rotation, so it uses at most
+/// :math:`m (n - m)` Givens rotations arranged in a diamond-shaped pattern (versus the
+/// :math:`n (n - 1) / 2` brick-wall of the square decomposition). The decomposition contains `no`
+/// diagonal phases, because a global phase and any rotation within the occupied space leave the
+/// prepared Slater determinant unchanged.
+///
+/// Each Givens rotation is defined by a 4-tuple, ``(c, s, i, j)``, with:
+///
+/// * ``c``: the real-valued cosine
+/// * ``s``: the complex-valued sine
+/// * ``i``: the first index
+/// * ``j``: the second (adjacent) index
+///
+/// which result in a matrix of the form:
+///
+/// .. math::
+///
+///    \begin{pmatrix}
+///    c & s \\
+///    -s^\dagger & c
+///    \end{pmatrix}
+///
+/// Args:
+///     orbital_coeffs: the :math:`m \times n` matrix of occupied-orbital coefficients.
+///
+/// Returns:
+///     The sequence of Givens rotations represented as 4-tuples as explained above.
+///
+/// The occupied orbitals are recovered by applying the returned rotations, `in order`, to the
+/// columns of the :math:`m \times n` reference :math:`\begin{pmatrix} I_m & 0 \end{pmatrix}`, where
+/// each rotation acting on indices :math:`i` and :math:`j` sends
+///
+/// .. math::
+///
+///    v_i \mapsto c \, v_i + s^\dagger v_j, \qquad v_j \mapsto c \, v_j - s \, v_i.
+///
+/// The result spans the same occupied space as ``orbital_coeffs`` (they define the same Slater
+/// determinant), so the squared overlap :math:`\lvert \det(A B^\dagger) \rvert^2` between the
+/// reconstructed orbitals :math:`A` and the target :math:`B` is one.
+///
+/// .. doctest::
+///
+///     >>> import numpy as np
+///     >>> from qiskit_fermions.linalg import givens_decomposition_slater
+///     >>> # two occupied orbitals in a basis of three, with orthonormal rows
+///     >>> base = np.array([[0.8, 0.6, 0.0], [-0.48, 0.64, 0.6]])
+///     >>> orbital_coeffs = (base * np.array([[1.0], [1j]])).astype(complex)
+///     >>> rotations = givens_decomposition_slater(orbital_coeffs)
+///     >>> m, n = orbital_coeffs.shape
+///     >>> reconstructed = np.eye(m, n, dtype=complex)
+///     >>> for c, s, i, j in rotations:
+///     ...     col_i, col_j = reconstructed[:, i].copy(), reconstructed[:, j].copy()
+///     ...     reconstructed[:, i] = c * col_i + s.conjugate() * col_j
+///     ...     reconstructed[:, j] = c * col_j - s * col_i
+///     >>> overlap = abs(np.linalg.det(reconstructed @ orbital_coeffs.conj().T)) ** 2
+///     >>> bool(np.isclose(overlap, 1.0))
+///     True
+///
+/// .. seealso::
+///    :func:`givens_decomposition` for the square (full orbital rotation) decomposition.
+#[gen_stub_pyfunction(module = "qiskit_fermions._lib.linalg.givens")]
+#[pyfunction(name = "givens_decomposition_slater")]
+pub fn py_givens_decomposition_slater(
+    orbital_coeffs: PyReadonlyArray2<Complex64>,
+) -> Vec<GivensRotation> {
+    let ndarray = orbital_coeffs.as_array().to_owned();
+    givens_decomposition_slater(ndarray)
+}
+
 #[pymodule]
 pub mod givens {
     #[pymodule_export]
     use super::py_givens_decomposition;
+    #[pymodule_export]
+    use super::py_givens_decomposition_slater;
 }

--- a/python/qiskit_fermions/_lib/linalg/givens/__init__.pyi
+++ b/python/qiskit_fermions/_lib/linalg/givens/__init__.pyi
@@ -6,6 +6,7 @@ import numpy
 import numpy.typing
 __all__ = [
     "givens_decomposition",
+    "givens_decomposition_slater",
 ]
 
 def givens_decomposition(unitary: numpy.typing.NDArray[numpy.complex128]) -> tuple[builtins.list[tuple[builtins.float, builtins.complex, builtins.int, builtins.int]], builtins.list[builtins.complex]]:
@@ -69,5 +70,80 @@ def givens_decomposition(unitary: numpy.typing.NDArray[numpy.complex128]) -> tup
     .. [1] W. R. Clements et al., Optimal design for universal multiport interferometers,
            Optica 3, 1460-1465 (2016),
            `doi:10.1364/OPTICA.3.001460 <https://doi.org/10.1364/OPTICA.3.001460>`_.
+    """
+
+def givens_decomposition_slater(orbital_coeffs: numpy.typing.NDArray[numpy.complex128]) -> builtins.list[tuple[builtins.float, builtins.complex, builtins.int, builtins.int]]:
+    r"""
+    Decomposes the occupied orbitals of a Slater determinant into Givens rotations.
+    
+    This is the rectangular counterpart of :func:`givens_decomposition`, specialized for Slater
+    determinant `state preparation`. Given the coefficient matrix of the occupied orbitals of a
+    Slater determinant, it returns a sequence of Givens rotations that, applied to the reference
+    configuration :math:`\lvert 1 \cdots 1 0 \cdots 0 \rangle` (the first :math:`m` orbitals
+    occupied), prepares the Slater determinant. Here ``orbital_coeffs`` is an :math:`m \times n`
+    matrix whose rows are the :math:`m` occupied orbitals expressed in a basis of :math:`n` spatial
+    orbitals (:math:`m \le n`); its rows are assumed to be orthonormal.
+    
+    Unlike :func:`givens_decomposition`, this decomposition only needs to realize the :math:`m`
+    occupied orbitals rather than a full :math:`n \times n` orbital rotation, so it uses at most
+    :math:`m (n - m)` Givens rotations arranged in a diamond-shaped pattern (versus the
+    :math:`n (n - 1) / 2` brick-wall of the square decomposition). The decomposition contains `no`
+    diagonal phases, because a global phase and any rotation within the occupied space leave the
+    prepared Slater determinant unchanged.
+    
+    Each Givens rotation is defined by a 4-tuple, ``(c, s, i, j)``, with:
+    
+    * ``c``: the real-valued cosine
+    * ``s``: the complex-valued sine
+    * ``i``: the first index
+    * ``j``: the second (adjacent) index
+    
+    which result in a matrix of the form:
+    
+    .. math::
+    
+       \begin{pmatrix}
+       c & s \\
+       -s^\dagger & c
+       \end{pmatrix}
+    
+    Args:
+        orbital_coeffs: the :math:`m \times n` matrix of occupied-orbital coefficients.
+    
+    Returns:
+        The sequence of Givens rotations represented as 4-tuples as explained above.
+    
+    The occupied orbitals are recovered by applying the returned rotations, `in order`, to the
+    columns of the :math:`m \times n` reference :math:`\begin{pmatrix} I_m & 0 \end{pmatrix}`, where
+    each rotation acting on indices :math:`i` and :math:`j` sends
+    
+    .. math::
+    
+       v_i \mapsto c \, v_i + s^\dagger v_j, \qquad v_j \mapsto c \, v_j - s \, v_i.
+    
+    The result spans the same occupied space as ``orbital_coeffs`` (they define the same Slater
+    determinant), so the squared overlap :math:`\lvert \det(A B^\dagger) \rvert^2` between the
+    reconstructed orbitals :math:`A` and the target :math:`B` is one.
+    
+    .. doctest::
+    
+        >>> import numpy as np
+        >>> from qiskit_fermions.linalg import givens_decomposition_slater
+        >>> # two occupied orbitals in a basis of three, with orthonormal rows
+        >>> base = np.array([[0.8, 0.6, 0.0], [-0.48, 0.64, 0.6]])
+        >>> orbital_coeffs = (base * np.array([[1.0], [1j]])).astype(complex)
+        >>> rotations = givens_decomposition_slater(orbital_coeffs)
+        >>> m, n = orbital_coeffs.shape
+        >>> reconstructed = np.eye(m, n, dtype=complex)
+        >>> for c, s, i, j in rotations:
+        ...     col_i, col_j = reconstructed[:, i].copy(), reconstructed[:, j].copy()
+        ...     reconstructed[:, i] = c * col_i + s.conjugate() * col_j
+        ...     reconstructed[:, j] = c * col_j - s * col_i
+        >>> overlap = abs(np.linalg.det(reconstructed @ orbital_coeffs.conj().T)) ** 2
+        >>> bool(np.isclose(overlap, 1.0))
+        True
+    
+    .. seealso::
+       :func:`givens_decomposition` for the square (full orbital rotation) decomposition.
     """
 

--- a/python/qiskit_fermions/linalg/__init__.py
+++ b/python/qiskit_fermions/linalg/__init__.py
@@ -24,6 +24,7 @@ This module provides various linear algebra utilities.
    :toctree: ../stubs/
 
    givens_decomposition
+   givens_decomposition_slater
    double_factorized_2body
    double_factorized_t2
    reconstruct_t2
@@ -38,13 +39,17 @@ from qiskit_fermions._lib.linalg.double_factorized import (
     reconstruct_t2,
     reconstruct_t2_alpha_beta,
 )
-from qiskit_fermions._lib.linalg.givens import givens_decomposition
+from qiskit_fermions._lib.linalg.givens import (
+    givens_decomposition,
+    givens_decomposition_slater,
+)
 
 __all__ = [
     "double_factorized_2body",
     "double_factorized_t2",
     "double_factorized_t2_alpha_beta",
     "givens_decomposition",
+    "givens_decomposition_slater",
     "reconstruct_t2",
     "reconstruct_t2_alpha_beta",
 ]

--- a/tests/python/linalg/test_givens.py
+++ b/tests/python/linalg/test_givens.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 import pytest
-from qiskit_fermions.linalg import givens_decomposition
+from qiskit_fermions.linalg import givens_decomposition, givens_decomposition_slater
 
 from ..utils import random_unitary
 
@@ -34,3 +34,32 @@ def test_givens_decomposition(dim: int):
         reconstructed @= givens_mat.conj()
 
     np.testing.assert_allclose(unitary, reconstructed)
+
+
+def _reconstruct_slater(rotations, m: int, n: int) -> np.ndarray:
+    """Reconstruct the occupied orbitals by applying the rotations to ``[I_m | 0]``."""
+    reconstructed = np.eye(m, n, dtype=complex)
+    for c, s, i, j in rotations:
+        col_i = reconstructed[:, i].copy()
+        col_j = reconstructed[:, j].copy()
+        reconstructed[:, i] = c * col_i + s.conjugate() * col_j
+        reconstructed[:, j] = c * col_j - s * col_i
+    return reconstructed
+
+
+@pytest.mark.parametrize("norb, nocc", [(6, 3), (7, 2), (5, 4), (4, 4), (5, 1), (8, 4)])
+def test_givens_decomposition_slater(norb: int, nocc: int):
+    # occupied-orbital coefficients: nocc rows of a random unitary, in a basis of norb orbitals
+    coeffs = random_unitary(norb, seed=norb * 100 + nocc).T[list(range(nocc))]
+    max_full = nocc * (norb - nocc)
+
+    rotations = givens_decomposition_slater(coeffs)
+
+    # diamond-pattern bound and adjacency
+    assert len(rotations) <= max_full
+    assert all(abs(i - j) == 1 for _, _, i, j in rotations)
+
+    # the reconstructed occupied space matches the target Slater determinant (fidelity 1)
+    reconstructed = _reconstruct_slater(rotations, nocc, norb)
+    overlap = abs(np.linalg.det(reconstructed @ coeffs.conj().T)) ** 2
+    assert overlap == pytest.approx(1.0)


### PR DESCRIPTION
The square `givens_decomposition` realizes a full n×n orbital rotation, but preparing a Slater determinant only needs its m occupied orbitals. Decomposing the m×n occupied-coefficient matrix instead yields a diamond-shaped pattern of at most m·(n-m) Givens rotations — far fewer than the n·(n-1)/2 brick-wall — and carries no diagonal phases, since a global phase and any rotation within the occupied space leave the prepared determinant unchanged. This unlocks the same gate-count reduction ffsim's `givens_decomposition_slater` provides for initial state preparation.

Closes #195