### PR TITLE
Parallel `InitializeModes` via an assert-only validator

### DIFF
--- a/crates/core/src/linalg/fci.rs
+++ b/crates/core/src/linalg/fci.rs
@@ -287,6 +287,50 @@ impl std::fmt::Display for FciMatvecError {
 
 impl std::error::Error for FciMatvecError {}
 
+/// Errors that can arise while building an [`occupation_axis_mask`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OccupationMaskError {
+    /// An `occupied`/`empty` constraint bit is set outside `0..norb`.
+    BitOutOfRange { bit: u32, norb: u32 },
+    /// An orbital is constrained to be both occupied and empty (`occupied & empty != 0`).
+    Overlap { bit: u32 },
+    /// The constraints cannot be satisfied by any `nocc`-electron determinant: either more than
+    /// `nocc` orbitals are forced occupied, or too few orbitals are left free to reach `nocc`.
+    Unsatisfiable {
+        norb: u32,
+        nocc: u32,
+        num_occupied: u32,
+        num_empty: u32,
+    },
+}
+
+impl std::fmt::Display for OccupationMaskError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OccupationMaskError::BitOutOfRange { bit, norb } => write!(
+                f,
+                "constraint bit {bit} is outside the range [0, {norb}) implied by the number of orbitals"
+            ),
+            OccupationMaskError::Overlap { bit } => write!(
+                f,
+                "orbital {bit} is constrained to be both occupied and empty"
+            ),
+            OccupationMaskError::Unsatisfiable {
+                norb,
+                nocc,
+                num_occupied,
+                num_empty,
+            } => write!(
+                f,
+                "no {nocc}-electron determinant on {norb} orbitals can have {num_occupied} orbitals \
+                 occupied and {num_empty} orbitals empty"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for OccupationMaskError {}
+
 /// Computes the spinful FCI dimension `C(norb, n_alpha) * C(norb, n_beta)`, checking for overflow.
 ///
 /// The per-sector dimensions each fit in `usize`, but their product need not; a silent wrap could
@@ -367,6 +411,66 @@ pub fn slater_determinant_statevector(
             Ok(vec)
         }
     }
+}
+
+/// Builds a boolean mask over the `(norb, nocc)` sector's addresses selecting the determinants that
+/// satisfy a partial occupation constraint.
+///
+/// The result has length `C(norb, nocc)`; entry `addr` is `true` iff the determinant at that address
+/// (see [`addr2str`]) has **all** orbitals in the `occupied` bitmask set **and all** orbitals in the
+/// `empty` bitmask clear. Orbitals in neither mask are unconstrained ("free"), so a partial
+/// constraint selects a whole family of determinants -- e.g. fixing only the alpha occupation of a
+/// spin sector accepts every determinant that agrees there, whatever the free orbitals do. This is
+/// the per-axis subspace test behind :class:`.InitializeModes`'s validator: an incoming state passes
+/// iff its amplitude is confined to the `true` entries of this mask along the constrained axis.
+///
+/// `occupied` and `empty` are bitmasks over `0..norb` (bit `p` set iff orbital `p` is constrained).
+/// Errors ([`OccupationMaskError`]) are raised for a constraint bit outside `0..norb`, an orbital
+/// constrained both occupied and empty, or an unsatisfiable constraint (more than `nocc` orbitals
+/// forced occupied, or too few free orbitals left to reach `nocc`) -- so an impossible constraint is
+/// a clear error rather than a silently all-`false` mask.
+pub fn occupation_axis_mask(
+    norb: u32,
+    nocc: u32,
+    occupied: u64,
+    empty: u64,
+) -> Result<Vec<bool>, OccupationMaskError> {
+    // Constraint bits must address real orbitals: an out-of-range bit could never be matched and
+    // signals a caller error, not an empty selection.
+    for mask in [occupied, empty] {
+        if let Some(bit) = mode_out_of_range(mask, norb) {
+            return Err(OccupationMaskError::BitOutOfRange { bit, norb });
+        }
+    }
+    // An orbital cannot be both forced occupied and forced empty.
+    let overlap = occupied & empty;
+    if overlap != 0 {
+        return Err(OccupationMaskError::Overlap {
+            bit: overlap.trailing_zeros(),
+        });
+    }
+    // The constraint must be satisfiable by *some* `nocc`-electron determinant: no more than `nocc`
+    // orbitals may be forced occupied, and enough orbitals must remain free to fill up to `nocc`.
+    let num_occupied = occupied.count_ones();
+    let num_empty = empty.count_ones();
+    let num_free = norb - num_occupied - num_empty;
+    if num_occupied > nocc || nocc - num_occupied > num_free {
+        return Err(OccupationMaskError::Unsatisfiable {
+            norb,
+            nocc,
+            num_occupied,
+            num_empty,
+        });
+    }
+
+    let table = BinomialTable::new(norb);
+    let mask = (0..table.num_strings(norb, nocc))
+        .map(|addr| {
+            let string = addr2str(&table, norb, nocc, addr);
+            string & occupied == occupied && string & empty == 0
+        })
+        .collect();
+    Ok(mask)
 }
 
 /// Applies a single term's ladder operators (right-to-left) to one sector's occupation `string`.
@@ -1136,6 +1240,78 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn occupation_axis_mask_matches_brute_force() {
+        // The mask selects the determinants whose bitmask has all `occupied` bits set and all `empty`
+        // bits clear. Cross-check against a brute-force scan over the enumerated sector strings for a
+        // spread of constraints, including a fully-pinned occupation (a single `true`) and a
+        // no-constraint case (all `true`).
+        let cases: &[(u32, u32, u64, u64)] = &[
+            // no constraint: every determinant of the sector qualifies.
+            (4, 2, 0b0000, 0b0000),
+            // fully pinned: exactly one determinant qualifies.
+            (4, 2, 0b0011, 0b1100),
+            // partial: fix orbital 0 occupied, leave the rest free.
+            (5, 3, 0b00001, 0b00000),
+            // partial: fix orbital 4 empty, leave the rest free.
+            (5, 3, 0b00000, 0b10000),
+            // mixed partial: orbital 1 occupied, orbital 3 empty.
+            (5, 2, 0b00010, 0b01000),
+            // higher rank, several fixed bits.
+            (6, 3, 0b000101, 0b100000),
+        ];
+        for &(norb, nocc, occupied, empty) in cases {
+            let mask = occupation_axis_mask(norb, nocc, occupied, empty).unwrap();
+            let strings = enumerate_strings(norb, nocc);
+            assert_eq!(mask.len(), strings.len(), "norb={norb} nocc={nocc}");
+            for (addr, &string) in strings.iter().enumerate() {
+                let want = string & occupied == occupied && string & empty == 0;
+                assert_eq!(
+                    mask[addr], want,
+                    "norb={norb} nocc={nocc} occ={occupied:b} emp={empty:b} string={string:b}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn occupation_axis_mask_full_and_empty_constraints() {
+        // A fully-pinned occupation selects exactly the one determinant at its address; an empty
+        // constraint selects the whole sector.
+        let full = occupation_axis_mask(3, 2, 0b011, 0b100).unwrap();
+        assert_eq!(full.iter().filter(|&&b| b).count(), 1);
+        // The single survivor sits at str2addr(0b011) = 0.
+        assert!(full[str2addr(&BinomialTable::new(3), 0b011)]);
+
+        let none = occupation_axis_mask(3, 2, 0, 0).unwrap();
+        assert_eq!(none.len(), BinomialTable::new(3).num_strings(3, 2));
+        assert!(none.iter().all(|&b| b));
+    }
+
+    #[test]
+    fn occupation_axis_mask_rejects_invalid_constraints() {
+        // A constraint bit outside 0..norb.
+        assert!(matches!(
+            occupation_axis_mask(3, 1, 0b1000, 0).unwrap_err(),
+            OccupationMaskError::BitOutOfRange { bit: 3, norb: 3 }
+        ));
+        // An orbital constrained both occupied and empty.
+        assert!(matches!(
+            occupation_axis_mask(3, 1, 0b010, 0b010).unwrap_err(),
+            OccupationMaskError::Overlap { bit: 1 }
+        ));
+        // More orbitals forced occupied than there are electrons.
+        assert!(matches!(
+            occupation_axis_mask(4, 1, 0b0011, 0).unwrap_err(),
+            OccupationMaskError::Unsatisfiable { .. }
+        ));
+        // Too few free orbitals left to reach nocc (3 of 4 forced empty, need 2 electrons).
+        assert!(matches!(
+            occupation_axis_mask(4, 2, 0, 0b1110).unwrap_err(),
+            OccupationMaskError::Unsatisfiable { .. }
+        ));
     }
 
     #[test]

--- a/crates/pyext/src/linalg/fci.rs
+++ b/crates/pyext/src/linalg/fci.rs
@@ -16,7 +16,7 @@ use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
 
 use qiskit_fermions_core::linalg::fci::{
-    FciMatvecError, MAX_ORBITALS, slater_determinant_statevector,
+    FciMatvecError, MAX_ORBITALS, occupation_axis_mask, slater_determinant_statevector,
 };
 
 /// A matvec closure closing over an operator and a fixed FCI sector.
@@ -176,10 +176,60 @@ pub fn py_slater_determinant_statevector(
     Ok(vec.into_pyarray(py))
 }
 
+/// Builds a boolean mask over an FCI sector's addresses selecting a partial-occupation subspace.
+///
+/// The mask has length ``C(norb, nocc)``; entry ``addr`` is ``True`` iff the determinant at that
+/// address has **all** orbitals in the ``occupied`` bitmask set **and all** orbitals in the ``empty``
+/// bitmask clear. Orbitals in neither mask are unconstrained, so a partial constraint selects a whole
+/// family of determinants (fixing only some orbitals accepts every determinant that agrees there,
+/// whatever the free orbitals do). This is the per-axis subspace test behind
+/// :class:`.InitializeModes`'s validator: an incoming state passes iff its amplitude is confined to
+/// the ``True`` entries of this mask along the constrained spin axis.
+///
+/// Args:
+///     norb: the number of spatial orbitals.
+///     nocc: the number of occupied orbitals of the sector (its address space is ``C(norb, nocc)``).
+///     occupied: a bitmask over ``0..norb`` whose set bits mark orbitals forced to be occupied.
+///     empty: a bitmask over ``0..norb`` whose set bits mark orbitals forced to be empty.
+///
+/// Returns:
+///     A one-dimensional ``bool`` array of length ``C(norb, nocc)``.
+///
+/// Raises:
+///     ValueError: if ``norb`` exceeds the maximum number of orbitals the bitmask representation
+///         supports (64); if a constraint bit is set outside ``0..norb``; if an orbital is
+///         constrained to be both occupied and empty; or if the constraint is unsatisfiable (more
+///         than ``nocc`` orbitals forced occupied, or too few free orbitals left to reach ``nocc``).
+#[gen_stub_pyfunction(module = "qiskit_fermions._lib.linalg.fci")]
+#[pyfunction(name = "occupation_axis_mask", signature = (norb, nocc, occupied, empty))]
+// `pyo3-stub-gen` has no NumPyScalar impl for `bool`, so the array return type cannot be derived;
+// spell it out to match the `numpy.typing.NDArray[...]` convention the sibling functions render.
+#[gen_stub(override_return_type(
+    type_repr = "numpy.typing.NDArray[numpy.bool_]",
+    imports = ("numpy", "numpy.typing")
+))]
+pub fn py_occupation_axis_mask(
+    py: Python<'_>,
+    norb: u32,
+    nocc: u32,
+    occupied: u64,
+    empty: u64,
+) -> PyResult<Bound<'_, PyArray1<bool>>> {
+    if norb > MAX_ORBITALS {
+        return Err(crate::value_err(format!(
+            "norb={norb} exceeds the maximum of {MAX_ORBITALS} orbitals"
+        )));
+    }
+    let mask = occupation_axis_mask(norb, nocc, occupied, empty).map_err(crate::value_err)?;
+    Ok(mask.into_pyarray(py))
+}
+
 #[pymodule]
 pub mod fci {
     #[pymodule_export]
     use super::FciLinearOperator;
+    #[pymodule_export]
+    use super::py_occupation_axis_mask;
     #[pymodule_export]
     use super::py_slater_determinant_statevector;
 }

--- a/crates/pyext/src/linalg/fci.rs
+++ b/crates/pyext/src/linalg/fci.rs
@@ -201,7 +201,7 @@ pub fn py_slater_determinant_statevector(
 ///         constrained to be both occupied and empty; or if the constraint is unsatisfiable (more
 ///         than ``nocc`` orbitals forced occupied, or too few free orbitals left to reach ``nocc``).
 #[gen_stub_pyfunction(module = "qiskit_fermions._lib.linalg.fci")]
-#[pyfunction(name = "occupation_axis_mask", signature = (norb, nocc, occupied, empty))]
+#[pyfunction(name = "occupation_axis_mask")]
 // `pyo3-stub-gen` has no NumPyScalar impl for `bool`, so the array return type cannot be derived;
 // spell it out to match the `numpy.typing.NDArray[...]` convention the sibling functions render.
 #[gen_stub(override_return_type(

--- a/docs/guides/lucj.rst
+++ b/docs/guides/lucj.rst
@@ -163,10 +163,10 @@ halving the number of layers.
 
 The :class:`.UCJ` gate is a pure unitary carrying no reference of its own, so we prepend an
 :class:`.InitializeModes` gate (built with
-:meth:`~qiskit_fermions.circuit.library.InitializeModes.from_hartree_fock`) to certify the
+:meth:`~qiskit_fermions.circuit.library.InitializeModes.from_hartree_fock`) to supply the
 Hartree-Fock reference the ansatz is applied to. Decomposing the circuit reveals its anatomy: the
-:class:`.InitializeModes` gate validates the reference, and each ansatz layer contributes an
-:class:`.OrbitalRotation` :math:`\mathcal{U}_k^\dagger`, then :math:`e^{i\mathcal{J}_k}` (an
+:class:`.InitializeModes` gate prepares the reference determinant, and each ansatz layer contributes
+an :class:`.OrbitalRotation` :math:`\mathcal{U}_k^\dagger`, then :math:`e^{i\mathcal{J}_k}` (an
 :class:`.Evolution` of the diagonal Coulomb operator :math:`\mathcal{J}_k`), then
 :math:`\mathcal{U}_k`, with a final :class:`.OrbitalRotation` at the end. The orbital rotations act
 per spin sector, so each is placed on the alpha modes ``0..norb`` and the beta modes

--- a/docs/guides/lucj.rst
+++ b/docs/guides/lucj.rst
@@ -146,11 +146,12 @@ halving the number of layers.
          :include-source:
 
          >>> from qiskit_fermions.circuit import FermionicCircuit
-         >>> from qiskit_fermions.circuit.library import UCJ
+         >>> from qiskit_fermions.circuit.library import InitializeModes, UCJ
          >>>
          >>> ansatz = UCJ.from_t_amplitudes(nelec, t2, t1=t1, n_reps=2)
          >>>
          >>> circuit = FermionicCircuit(2 * norb)
+         >>> circuit.append(InitializeModes.from_hartree_fock(norb, nelec), circuit.modes)
          >>> circuit.append(ansatz, circuit.modes)
 
    .. tab-item:: C
@@ -160,12 +161,16 @@ halving the number of layers.
 
          // The C API for FermionicCircuit is not available yet.
 
-Decomposing the gate reveals its anatomy: an :class:`.InitializeModes` gate prepares the
-Hartree-Fock reference determinant, and each ansatz layer contributes an :class:`.OrbitalRotation`
-:math:`\mathcal{U}_k^\dagger`, then :math:`e^{i\mathcal{J}_k}` (an :class:`.Evolution` of the
-diagonal Coulomb operator :math:`\mathcal{J}_k`), then :math:`\mathcal{U}_k`, with a final
-:class:`.OrbitalRotation` at the end. The orbital rotations act per spin sector, so each is placed
-on the alpha modes ``0..norb`` and the beta modes ``norb..2*norb`` independently.
+The :class:`.UCJ` gate is a pure unitary carrying no reference of its own, so we prepend an
+:class:`.InitializeModes` gate (built with
+:meth:`~qiskit_fermions.circuit.library.InitializeModes.from_hartree_fock`) to certify the
+Hartree-Fock reference the ansatz is applied to. Decomposing the circuit reveals its anatomy: the
+:class:`.InitializeModes` gate validates the reference, and each ansatz layer contributes an
+:class:`.OrbitalRotation` :math:`\mathcal{U}_k^\dagger`, then :math:`e^{i\mathcal{J}_k}` (an
+:class:`.Evolution` of the diagonal Coulomb operator :math:`\mathcal{J}_k`), then
+:math:`\mathcal{U}_k`, with a final :class:`.OrbitalRotation` at the end. The orbital rotations act
+per spin sector, so each is placed on the alpha modes ``0..norb`` and the beta modes
+``norb..2*norb`` independently.
 
 .. plot::
    :alt: The gates that the UCJ ansatz decomposes into.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,5 +200,10 @@ iz = "iz"
 ket = "ket"
 thr = "thr"
 
+[tool.typos.default.extend-identifiers]
+# numpy's array type; `ND` trips the "should be AND" heuristic. Spelled out verbatim in the
+# `occupation_axis_mask` stub-type override in crates/pyext (the generated `.pyi` are excluded).
+NDArray = "NDArray"
+
 [tool.typos.files]
 extend-exclude = ["crates/qiskit-pyo3-ffi"]

--- a/python/qiskit_fermions/_lib/linalg/fci/__init__.pyi
+++ b/python/qiskit_fermions/_lib/linalg/fci/__init__.pyi
@@ -7,6 +7,7 @@ import numpy.typing
 import typing
 __all__ = [
     "FciLinearOperator",
+    "occupation_axis_mask",
     "slater_determinant_statevector",
 ]
 
@@ -65,6 +66,34 @@ class FciLinearOperator:
             ValueError: if ``vec`` has the wrong length, or the underlying operator acts on a mode
                 index outside the sector.
         """
+
+def occupation_axis_mask(norb: builtins.int, nocc: builtins.int, occupied: builtins.int, empty: builtins.int) -> numpy.typing.NDArray[numpy.bool_]:
+    r"""
+    Builds a boolean mask over an FCI sector's addresses selecting a partial-occupation subspace.
+    
+    The mask has length ``C(norb, nocc)``; entry ``addr`` is ``True`` iff the determinant at that
+    address has **all** orbitals in the ``occupied`` bitmask set **and all** orbitals in the ``empty``
+    bitmask clear. Orbitals in neither mask are unconstrained, so a partial constraint selects a whole
+    family of determinants (fixing only some orbitals accepts every determinant that agrees there,
+    whatever the free orbitals do). This is the per-axis subspace test behind
+    :class:`.InitializeModes`'s validator: an incoming state passes iff its amplitude is confined to
+    the ``True`` entries of this mask along the constrained spin axis.
+    
+    Args:
+        norb: the number of spatial orbitals.
+        nocc: the number of occupied orbitals of the sector (its address space is ``C(norb, nocc)``).
+        occupied: a bitmask over ``0..norb`` whose set bits mark orbitals forced to be occupied.
+        empty: a bitmask over ``0..norb`` whose set bits mark orbitals forced to be empty.
+    
+    Returns:
+        A one-dimensional ``bool`` array of length ``C(norb, nocc)``.
+    
+    Raises:
+        ValueError: if ``norb`` exceeds the maximum number of orbitals the bitmask representation
+            supports (64); if a constraint bit is set outside ``0..norb``; if an orbital is
+            constrained to be both occupied and empty; or if the constraint is unsatisfiable (more
+            than ``nocc`` orbitals forced occupied, or too few free orbitals left to reach ``nocc``).
+    """
 
 def slater_determinant_statevector(norb: builtins.int, alpha_str: builtins.int, beta_str: typing.Optional[builtins.int] = None) -> numpy.typing.NDArray[numpy.complex128]:
     r"""

--- a/python/qiskit_fermions/circuit/fermionic_circuit.py
+++ b/python/qiskit_fermions/circuit/fermionic_circuit.py
@@ -111,7 +111,7 @@ class FermionicCircuit:
         return self._inner.draw(*args, **kwargs)
 
     def _apply_unitary_(
-        self, vec: np.ndarray | None, norb: int, nelec: int | tuple[int, int], copy: bool
+        self, vec: np.ndarray, norb: int, nelec: int | tuple[int, int], copy: bool
     ) -> np.ndarray:
         """Applies this circuit to an ffsim state vector, implementing ffsim's protocol.
 
@@ -124,16 +124,11 @@ class FermionicCircuit:
         are the vector's modes ``0..num_modes`` (i.e. an identity mode placement).
 
         Args:
-            vec: the state vector to apply this circuit to. May be ``None`` to let the circuit's
-                first instruction seed the initial state (e.g. :class:`.InitializeModes`, which
-                prepares an occupation determinant from no incoming state); the seeded vector is then
-                threaded through the remaining instructions. A ``None`` vector requires the first
-                instruction to be able to produce a state -- one that only transforms an incoming
-                vector will raise.
+            vec: the state vector to apply this circuit to. An empty circuit returns it unchanged.
             norb: the number of spatial orbitals.
             nelec: either a single integer representing the number of fermions for a spinless system,
                 or a pair of integers storing the numbers of spin alpha and spin beta fermions.
-            copy: whether to copy the vector before operating on it. Ignored when ``vec`` is ``None``.
+            copy: whether to copy the vector before operating on it.
 
         Returns:
             The transformed vector.
@@ -142,15 +137,14 @@ class FermionicCircuit:
             TypeError: if a circuit instruction does not implement ffsim's
                 :external:class:`ffsim.SupportsApplyUnitary` protocol.
             ValueError: if a circuit instruction declines to apply its unitary for the given
-                ``norb`` and ``nelec``; if an instruction implementing only the plain
-                ``_apply_unitary_`` protocol is placed on a non-identity mode subset; or if the
-                circuit is empty and ``vec`` is ``None`` (there is no state to return).
+                ``norb`` and ``nelec``; or if an instruction implementing only the plain
+                ``_apply_unitary_`` protocol is placed on a non-identity mode subset.
         """
         return self._apply_unitary_placed_(vec, norb, nelec, copy, list(range(len(self.register))))
 
     def _apply_unitary_placed_(
         self,
-        vec: np.ndarray | None,
+        vec: np.ndarray,
         norb: int,
         nelec: int | tuple[int, int],
         copy: bool,
@@ -176,16 +170,11 @@ class FermionicCircuit:
         silently applied on the wrong modes.
 
         Args:
-            vec: the state vector to apply this circuit to. May be ``None`` to let the circuit's
-                first instruction seed the initial state (e.g. :class:`.InitializeModes`, which
-                prepares an occupation determinant from no incoming state); the seeded vector is then
-                threaded through the remaining instructions. A ``None`` vector requires the first
-                instruction to be able to produce a state -- one that only transforms an incoming
-                vector will raise.
+            vec: the state vector to apply this circuit to. An empty circuit returns it unchanged.
             norb: the number of spatial orbitals of the *global* state vector.
             nelec: either a single integer representing the number of fermions for a spinless system,
                 or a pair of integers storing the numbers of spin alpha and spin beta fermions.
-            copy: whether to copy the vector before operating on it. Ignored when ``vec`` is ``None``.
+            copy: whether to copy the vector before operating on it.
             freg_indices: the absolute (global) mode indices that this circuit's modes map onto.
 
         Returns:
@@ -195,9 +184,8 @@ class FermionicCircuit:
             TypeError: if a circuit instruction does not implement ffsim's
                 :external:class:`ffsim.SupportsApplyUnitary` protocol.
             ValueError: if a circuit instruction declines to apply its unitary for the given
-                ``norb`` and ``nelec``; if an instruction implementing only the plain
-                ``_apply_unitary_`` protocol is placed on a non-identity mode subset; or if the
-                circuit is empty and ``vec`` is ``None`` (there is no state to return).
+                ``norb`` and ``nelec``; or if an instruction implementing only the plain
+                ``_apply_unitary_`` protocol is placed on a non-identity mode subset.
         """
         from qiskit_fermions.transpiler.converters import FermionicCircuitToDAG
 
@@ -214,10 +202,9 @@ class FermionicCircuit:
         # instructions un-normalized and be misclassified as spinful.
         nelec = FermionicGate._normalize_nelec(nelec)
 
-        # ``vec`` may be None to let the first instruction seed the state (e.g. InitializeModes);
-        # only copy a real array. The gate-to-gate loop below then threads whatever the first
-        # instruction returns into the rest of the circuit.
-        if copy and vec is not None:
+        # The gate-to-gate loop below threads whatever each instruction returns into the next; only
+        # copy the incoming array once up front so the caller's vector is left untouched.
+        if copy:
             vec = vec.copy()
 
         for node in dag.topological_op_nodes():
@@ -231,9 +218,7 @@ class FermionicCircuit:
             # absolute modes; fall back to the plain protocol method otherwise
             placed_method = getattr(instr, "_apply_unitary_placed_", None)
             if placed_method is not None:
-                result = self._call_apply_unitary(
-                    instr, placed_method, vec, norb, nelec, False, node_freg_indices
-                )
+                result = placed_method(vec, norb, nelec, False, node_freg_indices)
             else:
                 method = getattr(instr, "_apply_unitary_", None)
                 if method is None:
@@ -255,7 +240,7 @@ class FermionicCircuit:
                         f"{list(range(len(node.qargs)))}; implement '_apply_unitary_placed_' to "
                         "support subset placement."
                     )
-                result = self._call_apply_unitary(instr, method, vec, norb, nelec, False)
+                result = method(vec, norb, nelec, False)
 
             if result is NotImplemented:
                 raise ValueError(
@@ -265,35 +250,6 @@ class FermionicCircuit:
 
             vec = result
 
-        if vec is None:
-            # no instruction ran (an empty circuit) and no incoming vector was supplied, so there is
-            # no state to return. The protocol must yield an array, not ``None``; a caller wanting an
-            # identity here must pass the vector to act on.
-            raise ValueError(
-                "Cannot apply an empty circuit to a vector of None: there is no incoming state and "
-                "no instruction to seed one. Pass a state vector for the circuit to act on."
-            )
-
+        # An empty circuit ran no instruction, so the (already-copied) incoming vector is returned
+        # unchanged -- the identity.
         return vec
-
-    @staticmethod
-    def _call_apply_unitary(instr, method, vec, *args):
-        """Invokes an instruction's apply-unitary method, clarifying the ``vec is None`` failure.
-
-        A ``None`` incoming vector is only meaningful for a state-*producing* first instruction (e.g.
-        :class:`.InitializeModes`); a transform-only instruction (an :class:`.Evolution`, an
-        :class:`.OrbitalRotation`, ...) has no state to act on and fails deep inside ffsim/scipy with
-        an opaque ``AttributeError`` on the ``None``. Translate that into the clean ``ValueError`` the
-        ``_apply_unitary_``/``_apply_unitary_placed_`` docstrings promise, naming the instruction.
-        """
-        try:
-            return method(vec, *args)
-        except AttributeError as exc:
-            if vec is None:
-                raise ValueError(
-                    f"Circuit instruction of type '{type(instr)}' cannot seed a state from a None "
-                    "vector: it only transforms an incoming state. A None vector requires the "
-                    "circuit's first instruction to be a state producer (e.g. InitializeModes), or "
-                    "pass an explicit state vector for the circuit to act on."
-                ) from exc
-            raise

--- a/python/qiskit_fermions/circuit/library/initialize_modes.py
+++ b/python/qiskit_fermions/circuit/library/initialize_modes.py
@@ -14,18 +14,35 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Sequence
+from math import comb
 
 import numpy as np
 
 from .. import FermionicGate
 
-logger = logging.getLogger(__name__)
+# The absolute tolerance for the subspace-confinement check. There is no project-wide tolerance
+# constant; this is the de-facto convention (numpy's ``allclose`` default, matching the Rust
+# operator-method default) applied consistently across the apply-unitary stack.
+_ATOL = 1e-8
 
 
 class InitializeModes(FermionicGate):
-    """Implements the fermionic mode initialization.
+    """Asserts that a state vector matches a fermionic mode occupation.
+
+    This gate is a *validator*, not a state producer: applied to a state vector it checks that the
+    vector's amplitude is confined to the subspace its :attr:`occupation` defines, then returns the
+    vector unchanged. Placing it at the start of a circuit therefore certifies -- without mutating --
+    that the incoming state is the intended reference; the transforms that follow act on that same
+    vector.
+
+    Because the check constrains only the orbitals the occupation names (and, per spin sector, only
+    along that sector's axis), several :class:`InitializeModes` gates can be placed **in parallel** to
+    certify disjoint fragments of a state independently -- e.g. one gate per spin sector, or one per
+    orbital group. A spinful gate may cover a single sector (any fragment of it) or fully specify both
+    sectors, but a partial straddle of both is rejected (see :meth:`_apply_unitary_placed_`).
+
+    Use :meth:`from_hartree_fock` to construct the occupation of a Hartree-Fock reference.
 
     .. caution::
        This is an early development prototype. Beware of changes to its interface without warning
@@ -45,139 +62,188 @@ class InitializeModes(FermionicGate):
 
         super().__init__("InitializeModes", len(self.occupation), [])
 
+    @classmethod
+    def from_hartree_fock(cls, norb: int, nelec: int | tuple[int, int]) -> InitializeModes:
+        """Builds the gate for the Hartree-Fock reference occupation of ``(norb, nelec)``.
+
+        The Hartree-Fock determinant fills the lowest-indexed orbitals of each spin sector. Whether
+        the reference is spinless or spinful is inferred from ``nelec`` (an ``int`` selects the
+        spinless interpretation of the ``norb`` modes; a ``(n_alpha, n_beta)`` pair selects the
+        spinful block-spin interpretation of the ``2 * norb`` modes). Place the returned gate on the
+        matching register to certify a Hartree-Fock reference state.
+
+        Args:
+            norb: the number of spatial orbitals.
+            nelec: either a single integer for a spinless system, or a pair of integers storing the
+                numbers of spin alpha and spin beta fermions.
+
+        Returns:
+            An :class:`InitializeModes` gate whose occupation is the Hartree-Fock determinant.
+
+        Raises:
+            ValueError: if the electron count exceeds the ``norb`` orbitals available in a sector.
+        """
+        nelec = cls._normalize_nelec(nelec)
+        if isinstance(nelec, int):
+            if nelec > norb:
+                raise ValueError(f"nelec={nelec!r} exceeds the norb={norb} spinless modes.")
+            occ = [i < nelec for i in range(norb)]
+            return cls(occ)
+
+        n_alpha, n_beta = nelec
+        if n_alpha > norb or n_beta > norb:
+            raise ValueError(
+                f"nelec={nelec!r} has a spin sector exceeding the norb={norb} available orbitals."
+            )
+        occ = [False] * (2 * norb)
+        for i in range(n_alpha):
+            occ[i] = True
+        for i in range(n_beta):
+            occ[norb + i] = True
+        return cls(occ)
+
     def _apply_unitary_placed_(
         self,
-        vec: np.ndarray | None,
+        vec: np.ndarray,
         norb: int,
         nelec: int | tuple[int, int],
         copy: bool,
         freg_indices: list[int],
     ) -> np.ndarray:
-        r"""Produces the occupation determinant, placing it onto the vector's global modes.
+        r"""Asserts that ``vec`` is confined to this gate's occupation subspace, returning it unchanged.
 
-        Unlike most other fermionic gates, this gate is a state *producer*, not a transform: it
-        prepares the occupation determinant a Jordan-Wigner occupation would create from the vacuum.
-        Because seeding a determinant *defines* the fixed ``(norb, nelec)`` particle number sector
-        (the vacuum lives in a different sector), it cannot be expressed as a same-length linear map
-        of an incoming vector -- so this method returns a freshly built state vector rather than
-        transforming ``vec``.
-
-        .. warning::
-           Because this gate defines the whole ``(norb, nelec)`` sector at once, two
-           :class:`InitializeModes` gates cannot be placed in parallel to seed the alpha and beta
-           spin sectors independently: each seeds a full state vector for its own placement and the
-           second would discard the first. Seed a spinful determinant with a single gate covering all
-           ``2 * norb`` modes instead.
+        Unlike a transform gate, this gate does not modify the state: it *checks* that ``vec``'s
+        amplitude lives entirely in the subspace its :attr:`occupation` defines, and if so returns
+        ``vec`` untouched. The subspace is the set of determinants whose occupation agrees with this
+        gate on the orbitals it names, with every unnamed orbital left free -- so a partial occupation
+        (a fragment of a sector) accepts a whole family of determinants and the check composes with
+        other parallel :class:`InitializeModes` gates.
 
         The gate's local :attr:`occupation` (one flag per local mode) is placed onto the global
-        register via ``freg_indices``: local mode ``i`` occupies global mode ``freg_indices[i]``. The
-        occupied global modes are then interpreted under the ``(norb, nelec)`` convention:
+        register via ``freg_indices``: local mode ``i`` constrains global mode ``freg_indices[i]``.
+        The global modes are then interpreted under the ``(norb, nelec)`` convention:
 
-        - **Spinless** (``nelec`` is an ``int``): the ``norb`` modes are orbitals directly; the seed
-          is a one-hot at the determinant's address in the ``C(norb, nelec)``-dimensional space.
+        - **Spinless** (``nelec`` is an ``int``): the ``norb`` modes are orbitals directly; the check
+          is over the ``C(norb, nelec)``-dimensional space.
         - **Spinful** (``nelec`` is a pair): under the block-spin convention modes ``0..norb`` are
-          alpha orbitals and modes ``norb..2*norb`` are beta orbitals; the seed is a one-hot at the
-          flat index ``addr_a * dim_b + addr_b`` (alpha slow, beta fast).
+          alpha orbitals and modes ``norb..2*norb`` are beta orbitals. A gate touching a single
+          sector constrains that sector's axis of the ``(dim_a, dim_b)`` state (a set of full rows
+          for an alpha gate, or full columns for a beta gate) and leaves the other axis free, so it
+          composes with parallel gates on the other sector. A gate may also cover *both* sectors, but
+          only when it pins a complete determinant (every orbital of both sectors named, none left
+          free); a *partial* straddle -- constraining some orbitals of both sectors while leaving
+          others free -- is rejected, since it is not a product of per-axis subspaces and cannot
+          compose (use one gate per sector instead).
 
-        The determinant is built via the native ``slater_determinant_statevector`` kernel (a
-        position-indexed occupation is inherently sorted, so the one-hot carries no sign).
+        The check is on *confinement*, not equality: an incoming amplitude may carry any phase and
+        any magnitude within the subspace (a global phase or normalization is physically irrelevant),
+        so this validates the reference without pinning it to a specific determinant vector.
 
         Args:
-            vec: the state vector to act on, or ``None`` to seed from no incoming state. When a real
-                array is passed it must *agree* with the occupation -- same ``(norb, nelec)`` sector
-                dimension -- in which case a warning is logged and the freshly seeded determinant is
-                returned (the incoming amplitudes are replaced, since this gate defines the initial
-                state; placing it mid-circuit therefore drops the preceding gates' effect). A vector
-                of the wrong length is rejected.
+            vec: the state vector to validate. Its length must match the ``(norb, nelec)`` sector
+                dimension.
             norb: the number of spatial orbitals of the *global* state vector.
             nelec: either a single integer for a spinless system, or a pair of integers storing the
                 numbers of spin alpha and spin beta fermions. An integer selects the spinless mode
                 interpretation (the ``norb`` modes are orbitals); a pair selects the spinful
                 ``(orb, spin)`` block-spin interpretation of the ``2 * norb`` modes.
-            copy: accepted for protocol conformance but has no effect -- a fresh state vector is
-                always returned, so any incoming ``vec`` is inherently left untouched.
+            copy: accepted for protocol conformance but has no effect -- this gate does not mutate the
+                state, so ``vec`` is returned as-is regardless.
             freg_indices: the absolute (global) mode indices that this gate's local modes map onto.
 
         Returns:
-            The seeded occupation determinant as a state vector.
+            The input ``vec``, unchanged, once its confinement to the occupation subspace is verified.
 
         Raises:
-            ValueError: if the occupation's per-sector electron counts do not match ``nelec``, if an
-                occupied mode falls outside the range implied by ``norb``, or if a non-``None`` ``vec``
-                does not match the ``(norb, nelec)`` sector dimension.
+            ValueError: if an occupied mode falls outside the range implied by ``norb``; if a spinful
+                gate partially straddles both spin sectors (without pinning a full determinant); if
+                ``vec``'s length does not match the ``(norb, nelec)`` sector dimension; or if ``vec``
+                has amplitude outside the subspace the occupation defines.
         """
-        spinless = isinstance(nelec, int)
-        num_modes = norb if spinless else 2 * norb
+        from qiskit_fermions._lib.linalg.fci import occupation_axis_mask
 
-        # place the local occupation onto its global modes
-        global_occ = sorted(
-            int(g) for g, occ in zip(freg_indices, self.occupation, strict=True) if occ
+        num_modes = norb if isinstance(nelec, int) else 2 * norb
+
+        # place the local occupation onto its global modes, keeping the occupied/empty split
+        placed = sorted(
+            (int(g), bool(occ)) for g, occ in zip(freg_indices, self.occupation, strict=True)
         )
+        global_modes = [g for g, _ in placed]
 
-        if global_occ and (global_occ[0] < 0 or global_occ[-1] >= num_modes):
+        if global_modes and (global_modes[0] < 0 or global_modes[-1] >= num_modes):
             raise ValueError(
-                f"InitializeModes places an occupied mode outside the range [0, {num_modes}) "
+                f"InitializeModes places a mode outside the range [0, {num_modes}) "
                 f"implied by norb={norb} and nelec={nelec!r}."
             )
 
-        # split the occupied global modes into per-sector occupied orbital lists and validate that
-        # their electron counts define the requested (norb, nelec) sector
-        if spinless:
-            alpha_orbitals = global_occ
-            beta_orbitals: list[int] = []
-            counts: tuple[int, ...] = (len(alpha_orbitals),)
-            expected: tuple[int, ...] = (nelec,)  # type: ignore[assignment]
-        else:
-            alpha_orbitals = [m for m in global_occ if m < norb]
-            beta_orbitals = [m - norb for m in global_occ if m >= norb]
-            counts = (len(alpha_orbitals), len(beta_orbitals))
-            expected = nelec  # type: ignore[assignment]
-
-        if counts != tuple(expected):
-            raise ValueError(
-                f"InitializeModes occupation defines the electron counts {counts}, which do not "
-                f"match the requested nelec={nelec!r}; the occupation determinant is not in the "
-                "target particle-number sector."
-            )
-
-        seed = self._seed_statevector(norb, spinless, alpha_orbitals, beta_orbitals)
-
-        if vec is not None:
-            # a real vector must agree with the occupation's own sector; the per-sector counts were
-            # already validated above, so a matching length confirms agreement
-            if len(vec) != len(seed):
+        if isinstance(nelec, int):
+            occupied_bits = sum(1 << g for g, occ in placed if occ)
+            empty_bits = sum(1 << g for g, occ in placed if not occ)
+            mask = occupation_axis_mask(norb, nelec, occupied_bits, empty_bits)
+            # the sole axis: amplitude on any determinant outside the mask must vanish
+            if len(vec) != len(mask):
                 raise ValueError(
                     f"InitializeModes received a state vector of length {len(vec)}, which does not "
-                    f"match the dimension {len(seed)} of the (norb={norb}, nelec={nelec!r}) sector "
-                    "defined by its occupation."
+                    f"match the dimension {len(mask)} of the (norb={norb}, nelec={nelec!r}) sector."
                 )
-            logger.warning(
-                "InitializeModes: discarding the incoming state vector and reseeding the "
-                "occupation determinant for the (norb=%s, nelec=%r) sector. This gate is a state "
-                "producer, not a transform, so any accumulated amplitudes are replaced -- placing "
-                "it after other gates (rather than at the circuit start) drops their effect.",
-                norb,
-                nelec,
+            if not np.allclose(vec[~mask], 0.0, atol=_ATOL):
+                raise ValueError(
+                    "InitializeModes: the state vector has amplitude outside the subspace defined by "
+                    f"its occupation for the (norb={norb}, nelec={nelec!r}) sector."
+                )
+            return vec
+
+        # Spinful: split the placed modes into the two spin sectors. A gate constrains one axis of the
+        # (dim_a, dim_b) state per sector it touches -- an alpha gate fixes rows, a beta gate columns.
+        n_alpha, n_beta = nelec
+        alpha = [(g, occ) for g, occ in placed if g < norb]
+        beta = [(g - norb, occ) for g, occ in placed if g >= norb]
+
+        # A gate touching *both* sectors is a joint constraint. It is a well-defined per-axis product
+        # only when it pins a complete determinant -- every orbital of both sectors named, none left
+        # free (i.e. it covers all 2*norb modes). A partial straddle (some orbitals free in a sector)
+        # is not a product of per-axis subspaces and cannot compose with parallel gates, so reject it.
+        if alpha and beta and not (len(alpha) == norb and len(beta) == norb):
+            raise ValueError(
+                "InitializeModes straddles both spin sectors without pinning a full determinant "
+                f"(some orbitals are left free) under norb={norb}. A spinful InitializeModes must "
+                "either lie entirely within one spin sector or fully specify both; place a separate "
+                "gate per sector to seed disjoint fragments in parallel."
             )
 
-        return seed
+        dim_a = comb(norb, n_alpha)
+        dim_b = comb(norb, n_beta)
+        if len(vec) != dim_a * dim_b:
+            raise ValueError(
+                f"InitializeModes received a state vector of length {len(vec)}, which does not match "
+                f"the dimension {dim_a * dim_b} of the (norb={norb}, nelec={nelec!r}) sector."
+            )
+        vec_2d = np.asarray(vec).reshape(dim_a, dim_b)
 
-    @staticmethod
-    def _seed_statevector(
-        norb: int,
-        spinless: bool,
-        alpha_orbitals: list[int],
-        beta_orbitals: list[int],
-    ) -> np.ndarray:
-        """Builds the one-hot occupation determinant for the given per-sector occupied orbitals.
-
-        For a spinless system ``beta_orbitals`` is empty and ignored. Uses the native
-        ``slater_determinant_statevector`` kernel: it produces the one-hot at the determinant's FCI
-        address (the occupied-orbital lists are already sorted, so the determinant carries no sign),
-        matching :func:`ffsim.slater_determinant` bit-for-bit while being consistently faster.
-        """
-        from qiskit_fermions._lib.linalg.fci import slater_determinant_statevector
-
-        alpha_str = sum(1 << orb for orb in alpha_orbitals)
-        beta_str = None if spinless else sum(1 << orb for orb in beta_orbitals)
-        return slater_determinant_statevector(norb, alpha_str, beta_str)
+        # Constrain each touched axis. A sector the gate does not touch is left free (its mask is the
+        # whole axis), so a single-sector gate constrains only its own axis and the other stays open.
+        if alpha:
+            mask_a = occupation_axis_mask(
+                norb,
+                n_alpha,
+                sum(1 << g for g, occ in alpha if occ),
+                sum(1 << g for g, occ in alpha if not occ),
+            )
+            if not np.allclose(vec_2d[~mask_a, :], 0.0, atol=_ATOL):
+                raise ValueError(
+                    "InitializeModes: the state vector has amplitude outside the alpha-sector "
+                    f"subspace defined by its occupation for the (norb={norb}, nelec={nelec!r}) sector."
+                )
+        if beta:
+            mask_b = occupation_axis_mask(
+                norb,
+                n_beta,
+                sum(1 << g for g, occ in beta if occ),
+                sum(1 << g for g, occ in beta if not occ),
+            )
+            if not np.allclose(vec_2d[:, ~mask_b], 0.0, atol=_ATOL):
+                raise ValueError(
+                    "InitializeModes: the state vector has amplitude outside the beta-sector "
+                    f"subspace defined by its occupation for the (norb={norb}, nelec={nelec!r}) sector."
+                )
+        return vec

--- a/python/qiskit_fermions/circuit/library/initialize_modes.py
+++ b/python/qiskit_fermions/circuit/library/initialize_modes.py
@@ -14,12 +14,18 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Sequence
 from math import comb
 
 import numpy as np
 
 from .. import FermionicGate
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 # The absolute tolerance for the subspace-confinement check. There is no project-wide tolerance
 # constant; this is the de-facto convention (numpy's ``allclose`` default, matching the Rust
@@ -28,19 +34,25 @@ _ATOL = 1e-8
 
 
 class InitializeModes(FermionicGate):
-    """Asserts that a state vector matches a fermionic mode occupation.
+    """Prepares (or, under simulation, certifies) a fermionic mode occupation.
 
-    This gate is a *validator*, not a state producer: applied to a state vector it checks that the
-    vector's amplitude is confined to the subspace its :attr:`occupation` defines, then returns the
-    vector unchanged. Placing it at the start of a circuit therefore certifies -- without mutating --
-    that the incoming state is the intended reference; the transforms that follow act on that same
-    vector.
+    This gate declares an intended occupation of the modes it is placed on. Its behavior depends on
+    how the circuit is consumed:
 
-    Because the check constrains only the orbitals the occupation names (and, per spin sector, only
-    along that sector's axis), several :class:`InitializeModes` gates can be placed **in parallel** to
-    certify disjoint fragments of a state independently -- e.g. one gate per spin sector, or one per
-    orbital group. A spinful gate may cover a single sector (any fragment of it) or fully specify both
-    sectors, but a partial straddle of both is rejected (see :meth:`_apply_unitary_placed_`).
+    - **Transpiled** (synthesized to qubit gates): it *produces* the state -- the synthesis plugin
+      emits the gates that set the named modes to their occupation, as one would expect of an
+      initialization gate.
+    - **Simulated** (:meth:`_apply_unitary_`): it acts as a *validator* rather than a producer. Given
+      a state vector it checks that the vector's amplitude is confined to the subspace its
+      :attr:`occupation` defines and returns the vector unchanged, certifying -- without mutating --
+      that the incoming state is the intended reference so the transforms that follow act on it.
+
+    In both modes the gate constrains only the orbitals the occupation names (and, per spin sector,
+    only along that sector's axis), so several :class:`InitializeModes` gates can be placed **in
+    parallel** to seed disjoint fragments of a state independently -- e.g. one gate per spin sector,
+    or one per orbital group. A spinful gate may cover a single sector (any fragment of it) or fully
+    specify both sectors, but a partial straddle of both is rejected (see
+    :meth:`_apply_unitary_placed_`).
 
     Use :meth:`from_hartree_fock` to construct the occupation of a Hartree-Fock reference.
 
@@ -63,7 +75,7 @@ class InitializeModes(FermionicGate):
         super().__init__("InitializeModes", len(self.occupation), [])
 
     @classmethod
-    def from_hartree_fock(cls, norb: int, nelec: int | tuple[int, int]) -> InitializeModes:
+    def from_hartree_fock(cls, norb: int, nelec: int | tuple[int, int]) -> Self:
         """Builds the gate for the Hartree-Fock reference occupation of ``(norb, nelec)``.
 
         The Hartree-Fock determinant fills the lowest-indexed orbitals of each spin sector. Whether

--- a/python/qiskit_fermions/circuit/library/ucj.py
+++ b/python/qiskit_fermions/circuit/library/ucj.py
@@ -52,10 +52,6 @@ class UCJ(FermionicGate):
     and :math:`\mathcal{U}_\text{final}` is an optional final orbital rotation. The number of terms
     :math:`L` is the number of ansatz repetitions.
 
-    This gate is a pure unitary (matching ffsim's UCJ operators): it carries no reference state.
-    Prepare the reference separately -- e.g. place an :class:`.InitializeModes` gate (see
-    :meth:`.InitializeModes.from_hartree_fock`) ahead of this one -- and apply the ansatz to it.
-
     This gate supports three spin variants (see :class:`.UCJ.Variant`), selected by the shapes of the
     supplied tensors and by ``nelec`` (mirroring ffsim's
     :external:class:`~ffsim.UCJOpSpinBalanced`, :external:class:`~ffsim.UCJOpSpinUnbalanced` and
@@ -529,9 +525,7 @@ class UCJ(FermionicGate):
         This builds the gate's definition (the per-repetition orbital rotations and diagonal Coulomb
         evolutions) and applies it to ``vec``, with the definition circuit placed onto the global
         modes ``freg_indices`` (each of its instructions is relabeled onto the corresponding absolute
-        modes). UCJ is a pure unitary carrying no reference state, mirroring ffsim's own
-        ``UCJOpSpin*._apply_unitary_``; prepare the reference separately (see the class docstring).
-        See :meth:`_define` for the exact gate sequence.
+        modes). See :meth:`_define` for the exact gate sequence.
 
         Args:
             vec: the state vector to act on.

--- a/python/qiskit_fermions/circuit/library/ucj.py
+++ b/python/qiskit_fermions/circuit/library/ucj.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import numbers
-from collections.abc import Sequence
 from enum import Enum
 from typing import TYPE_CHECKING, cast
 
@@ -26,7 +25,6 @@ from qiskit_fermions.operators.fermion_action import ann, cre
 
 from .. import FermionicGate
 from .evolution import Evolution
-from .initialize_modes import InitializeModes
 from .orbital_rotation import OrbitalRotation
 
 if TYPE_CHECKING:
@@ -43,9 +41,8 @@ class UCJ(FermionicGate):
         \left(\prod_{k=1}^{L} \mathcal{U}_k\, e^{i \mathcal{J}_k}\, \mathcal{U}_k^\dagger\right)
         \mathcal{U}_\text{final}
 
-    applied to a reference state (by default the Hartree-Fock determinant), where each
-    :math:`\mathcal{U}_k` is an :class:`.OrbitalRotation`, each :math:`\mathcal{J}_k` is a diagonal
-    Coulomb operator
+    where each :math:`\mathcal{U}_k` is an :class:`.OrbitalRotation`, each :math:`\mathcal{J}_k` is a
+    diagonal Coulomb operator
 
     .. math::
 
@@ -54,6 +51,10 @@ class UCJ(FermionicGate):
 
     and :math:`\mathcal{U}_\text{final}` is an optional final orbital rotation. The number of terms
     :math:`L` is the number of ansatz repetitions.
+
+    This gate is a pure unitary (matching ffsim's UCJ operators): it carries no reference state.
+    Prepare the reference separately -- e.g. place an :class:`.InitializeModes` gate (see
+    :meth:`.InitializeModes.from_hartree_fock`) ahead of this one -- and apply the ansatz to it.
 
     This gate supports three spin variants (see :class:`.UCJ.Variant`), selected by the shapes of the
     supplied tensors and by ``nelec`` (mirroring ffsim's
@@ -105,7 +106,6 @@ class UCJ(FermionicGate):
         orbital_rotations: np.ndarray,
         *,
         final_orbital_rotation: np.ndarray | None = None,
-        reference_occupation: Sequence[bool] | None = None,
     ) -> None:
         r"""Initializing an instance of this gate can be done with the arguments listed below.
 
@@ -121,10 +121,6 @@ class UCJ(FermionicGate):
                 spinless) or ``(L, 2, norb, norb)`` (spin-unbalanced).
             final_orbital_rotation: an optional final orbital rotation, of shape ``(norb, norb)``
                 (spin-balanced or spinless) or ``(2, norb, norb)`` (spin-unbalanced).
-            reference_occupation: the occupation (one boolean per mode) of the reference determinant
-                the ansatz is applied to. Defaults to the Hartree-Fock determinant implied by
-                ``nelec`` (the first ``n_alpha`` alpha modes and first ``n_beta`` beta modes
-                occupied).
 
         Raises:
             ValueError: if the tensor shapes are inconsistent with each other, with ``norb``, or
@@ -153,17 +149,6 @@ class UCJ(FermionicGate):
         self._variant = self._infer_variant(norb)
         num_modes = norb if self._spinless else 2 * norb
 
-        if reference_occupation is None:
-            reference_occupation = self._hartree_fock_occupation(norb, nelec, self._spinless)
-        self.reference_occupation = np.asarray(reference_occupation, dtype=bool)
-        """The occupation of the reference determinant the ansatz is applied to."""
-
-        if len(self.reference_occupation) != num_modes:
-            raise ValueError(
-                f"reference_occupation has length {len(self.reference_occupation)}, expected "
-                f"{num_modes} for norb={norb} and nelec={nelec!r}."
-            )
-
         super().__init__("UCJ", num_modes, [])
 
     @property
@@ -191,7 +176,6 @@ class UCJ(FermionicGate):
             list[tuple[int, int]] | tuple[list[tuple[int, int]] | None, ...] | None
         ) = None,
         tol: float = 1e-8,
-        reference_occupation: Sequence[bool] | None = None,
     ) -> UCJ:
         r"""Constructs a UCJ ansatz from coupled-cluster :math:`t_2` (and optional :math:`t_1`) amplitudes.
 
@@ -230,8 +214,6 @@ class UCJ(FermionicGate):
                 a ``None`` element (or the whole argument being ``None``) leaves the block untouched,
                 whereas an empty list allows no interactions and so zeros the entire block.
             tol: the double-factorization truncation tolerance.
-            reference_occupation: forwarded to :class:`.UCJ`; defaults to the Hartree-Fock
-                determinant.
 
         Returns:
             The constructed :class:`.UCJ` gate.
@@ -273,7 +255,6 @@ class UCJ(FermionicGate):
             diag_coulomb_mats,
             orbital_rotations,
             final_orbital_rotation=final_orbital_rotation,
-            reference_occupation=reference_occupation,
         )
 
     @staticmethod
@@ -535,38 +516,9 @@ class UCJ(FermionicGate):
             arr = arr.real
         return np.asarray(arr, dtype=float)
 
-    @staticmethod
-    def _hartree_fock_occupation(
-        norb: int, nelec: int | tuple[int, int], spinless: bool
-    ) -> list[bool]:
-        """Returns the Hartree-Fock reference occupation for ``(norb, nelec)``.
-
-        Raises:
-            ValueError: if the electron count exceeds the ``norb`` spin-orbitals available in a
-                sector (which would otherwise silently spill into the wrong block).
-        """
-        if spinless:
-            if nelec > norb:  # type: ignore[operator]
-                raise ValueError(f"nelec={nelec!r} exceeds the norb={norb} spinless modes.")
-            occ = [False] * norb
-            for i in range(nelec):  # type: ignore[arg-type]
-                occ[i] = True
-            return occ
-        n_alpha, n_beta = nelec  # type: ignore[misc]
-        if n_alpha > norb or n_beta > norb:
-            raise ValueError(
-                f"nelec={nelec!r} has a spin sector exceeding the norb={norb} available orbitals."
-            )
-        occ = [False] * (2 * norb)
-        for i in range(n_alpha):
-            occ[i] = True
-        for i in range(n_beta):
-            occ[norb + i] = True
-        return occ
-
     def _apply_unitary_placed_(
         self,
-        vec: np.ndarray | None,
+        vec: np.ndarray,
         norb: int,
         nelec: int | tuple[int, int],
         copy: bool,
@@ -574,23 +526,19 @@ class UCJ(FermionicGate):
     ) -> np.ndarray:
         """Applies the ansatz after placing its modes onto the vector's global modes.
 
-        This builds the gate's definition (an :class:`.InitializeModes` seeding the reference
-        determinant, followed by the per-repetition orbital rotations and diagonal Coulomb
-        evolutions) and applies it, with the definition circuit placed onto the global modes
-        ``freg_indices`` (each of its instructions is relabeled onto the corresponding absolute
-        modes). Because the definition opens with :class:`.InitializeModes`, an incoming ``vec`` of
-        ``None`` is supported: the reference determinant is seeded from no incoming state.
-
-        This mirrors ffsim's own ``UCJOpSpin*._apply_unitary_``, which prepares the reference state
-        and applies the ansatz layers. See :meth:`_define` for the exact gate sequence.
+        This builds the gate's definition (the per-repetition orbital rotations and diagonal Coulomb
+        evolutions) and applies it to ``vec``, with the definition circuit placed onto the global
+        modes ``freg_indices`` (each of its instructions is relabeled onto the corresponding absolute
+        modes). UCJ is a pure unitary carrying no reference state, mirroring ffsim's own
+        ``UCJOpSpin*._apply_unitary_``; prepare the reference separately (see the class docstring).
+        See :meth:`_define` for the exact gate sequence.
 
         Args:
-            vec: the state vector to act on, or ``None`` to seed the reference determinant from no
-                incoming state.
+            vec: the state vector to act on.
             norb: the number of spatial orbitals of the *global* state vector.
             nelec: either a single integer for a spinless system, or a pair of integers storing the
                 numbers of spin alpha and spin beta fermions.
-            copy: whether to copy the vector before operating on it. Ignored when ``vec`` is ``None``.
+            copy: whether to copy the vector before operating on it.
             freg_indices: the absolute (global) mode indices that this gate's local modes map onto.
 
         Returns:
@@ -603,7 +551,6 @@ class UCJ(FermionicGate):
         from qiskit_fermions.circuit import FermionicCircuit
 
         definition = FermionicCircuit(self.num_modes)
-        definition.append(InitializeModes(self.reference_occupation.tolist()), definition.modes)
 
         for diag_coulomb_mat, orbital_rotation in zip(
             self.diag_coulomb_mats, self.orbital_rotations, strict=True

--- a/tests/python/circuit/library/test_initialize_modes.py
+++ b/tests/python/circuit/library/test_initialize_modes.py
@@ -14,7 +14,10 @@
 
 from __future__ import annotations
 
+from math import comb
+
 import numpy as np
+import pytest
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import InitializeModes
 
@@ -38,3 +41,42 @@ def test_initialize_modes_gate(subtests):
 
     with subtests.test("from np.ndarray"):
         _test_initialize_modes(np.asarray([True, False, True, False], dtype=bool))
+
+
+def test_apply_unitary_rejects_out_of_range_mode():
+    """A gate placed onto a mode outside ``[0, num_modes)`` is rejected before touching ``vec``.
+
+    Uses a raw ``_apply_unitary_placed_`` call with an out-of-range global mode index; a determinant
+    vector is not needed since the range check precedes any amplitude inspection.
+    """
+    norb = 3
+    nelec = 2  # spinless -> num_modes == norb == 3
+    vec = np.zeros(comb(norb, nelec), dtype=complex)
+    # place the single local mode onto global mode 3, which is >= num_modes == 3
+    with pytest.raises(ValueError, match="places a mode outside the range"):
+        InitializeModes([True])._apply_unitary_placed_(vec, norb, nelec, False, [norb])
+
+
+def test_apply_unitary_rejects_wrong_length_vec_spinless():
+    """A spinless vector whose length disagrees with ``C(norb, nelec)`` is rejected."""
+    norb = 4
+    nelec = 2  # sector dimension is C(4, 2) == 6
+    occupation = [True, True, False, False]  # a satisfiable 2-electron occupation
+    wrong = np.zeros(5, dtype=complex)
+    with pytest.raises(ValueError, match="does not match the dimension"):
+        InitializeModes(occupation)._apply_unitary_(wrong, norb, nelec, copy=True)
+
+
+def test_apply_unitary_rejects_amplitude_outside_alpha_subspace():
+    """A spinful state with amplitude outside the alpha-sector subspace is rejected.
+
+    An all-ones vector necessarily carries weight on alpha determinants that leave orbital 0 empty,
+    so an alpha-only gate fixing orbital 0 occupied must reject it (the alpha-axis branch).
+    """
+    norb = 3
+    nelec = (2, 1)
+    dim = comb(norb, nelec[0]) * comb(norb, nelec[1])
+    bad = np.ones(dim, dtype=complex)
+    # a partial alpha gate: orbital 0 occupied, orbitals 1 and 2 left free (beta sector untouched)
+    with pytest.raises(ValueError, match="outside the alpha-sector subspace"):
+        InitializeModes([True])._apply_unitary_placed_(bad, norb, nelec, False, [0])

--- a/tests/python/circuit/library/test_initialize_modes_apply_unitary.py
+++ b/tests/python/circuit/library/test_initialize_modes_apply_unitary.py
@@ -10,11 +10,9 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Tests for seeding an InitializeModes gate into an ffsim state vector (SupportsApplyUnitary)."""
+"""Tests for the InitializeModes assert-only validator (SupportsApplyUnitary)."""
 
 from __future__ import annotations
-
-import logging
 
 import numpy as np
 import pytest
@@ -46,98 +44,201 @@ ffsim = pytest.importorskip("ffsim")
         (6, 3, [False, True, False, True, False, True], [1, 3, 5]),
     ],
 )
-def test_initialize_modes_apply_unitary_seed_matches_ffsim(norb, nelec, occupation, ffsim_occ):
-    """Seeding a vec=None state produces the same determinant as ffsim.slater_determinant.
+def test_initialize_modes_matching_determinant_passes_unchanged(norb, nelec, occupation, ffsim_occ):
+    """A full-determinant occupation accepts its own determinant and returns it unchanged.
 
-    Covers the spinful and spinless mode conventions across several ranks and placements; the native
-    ``slater_determinant_statevector`` seed must match ffsim's determinant bit-for-bit in every case.
+    The gate is a validator: given the determinant its occupation describes, the amplitude is
+    confined to the occupation's subspace, so the check passes and the very same vector is returned
+    (identity). Covers the spinful (full both-sector) and spinless conventions across several ranks.
     """
-    result = InitializeModes(occupation)._apply_unitary_(None, norb, nelec, copy=True)
-    expected = ffsim.slater_determinant(norb, ffsim_occ)
+    vec = ffsim.slater_determinant(norb, ffsim_occ)
+    result = InitializeModes(occupation)._apply_unitary_(vec, norb, nelec, copy=True)
+    np.testing.assert_array_equal(result, vec)
 
-    np.testing.assert_allclose(result, expected, atol=1e-12)
+
+def test_initialize_modes_parallel_spinful_hartree_fock():
+    """Two parallel per-sector gates each certify their own axis of a spinful HF state.
+
+    An alpha-only gate fixes the alpha axis (a set of full rows) and a beta-only gate fixes the beta
+    axis (full columns); the Hartree-Fock determinant lies in both, so both pass and the state is
+    returned unchanged. This is the parallel placement the old producer could not express.
+    """
+    norb = 3
+    nelec = (2, 1)
+    vec = ffsim.slater_determinant(norb, ([0, 1], [0]))
+
+    circ = FermionicCircuit(2 * norb)
+    circ.append(InitializeModes([True, True, False]), [circ.modes[i] for i in range(norb)])
+    circ.append(InitializeModes([True, False, False]), [circ.modes[norb + i] for i in range(norb)])
+
+    result = circ._apply_unitary_(vec, norb, nelec, copy=True)
+    np.testing.assert_allclose(result, vec, atol=1e-12)
 
 
-def test_initialize_modes_apply_unitary_agreeing_vec_logs_and_seeds(caplog):
-    """A non-None vec that agrees with the occupation's sector is accepted, warned, and overwritten."""
+def test_initialize_modes_parallel_disjoint_fragments_within_one_sector():
+    """Three disjoint single-orbital gates within one spin sector compose (each fixes one row family).
+
+    Each gate fixes one alpha orbital's occupation and leaves the rest free; their intersection pins
+    the alpha determinant. A beta gate on the other sector rounds out a full spinful HF state.
+    """
+    norb = 4
+    nelec = (3, 1)
+    vec = ffsim.slater_determinant(norb, ([0, 1, 2], [0]))
+
+    circ = FermionicCircuit(2 * norb)
+    # three disjoint alpha fragments: orbitals 0, 1, 2 each occupied (orbital 3 left free)
+    circ.append(InitializeModes([True]), [circ.modes[0]])
+    circ.append(InitializeModes([True]), [circ.modes[1]])
+    circ.append(InitializeModes([True]), [circ.modes[2]])
+    # the beta sector
+    circ.append(
+        InitializeModes([True, False, False, False]), [circ.modes[norb + i] for i in range(norb)]
+    )
+
+    result = circ._apply_unitary_(vec, norb, nelec, copy=True)
+    np.testing.assert_allclose(result, vec, atol=1e-12)
+
+
+def test_initialize_modes_partial_fragment_accepts_spread_over_free_axis():
+    """A partial (single-orbital) gate accepts a state spread across the orbitals it leaves free.
+
+    Fixing only that alpha orbital 0 is occupied, the gate must accept any superposition of
+    determinants that all occupy orbital 0 -- the free orbitals may carry genuine multi-address
+    amplitude -- and reject a state with weight on a determinant that leaves orbital 0 empty.
+    """
+    norb = 4
+    nelec = 2  # spinless
+
+    circ = FermionicCircuit(norb)
+    circ.append(InitializeModes([True]), [circ.modes[0]])  # orbital 0 occupied; 1,2,3 free
+
+    # a genuine superposition, both terms occupying orbital 0
+    good = ffsim.slater_determinant(norb, [0, 1]) + ffsim.slater_determinant(norb, [0, 2])
+    result = circ._apply_unitary_(good, norb, nelec, copy=True)
+    np.testing.assert_allclose(result, good, atol=1e-12)
+
+    # a determinant leaving orbital 0 empty must be rejected
+    bad = ffsim.slater_determinant(norb, [1, 2])
+    with pytest.raises(ValueError, match="amplitude outside the subspace"):
+        circ._apply_unitary_(bad, norb, nelec, copy=True)
+
+
+def test_initialize_modes_global_phase_and_magnitude_tolerated():
+    """The check is on confinement, not equality: a phased / rescaled determinant still passes."""
     norb = 3
     nelec = (2, 1)
     occupation = [True, True, False, True, False, False]
-    expected = ffsim.slater_determinant(norb, ([0, 1], [0]))
+    vec = ffsim.slater_determinant(norb, ([0, 1], [0]))
 
-    # a real, correctly sized (but different) vector in the same sector
-    rng = np.random.default_rng(0)
-    incoming = rng.standard_normal(len(expected)) + 1j * rng.standard_normal(len(expected))
-    incoming_before = incoming.copy()
-
-    with caplog.at_level(
-        logging.WARNING, logger="qiskit_fermions.circuit.library.initialize_modes"
-    ):
-        result = InitializeModes(occupation)._apply_unitary_(incoming, norb, nelec, copy=True)
-
-    np.testing.assert_allclose(result, expected, atol=1e-12)
-    # the incoming amplitudes are replaced by the determinant, and the input is left untouched
-    np.testing.assert_array_equal(incoming, incoming_before)
-    # discarding accumulated state is surprising enough to warrant a warning, not just an info log
-    assert any(rec.levelname == "WARNING" for rec in caplog.records)
-    assert any("discarding the incoming state vector" in rec.message for rec in caplog.records)
+    scaled = 0.5 * np.exp(1j * 0.9) * vec
+    result = InitializeModes(occupation)._apply_unitary_(scaled, norb, nelec, copy=True)
+    np.testing.assert_array_equal(result, scaled)
 
 
-def test_initialize_modes_apply_unitary_through_circuit_with_placement():
-    """A subset-placed InitializeModes seeds onto its global modes (straddling alpha and beta)."""
+def test_initialize_modes_rejects_partial_straddle():
+    """A spinful gate constraining orbitals of *both* sectors without pinning a full determinant."""
     norb = 3
     nelec = (1, 1)
+    vec = ffsim.slater_determinant(norb, ([0], [0]))
 
-    # a single gate placed on a subset of the 2*norb register: its two local modes map onto global
-    # alpha mode 2 and global beta mode (norb + 1), so the seeded determinant is ([2], [1])
-    circ = FermionicCircuit(2 * norb)
-    circ.append(InitializeModes([True, True]), [circ.modes[2], circ.modes[norb + 1]])
-
-    result = circ._apply_unitary_(None, norb, nelec, copy=True)
-    expected = ffsim.slater_determinant(norb, ([2], [1]))
-
-    np.testing.assert_allclose(result, expected, atol=1e-12)
+    # two local modes placed onto alpha orbital 0 and beta orbital 1 -- a partial straddle
+    with pytest.raises(ValueError, match="straddles both spin sectors"):
+        InitializeModes([True, True])._apply_unitary_placed_(vec, norb, nelec, False, [0, norb + 1])
 
 
-def test_initialize_modes_apply_unitary_end_to_end_full_circuit():
-    """Seeding via InitializeModes then rotating matches the external-seed flow."""
+def test_initialize_modes_rejects_amplitude_outside_subspace():
+    """A state whose amplitude falls outside the occupation's subspace is rejected."""
     norb = 3
     nelec = (2, 1)
-    occupation = [True, True, False, True, False, False]
-    rot = random_unitary(norb, seed=5)
-
-    # our flow: InitializeModes seeds the state, then OrbitalRotation acts on it
-    circ = FermionicCircuit(2 * norb)
-    circ.append(InitializeModes(occupation), circ.modes)
-    circ.append(OrbitalRotation(rot), [circ.modes[i] for i in range(norb)])
-    result = circ._apply_unitary_(None, norb, nelec, copy=True)
-
-    # reference: the current external-seed flow (build the determinant, then apply the same rotation)
-    vec0 = ffsim.slater_determinant(norb, ([0, 1], [0]))
-    expected = ffsim.apply_orbital_rotation(vec0.copy(), (rot, None), norb=norb, nelec=nelec)
-
-    np.testing.assert_allclose(result, expected, atol=1e-10)
+    occupation = [True, True, False, True, False, False]  # alpha {0,1}, beta {0}
+    # a determinant with the beta electron on orbital 1 instead of 0
+    bad = ffsim.slater_determinant(norb, ([0, 1], [1]))
+    with pytest.raises(ValueError, match="outside the beta-sector subspace"):
+        InitializeModes(occupation)._apply_unitary_(bad, norb, nelec, copy=False)
 
 
-def test_initialize_modes_apply_unitary_rejects_sector_mismatch():
-    """An occupation whose electron counts disagree with nelec is rejected."""
-    # spinful: occupation sets 3 alpha but nelec asks for 2
+def test_initialize_modes_rejects_unsatisfiable_occupation():
+    """An occupation forcing more electrons into a sector than nelec allows is rejected.
+
+    With a full-register occupation, forcing three alpha orbitals occupied is impossible for a
+    two-alpha sector; the subspace mask is unsatisfiable, surfaced as a ValueError.
+    """
     norb = 3
     nelec = (2, 1)
-    occupation = [True, True, True, True, False, False]  # 3 alpha, 1 beta
-    with pytest.raises(ValueError, match="do not match the requested nelec"):
-        InitializeModes(occupation)._apply_unitary_(None, norb, nelec, copy=False)
-
-    # spinless: total count disagrees
-    with pytest.raises(ValueError, match="do not match the requested nelec"):
-        InitializeModes([True, True, True])._apply_unitary_(None, 3, 2, copy=False)
+    occupation = [True, True, True, True, False, False]  # 3 alpha occupied, sector has 2
+    vec = ffsim.slater_determinant(norb, ([0, 1], [0]))
+    with pytest.raises(ValueError):
+        InitializeModes(occupation)._apply_unitary_(vec, norb, nelec, copy=False)
 
 
-def test_initialize_modes_apply_unitary_rejects_wrong_length_vec():
-    """A non-None vec whose length disagrees with the occupation's sector is rejected."""
+def test_initialize_modes_rejects_wrong_length_vec():
+    """A vector whose length disagrees with the (norb, nelec) sector dimension is rejected."""
     norb = 3
     nelec = (2, 1)
     occupation = [True, True, False, True, False, False]
     wrong = np.zeros(5, dtype=complex)  # sector dim is C(3,2)*C(3,1) = 9
     with pytest.raises(ValueError, match="does not match the dimension"):
         InitializeModes(occupation)._apply_unitary_(wrong, norb, nelec, copy=True)
+
+
+def test_initialize_modes_through_circuit_with_full_placement():
+    """A single spinful gate placed on the full 2*norb register pins a full determinant and passes."""
+    norb = 3
+    nelec = (1, 1)
+
+    # local modes map onto global alpha mode 2 and global beta mode (norb + 1): a full straddle only
+    # if the whole register is covered, so place a full-register occupation pinning ([2], [1]).
+    occupation = [False, False, True, False, True, False]  # alpha orbital 2, beta orbital 1
+    vec = ffsim.slater_determinant(norb, ([2], [1]))
+
+    circ = FermionicCircuit(2 * norb)
+    circ.append(InitializeModes(occupation), circ.modes)
+
+    result = circ._apply_unitary_(vec, norb, nelec, copy=True)
+    np.testing.assert_array_equal(result, vec)
+
+
+def test_initialize_modes_end_to_end_seed_then_rotate():
+    """Certifying a reference then rotating it matches the external-seed flow."""
+    norb = 3
+    nelec = (2, 1)
+    occupation = [True, True, False, True, False, False]
+    rot = random_unitary(norb, seed=5)
+
+    # our flow: InitializeModes certifies the prepared reference, then OrbitalRotation acts on it
+    vec0 = ffsim.slater_determinant(norb, ([0, 1], [0]))
+    circ = FermionicCircuit(2 * norb)
+    circ.append(InitializeModes(occupation), circ.modes)
+    circ.append(OrbitalRotation(rot), [circ.modes[i] for i in range(norb)])
+    result = circ._apply_unitary_(vec0, norb, nelec, copy=True)
+
+    # reference: apply the same rotation directly to the same prepared determinant
+    expected = ffsim.apply_orbital_rotation(vec0.copy(), (rot, None), norb=norb, nelec=nelec)
+
+    np.testing.assert_allclose(result, expected, atol=1e-10)
+
+
+@pytest.mark.parametrize(
+    "norb, nelec, expected_occ, ffsim_occ",
+    [
+        (3, (2, 1), [True, True, False, True, False, False], ([0, 1], [0])),
+        (4, (1, 1), [True, False, False, False, True, False, False, False], ([0], [0])),
+        (5, 2, [True, True, False, False, False], [0, 1]),  # spinless
+    ],
+)
+def test_initialize_modes_from_hartree_fock(norb, nelec, expected_occ, ffsim_occ):
+    """``from_hartree_fock`` builds the HF occupation and round-trips through the validator."""
+    gate = InitializeModes.from_hartree_fock(norb, nelec)
+    assert list(gate.occupation) == expected_occ
+
+    vec = ffsim.slater_determinant(norb, ffsim_occ)
+    result = gate._apply_unitary_(vec, norb, nelec, copy=True)
+    np.testing.assert_array_equal(result, vec)
+
+
+def test_initialize_modes_from_hartree_fock_rejects_overfull_sector():
+    """``from_hartree_fock`` rejects an electron count exceeding the available orbitals."""
+    with pytest.raises(ValueError, match="exceeds the norb"):
+        InitializeModes.from_hartree_fock(2, 3)  # spinless: 3 electrons, 2 orbitals
+    with pytest.raises(ValueError, match="exceeding the norb"):
+        InitializeModes.from_hartree_fock(2, (3, 1))  # spinful: 3 alpha, 2 orbitals

--- a/tests/python/circuit/library/test_ucj.py
+++ b/tests/python/circuit/library/test_ucj.py
@@ -87,46 +87,12 @@ def test_ucj_rejects_integer_nelec_for_balanced_tensors():
         UCJ(norb, 2, mats, rotations)
 
 
-def test_ucj_default_reference_is_hartree_fock():
-    """The default reference occupation is the Hartree-Fock determinant."""
-    norb = 3
-    mats, rotations = _balanced_tensors(norb, 1, seed=5)
-    gate = UCJ(norb, (2, 1), mats, rotations)
-    # block-spin order: alpha modes 0..3 (first 2 occupied), beta modes 3..6 (first 1 occupied)
-    expected = [True, True, False, True, False, False]
-    np.testing.assert_array_equal(gate.reference_occupation, expected)
-
-
-def test_ucj_rejects_wrong_reference_length():
-    """A reference occupation whose length does not match the mode count raises ValueError."""
-    norb = 3
-    mats, rotations = _balanced_tensors(norb, 1, seed=6)
-    with pytest.raises(ValueError, match="reference_occupation has length"):
-        UCJ(norb, (1, 1), mats, rotations, reference_occupation=[True, False])
-
-
-def test_ucj_rejects_spin_sector_exceeding_norb():
-    """A spin sector with more electrons than orbitals raises instead of spilling into the block."""
-    norb = 2
-    mats, rotations = _balanced_tensors(norb, 1, seed=11)
-    with pytest.raises(ValueError, match="exceeding the norb"):
-        UCJ(norb, (3, 0), mats, rotations)
-
-
-def test_ucj_rejects_spinless_nelec_exceeding_norb():
-    """A spinless electron count above ``norb`` raises rather than indexing out of range."""
-    norb = 2
-    n_reps = 1
-    rng = np.random.default_rng(12)
-    mats = rng.standard_normal((n_reps, norb, norb))
-    mats = mats + mats.transpose(0, 2, 1)
-    rotations = np.stack([random_unitary(norb, seed=12)])
-    with pytest.raises(ValueError, match="exceeds the norb"):
-        UCJ(norb, 3, mats, rotations)
-
-
 def test_ucj_define_gate_sequence():
-    """The gate definition is InitializeModes + per-rep (rotation, evolution, rotation) + final."""
+    """The gate definition is per-rep (rotation, evolution, rotation) + optional final rotation.
+
+    UCJ is a pure unitary carrying no reference state, so its definition contains only the ansatz
+    layers -- no opening :class:`.InitializeModes`.
+    """
     norb = 3
     n_reps = 2
     mats, rotations = _balanced_tensors(norb, n_reps, seed=7)
@@ -137,7 +103,7 @@ def test_ucj_define_gate_sequence():
     circ.append(gate, circ.modes)
     ops = circ.decompose().count_ops()
 
-    assert ops["InitializeModes"] == 1
+    assert "InitializeModes" not in ops
     assert ops["Evolution"] == n_reps
     # per rep: U^dagger (2 local) + U (2 local) = 4; plus a final rotation (2 local)
     assert ops["OrbitalRotation"] == 4 * n_reps + 2
@@ -155,7 +121,7 @@ def test_ucj_spinless_true_uses_norb_modes():
     circ = FermionicCircuit(gate.num_modes)
     circ.append(gate, circ.modes)
     ops = circ.decompose().count_ops()
-    assert ops["InitializeModes"] == 1
+    assert "InitializeModes" not in ops
     assert ops["Evolution"] == n_reps
     # spinless places a single rotation on all norb modes: U^dagger + U = 2 per rep
     assert ops["OrbitalRotation"] == 2 * n_reps

--- a/tests/python/circuit/library/test_ucj.py
+++ b/tests/python/circuit/library/test_ucj.py
@@ -168,6 +168,103 @@ def test_ucj_from_t_amplitudes_empty_interaction_pairs_zeros_layer():
     assert np.any(gate_none.diag_coulomb_mats != 0.0)
 
 
+def _unbalanced_t2(nocc, nvrt, *, seed):
+    """Returns nontrivial ``(t2aa, t2ab, t2bb)`` amplitudes for the unbalanced variant.
+
+    The same-spin blocks are symmetrized so their (aa, bb) double factorizations are non-empty,
+    which exercises the same-spin assembly path.
+    """
+    rng = np.random.default_rng(seed)
+
+    def _sym(a):
+        return a + a.transpose(1, 0, 3, 2)
+
+    t2aa = _sym(rng.standard_normal((nocc, nocc, nvrt, nvrt)))
+    t2ab = rng.standard_normal((nocc, nocc, nvrt, nvrt))
+    t2bb = _sym(rng.standard_normal((nocc, nocc, nvrt, nvrt)))
+    return t2aa, t2ab, t2bb
+
+
+def test_ucj_from_t_amplitudes_rejects_unknown_variant():
+    """An unrecognized variant string raises a ValueError naming the accepted variants."""
+    t2 = np.zeros((1, 1, 2, 2))
+    with pytest.raises(ValueError, match="Unknown UCJ variant"):
+        UCJ.from_t_amplitudes((1, 1), t2, variant="nonsense")
+
+
+def test_ucj_from_t_amplitudes_unbalanced_tuple_n_reps_and_interaction_pairs():
+    """A tuple ``n_reps`` and per-block interaction_pairs drive the unbalanced factorization path.
+
+    This exercises the ``(n_reps_ab, n_reps_same)`` tuple split, the per-block masking (symmetric
+    aa/bb, non-symmetric ab), and the same-spin (aa, bb) assembly.
+    """
+    nocc, nvrt = 1, 2
+    t2 = _unbalanced_t2(nocc, nvrt, seed=21)
+    gate = UCJ.from_t_amplitudes(
+        (1, 1),
+        t2,
+        variant="unbalanced",
+        n_reps=(2, 1),
+        interaction_pairs=([(0, 0)], [(0, 0)], [(0, 0)]),
+    )
+    assert gate._variant is UCJ.Variant.UNBALANCED
+    norb = nocc + nvrt
+    assert gate.diag_coulomb_mats.shape == (3, 3, norb, norb)
+    # every diagonal-Coulomb block keeps only the whitelisted (0, 0) entry
+    for block in gate.diag_coulomb_mats.reshape(-1, norb, norb):
+        off_diagonal = block.copy()
+        off_diagonal[0, 0] = 0.0
+        np.testing.assert_array_equal(off_diagonal, 0.0)
+
+
+def test_ucj_from_t_amplitudes_unbalanced_int_n_reps_truncates():
+    """An integer ``n_reps`` smaller than the factorization truncates the unbalanced tensors."""
+    nocc, nvrt = 1, 2
+    t2 = _unbalanced_t2(nocc, nvrt, seed=22)
+    full = UCJ.from_t_amplitudes((1, 1), t2, variant="unbalanced")
+    assert full.diag_coulomb_mats.shape[0] >= 2
+    truncated = UCJ.from_t_amplitudes((1, 1), t2, variant="unbalanced", n_reps=1)
+    assert truncated.diag_coulomb_mats.shape[0] == 1
+    assert truncated.orbital_rotations.shape[0] == 1
+
+
+def test_ucj_from_t_amplitudes_unbalanced_int_n_reps_pads():
+    """An integer ``n_reps`` larger than the factorization pads with identity/zero layers."""
+    nocc, nvrt = 1, 2
+    t2 = _unbalanced_t2(nocc, nvrt, seed=23)
+    full = UCJ.from_t_amplitudes((1, 1), t2, variant="unbalanced")
+    n_have = full.diag_coulomb_mats.shape[0]
+    padded = UCJ.from_t_amplitudes((1, 1), t2, variant="unbalanced", n_reps=n_have + 2)
+    assert padded.diag_coulomb_mats.shape[0] == n_have + 2
+    # the padding layers are zero diagonal-Coulomb matrices and identity rotations
+    np.testing.assert_array_equal(padded.diag_coulomb_mats[n_have:], 0.0)
+    norb = nocc + nvrt
+    for rot_pair in padded.orbital_rotations[n_have:]:
+        for rot in rot_pair:
+            np.testing.assert_allclose(rot, np.eye(norb), atol=1e-12)
+
+
+def test_ucj_rejects_uninferable_tensor_shapes():
+    """Tensor shapes matching no variant raise a ValueError explaining the expected layouts."""
+    norb = 3
+    # a 4-D diag-Coulomb tensor with an unrecognized second axis (neither 2 nor 3)
+    mats = np.zeros((1, 4, norb, norb))
+    rotations = np.zeros((1, norb, norb))
+    with pytest.raises(ValueError, match="Could not infer the UCJ spin variant"):
+        UCJ(norb, (1, 1), mats, rotations)
+
+
+def test_ucj_rejects_mismatched_repetition_counts():
+    """Differing repetition counts between the diag-Coulomb and rotation tensors are rejected."""
+    norb = 3
+    mats = np.zeros((2, 2, norb, norb))  # 2 reps
+    rotations = np.stack([random_unitary(norb, seed=50), random_unitary(norb, seed=51)])[
+        :1
+    ]  # 1 rep
+    with pytest.raises(ValueError, match="same number of repetitions"):
+        UCJ(norb, (1, 1), mats, rotations)
+
+
 def test_orbital_rotation_from_t1_amplitudes_is_unitary():
     """OrbitalRotation.from_t1_amplitudes builds a unitary of the right size."""
     t1 = np.array([[0.1, 0.2], [0.3, -0.1]])  # 2 occ, 2 virt

--- a/tests/python/circuit/library/test_ucj_apply_unitary.py
+++ b/tests/python/circuit/library/test_ucj_apply_unitary.py
@@ -123,8 +123,12 @@ def test_ucj_gate_accepts_numpy_int_nelec():
     assert build(2)._variant is build(np.int64(2))._variant is UCJ.Variant.SPINLESS
 
 
-def test_ucj_gate_apply_unitary_seeds_from_none():
-    """The bare gate's _apply_unitary_ seeds the reference from a None vector and matches ffsim."""
+def test_ucj_gate_apply_unitary_matches_ffsim():
+    """The bare gate's _apply_unitary_ applied to the HF reference matches ffsim's UCJ operator.
+
+    UCJ is a pure unitary carrying no reference: the caller supplies the reference state, exactly as
+    ffsim's own operator does.
+    """
     norb = 4
     nelec = (2, 2)
     ucj_op = ffsim.random.random_ucj_op_spin_balanced(
@@ -140,7 +144,7 @@ def test_ucj_gate_apply_unitary_seeds_from_none():
         ucj_op.orbital_rotations,
         final_orbital_rotation=ucj_op.final_orbital_rotation,
     )
-    result = gate._apply_unitary_(None, norb, nelec, copy=True)
+    result = gate._apply_unitary_(reference.copy(), norb, nelec, copy=True)
     np.testing.assert_allclose(result, expected, atol=1e-10)
 
 
@@ -197,24 +201,23 @@ def test_ucj_gate_subset_placement_matches_global_embedding():
         orbital_rotations=global_rotations,
         final_orbital_rotation=global_final,
     )
-    # the UCJ gate seeds its own reference determinant on the placed orbitals (both local modes
-    # occupied -> global orbitals ``placement``), so the oracle must transform that same determinant
+    # a reference determinant occupying exactly the placed orbitals; both the oracle and our path
+    # transform this same state (UCJ is a pure unitary and carries no reference of its own)
     reference = ffsim.slater_determinant(norb_global, placement)
     expected = ffsim.apply_unitary(reference, global_ucj, norb=norb_global, nelec=nelec)
 
-    # our path: the local UCJ gate, placed on the global orbitals via ``placement`` in the circuit.
-    # the gate seeds its own reference determinant on the placed modes, so pass ``None`` through.
+    # our path: the local UCJ gate, placed on the global orbitals via ``placement`` in the circuit,
+    # applied to the same reference.
     gate = UCJ(
         norb_local,
         nelec,
         ucj_op.diag_coulomb_mats,
         ucj_op.orbital_rotations,
         final_orbital_rotation=ucj_op.final_orbital_rotation,
-        reference_occupation=[True, True],  # both local orbitals occupied -> global orbitals 1, 3
     )
     circ = FermionicCircuit(norb_global)
     circ.append(gate, [circ.modes[p] for p in placement])
-    result = ffsim.apply_unitary(None, circ, norb=norb_global, nelec=nelec)
+    result = ffsim.apply_unitary(reference, circ, norb=norb_global, nelec=nelec)
 
     np.testing.assert_allclose(result, expected, atol=1e-10)
 

--- a/tests/python/circuit/test_fermionic_circuit_apply_unitary.py
+++ b/tests/python/circuit/test_fermionic_circuit_apply_unitary.py
@@ -116,17 +116,6 @@ def test_apply_unitary_rejects_plain_protocol_gate_on_non_identity_placement():
         circ._apply_unitary_(vec0, norb, nelec, copy=True)
 
 
-def test_apply_unitary_empty_circuit_with_none_vec_raises():
-    """An empty circuit applied to ``vec=None`` raises rather than returning ``None``.
-
-    With no instruction to seed a state and no incoming vector, there is nothing to return; the
-    protocol requires an array, so this is rejected instead of silently yielding ``None``.
-    """
-    circ = FermionicCircuit(4)
-    with pytest.raises(ValueError, match="empty circuit"):
-        circ._apply_unitary_(None, 2, (1, 1), copy=True)
-
-
 def test_apply_unitary_empty_circuit_with_vec_returns_it():
     """An empty circuit applied to a real vector returns that vector unchanged (identity)."""
     norb = 2
@@ -136,22 +125,6 @@ def test_apply_unitary_empty_circuit_with_vec_returns_it():
 
     result = circ._apply_unitary_(vec0, norb, nelec, copy=True)
     np.testing.assert_array_equal(result, vec0)
-
-
-def test_apply_unitary_seeds_from_none_vec_via_producer_first_instruction():
-    """A circuit whose first instruction is a state producer seeds from a None vec with copy=True.
-
-    Regression: the DAG walk must let a producer (:class:`.InitializeModes`) seed the state from a
-    ``None`` incoming vector without tripping the ``copy`` handling.
-    """
-    norb = 2
-    nelec = (1, 1)
-    circ = FermionicCircuit(2 * norb)
-    circ.append(InitializeModes([True, False, True, False]), circ.modes)
-
-    result = circ._apply_unitary_(None, norb, nelec, copy=True)
-    expected = ffsim.slater_determinant(norb, ([0], [0]))
-    np.testing.assert_allclose(result, expected, atol=1e-12)
 
 
 def test_apply_unitary_normalizes_numpy_int_nelec_in_dag_walk():
@@ -165,39 +138,36 @@ def test_apply_unitary_normalizes_numpy_int_nelec_in_dag_walk():
     """
     norb = 5
     circ = FermionicCircuit(norb)
+    # a validator gate that only accepts the spinless interpretation of nelec: without normalizing
+    # the np.int64 it would be routed to the spinful path and behave differently.
     circ.append(InitializeModes([True, False, True, False, False]), circ.modes)
+    vec = ffsim.slater_determinant(norb, [0, 2])
 
-    expected = circ._apply_unitary_(None, norb, 2, copy=True)
-    result = circ._apply_unitary_(None, norb, np.int64(2), copy=True)
+    expected = circ._apply_unitary_(vec, norb, 2, copy=True)
+    result = circ._apply_unitary_(vec, norb, np.int64(2), copy=True)
     np.testing.assert_array_equal(result, expected)
 
 
-def test_apply_unitary_transform_first_gate_with_none_vec_raises_clean_error():
-    """A transform-only first instruction fed ``vec=None`` raises a clear ValueError, not an opaque one.
+def test_apply_unitary_parallel_seed_then_rotate():
+    """Two parallel per-sector InitializeModes gates then an OrbitalRotation, driven with a real vec.
 
-    A ``None`` incoming vector is only meaningful for a state-*producing* first instruction. A
-    transform-only gate has nothing to act on and, left unguarded, fails deep inside its numerics
-    with an opaque ``AttributeError`` on the ``None``. The walk must instead raise a ``ValueError``
-    naming the offending instruction, as the ``_apply_unitary_`` docstring promises.
+    The seed gates validate the incoming Hartree-Fock reference per spin sector (the placement the old
+    producer could not express); a following alpha-sector rotation transforms it. The result must
+    match applying the same rotation directly to the reference.
     """
+    norb = 3
+    nelec = (2, 1)
+    rot = random_unitary(norb, seed=7)
+    vec0 = ffsim.slater_determinant(norb, ([0, 1], [0]))
 
-    class _TransformOnlyGate(FermionicGate):
-        """A transform-only gate that touches ``vec.shape`` -- the exact failure mode of the real
-        transform gates (Evolution/OrbitalRotation), which raise ``AttributeError`` on a None vec."""
-
-        def __init__(self, num_modes):
-            super().__init__("transform", num_modes)
-
-        def _apply_unitary_(self, vec, norb, nelec, copy):
-            return np.zeros(vec.shape, dtype=complex)  # AttributeError when vec is None
-
-    norb = 2
-    nelec = (1, 1)
     circ = FermionicCircuit(2 * norb)
-    circ.append(_TransformOnlyGate(2 * norb), circ.modes)  # identity placement, transform-only
+    circ.append(InitializeModes([True, True, False]), [circ.modes[i] for i in range(norb)])
+    circ.append(InitializeModes([True, False, False]), [circ.modes[norb + i] for i in range(norb)])
+    circ.append(OrbitalRotation(rot), [circ.modes[i] for i in range(norb)])
 
-    with pytest.raises(ValueError, match="cannot seed a state from a None vector"):
-        circ._apply_unitary_(None, norb, nelec, copy=True)
+    result = circ._apply_unitary_(vec0, norb, nelec, copy=True)
+    expected = ffsim.apply_orbital_rotation(vec0.copy(), (rot, None), norb=norb, nelec=nelec)
+    np.testing.assert_allclose(result, expected, atol=1e-10)
 
 
 def test_apply_unitary_accepts_plain_protocol_gate_on_identity_placement():
@@ -236,9 +206,9 @@ def test_public_ffsim_apply_unitary_drives_a_fermionic_circuit():
     circ.append(InitializeModes(occupation), circ.modes)
     circ.append(OrbitalRotation(rot), [circ.modes[i] for i in range(norb)])
 
-    # public entry point: ffsim.apply_unitary invokes circ._apply_unitary_ with keyword args
-    result = ffsim.apply_unitary(None, circ, norb=norb, nelec=nelec)
-
     vec0 = ffsim.slater_determinant(norb, ([0, 1], [0]))
+    # public entry point: ffsim.apply_unitary invokes circ._apply_unitary_ with keyword args
+    result = ffsim.apply_unitary(vec0, circ, norb=norb, nelec=nelec)
+
     expected = ffsim.apply_orbital_rotation(vec0, (rot, None), norb=norb, nelec=nelec)
     np.testing.assert_allclose(result, expected, atol=1e-10)


### PR DESCRIPTION
Lifts the limitation that prevented placing multiple `InitializeModes` gates in parallel. Previously `InitializeModes` was a state producer (built a full sector vector when `vec=None` was provided during simulation), so two parallel seed gates would clobber each other as `FermionicCircuit` threaded one vector sequentially. It now validates the incoming state instead, which composes cleanly.

### Details

- `InitializeModes` is now an assert-only validator. Given a real state vector, it checks the amplitude is confined to the subspace its occupation defines and returns the vector unchanged -- no production, no mutation. The check is phase- and magnitude-tolerant (`atol=1e-8`).
- Parallel seeding works. Each gate constrains only the orbitals it names, and per spin sector only that sector's FCI axis -- so disjoint fragments (e.g. one gate per spin sector) certify independently. A spinful gate may cover one sector or fully pin both; a partial straddle is rejected.
- New `InitializeModes.from_hartree_fock(norb, nelec)` classmethod to place a Hartree–Fock reference frictionlessly.
- :warning: `UCJ` is now a pure unitary. Removed `reference_occupation` entirely -- it no longer carries a hidden reference state, matching ffsim's model where the caller prepares the state.
- :warning: Dropped all `vec=None` paths from the apply-unitary stack. Every call now passes a real vector; an empty circuit returns its input unchanged.
- New Rust core helper `occupation_axis_mask` (in `crates/core/src/linalg/fci.rs`, exposed via pyext) builds the per-axis subspace mask from the canonical FCI addressing, rather than reimplementing it in numpy.
- LUCJ guide updated to prepend an explicit HF reference ahead of the `UCJ` ansatz.

Breaking changes are marked with :warning: in the list above!