### PR TITLE
Adds the `PrepareSlaterDeterminant` gate

### DIFF
--- a/docs/pydoc/qiskit_fermions.transpiler.passes.plugins.rst
+++ b/docs/pydoc/qiskit_fermions.transpiler.passes.plugins.rst
@@ -33,20 +33,23 @@ they act upon:
 
 .. table:: An overview of the builtin ``qiskit_fermions.transpiler.synthesis`` entry-points.
 
-   +---------------------------+-------------------------+------------------------------------------------------+
-   | Circuit instruction name  | Plugin method name      | Reference                                            |
-   +===========================+=========================+======================================================+
-   | :class:`.Evolution`       | ``MapperFn``            | :class:`MapperFnEvolutionSynthesis`                  |
-   +---------------------------+-------------------------+------------------------------------------------------+
-   | :class:`.InitializeModes` | ``TrivialOccupation``   | :class:`TrivialOccupationInitializeModesSynthesis`   |
-   +---------------------------+-------------------------+------------------------------------------------------+
-   | :class:`.OrbitalRotation` | ``GivensDecomposition`` | :class:`GivensDecompositionOrbitalRotationSynthesis` |
-   +---------------------------+-------------------------+------------------------------------------------------+
+   +------------------------------------+-------------------------------+--------------------------------------------------------+
+   | Circuit instruction name           | Plugin method name            | Reference                                              |
+   +====================================+===============================+========================================================+
+   | :class:`.Evolution`                | ``MapperFn``                  | :class:`MapperFnEvolutionSynthesis`                    |
+   +------------------------------------+-------------------------------+--------------------------------------------------------+
+   | :class:`.InitializeModes`          | ``TrivialOccupation``         | :class:`TrivialOccupationInitializeModesSynthesis`     |
+   +------------------------------------+-------------------------------+--------------------------------------------------------+
+   | :class:`.OrbitalRotation`          | ``GivensDecomposition``       | :class:`GivensDecompositionOrbitalRotationSynthesis`   |
+   +------------------------------------+-------------------------------+--------------------------------------------------------+
+   | :class:`.PrepareSlaterDeterminant` | ``GivensDecompositionSlater`` | :class:`GivensDecompositionSlaterDeterminantSynthesis` |
+   +------------------------------------+-------------------------------+--------------------------------------------------------+
 
 .. autosummary::
    :toctree: ../stubs/
    :class: sd-d-none
 
    GivensDecompositionOrbitalRotationSynthesis
+   GivensDecompositionSlaterDeterminantSynthesis
    MapperFnEvolutionSynthesis
    TrivialOccupationInitializeModesSynthesis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ dev = [
 "Evolution.MapperFn" = "qiskit_fermions.transpiler.passes.synthesis:MapperFnEvolutionSynthesis"
 "InitializeModes.TrivialOccupation" = "qiskit_fermions.transpiler.passes.synthesis:TrivialOccupationInitializeModesSynthesis"
 "OrbitalRotation.GivensDecomposition" = "qiskit_fermions.transpiler.passes.synthesis:GivensDecompositionOrbitalRotationSynthesis"
+"PrepareSlaterDeterminant.GivensDecompositionSlater" = "qiskit_fermions.transpiler.passes.synthesis:GivensDecompositionSlaterDeterminantSynthesis"
 
 [tool.setuptools]
 include-package-data = true

--- a/python/qiskit_fermions/circuit/library/__init__.py
+++ b/python/qiskit_fermions/circuit/library/__init__.py
@@ -28,12 +28,14 @@ This module provides a library of :class:`.FermionicGate` implementations.
    Evolution
    InitializeModes
    OrbitalRotation
+   PrepareSlaterDeterminant
    UCJ
 """
 
 from .evolution import Evolution
 from .initialize_modes import InitializeModes
 from .orbital_rotation import OrbitalRotation
+from .prepare_slater_determinant import PrepareSlaterDeterminant
 from .ucj import UCJ
 
 __all__ = [
@@ -41,4 +43,5 @@ __all__ = [
     "Evolution",
     "InitializeModes",
     "OrbitalRotation",
+    "PrepareSlaterDeterminant",
 ]

--- a/python/qiskit_fermions/circuit/library/orbital_rotation.py
+++ b/python/qiskit_fermions/circuit/library/orbital_rotation.py
@@ -54,7 +54,7 @@ class OrbitalRotation(FermionicGate):
                 rotation via :math:`a^\dagger_i \mapsto \sum_j U_{ji} a^\dagger_j`. It must be
                 square and unitary; this is the caller's responsibility and is not verified.
         """
-        self.rotation_unitary = rotation_unitary
+        self.rotation_unitary = np.asarray(rotation_unitary, dtype=complex)
         """The unitary matrix representing the orbital rotation coefficients."""
 
         super().__init__("OrbitalRotation", self.rotation_unitary.shape[0], [])

--- a/python/qiskit_fermions/circuit/library/prepare_slater_determinant.py
+++ b/python/qiskit_fermions/circuit/library/prepare_slater_determinant.py
@@ -1,0 +1,141 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Slater determinant preparation gate."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from .. import FermionicGate
+from .initialize_modes import InitializeModes
+from .orbital_rotation import OrbitalRotation
+
+if TYPE_CHECKING:
+    from qiskit_fermions.circuit import FermionicCircuit
+
+
+class PrepareSlaterDeterminant(FermionicGate):
+    r"""Prepares a Slater determinant from an occupation and an orbital rotation.
+
+    This gate is the composition of an :class:`.InitializeModes` reference occupation followed by an
+    :class:`.OrbitalRotation`: it declares that the modes it acts on start in the determinant defined
+    by ``occupation`` and are then rotated by ``rotation_unitary``. Because the initial occupation is
+    known, transpiling this gate can use the rectangular :func:`.givens_decomposition_slater` for a
+    reduced-gate-count synthesis (see :class:`.GivensDecompositionSlaterDeterminantSynthesis`) rather
+    than the full square decomposition an :class:`.OrbitalRotation` alone would require.
+
+    Following the :class:`.OrbitalRotation` convention :math:`a^\dagger_i \mapsto \sum_j U_{ji}
+    a^\dagger_j`, rotating the occupied modes maps them onto the corresponding columns of
+    ``rotation_unitary``; those columns span the occupied space of the prepared Slater determinant.
+
+    .. rubric:: Simulation semantics
+
+    Under simulation this gate is **validate-then-rotate**, not a state producer: given an incoming
+    state vector it validates that the vector is confined to the subspace ``occupation`` defines (via
+    :class:`.InitializeModes`) and then applies ``rotation_unitary`` (via :class:`.OrbitalRotation`).
+    It therefore requires a real reference state vector, prepared externally (e.g. via
+    :func:`ffsim.slater_determinant`). The *producer* behavior -- emitting the gates that set the
+    reference occupation -- lives in the synthesis plugin, not the simulation path.
+
+    Applying (rather than dropping) the rotation is what guarantees that merging an
+    :class:`.InitializeModes` and an :class:`.OrbitalRotation` into this single gate leaves the
+    simulated final state unchanged.
+
+    .. caution::
+       This is an early development prototype. Beware of changes to its interface without warning
+       during the pre-release development of this package.
+
+    .. seealso::
+       :class:`.InitializeModes`, :class:`.OrbitalRotation`, and
+       :func:`~qiskit_fermions.linalg.givens_decomposition_slater`.
+    """
+
+    def __init__(self, occupation: Sequence[bool], rotation_unitary: np.ndarray) -> None:
+        r"""Initializing an instance of this gate can be done with the arguments listed below.
+
+        Args:
+            occupation: a sequence of booleans indicating the reference occupation for each mode this
+                gate acts on.
+            rotation_unitary: the :math:`n \times n` unitary matrix :math:`U` defining the orbital
+                rotation via :math:`a^\dagger_i \mapsto \sum_j U_{ji} a^\dagger_j`, where :math:`n` is
+                the number of modes (``len(occupation)``). It must be square and unitary; this is the
+                caller's responsibility and is not verified.
+
+        Raises:
+            ValueError: if ``rotation_unitary`` is not a square matrix whose dimension matches the
+                length of ``occupation``.
+        """
+        self.occupation = np.asarray(occupation, dtype=bool)
+        """The reference occupation (one boolean per mode) the rotation is applied to."""
+
+        self.rotation_unitary = np.asarray(rotation_unitary, dtype=complex)
+        """The unitary matrix representing the orbital rotation coefficients."""
+
+        num_modes = len(self.occupation)
+        if self.rotation_unitary.shape != (num_modes, num_modes):
+            raise ValueError(
+                f"rotation_unitary has shape {self.rotation_unitary.shape}, expected "
+                f"({num_modes}, {num_modes}) to match the occupation length {num_modes}."
+            )
+
+        super().__init__("PrepareSlaterDeterminant", num_modes, [])
+
+    def _build_definition(self) -> FermionicCircuit:
+        """Builds the gate as a :class:`.FermionicCircuit` (shared by ``_define`` and the sim path).
+
+        The definition is an :class:`.InitializeModes` reference validator followed by an
+        :class:`.OrbitalRotation`, both on all modes. Walking this two-gate definition is exactly the
+        validate-then-rotate semantics, which guarantees that merging an :class:`.InitializeModes`
+        and an :class:`.OrbitalRotation` into this gate leaves the simulated state unchanged.
+        """
+        from qiskit_fermions.circuit import FermionicCircuit
+
+        definition = FermionicCircuit(self.num_modes)
+        definition.append(InitializeModes(self.occupation.tolist()), definition.modes)
+        definition.append(OrbitalRotation(self.rotation_unitary), definition.modes)
+        return definition
+
+    def _define(self) -> None:
+        self._definition = self._build_definition()._inner
+
+    def _apply_unitary_placed_(
+        self,
+        vec: np.ndarray,
+        norb: int,
+        nelec: int | tuple[int, int],
+        copy: bool,
+        freg_indices: list[int],
+    ) -> np.ndarray:
+        """Validates the reference occupation and applies the rotation, placing modes onto ``vec``.
+
+        Delegates to the gate's definition (:meth:`_build_definition`): the leading
+        :class:`.InitializeModes` validates that ``vec`` is confined to the subspace ``occupation``
+        defines and the following :class:`.OrbitalRotation` rotates it. See those gates'
+        ``_apply_unitary_placed_`` for the full semantics (subspace confinement and the rejection of
+        spin-mixing rotations).
+
+        Args:
+            vec: the reference state vector to validate and rotate.
+            norb: the number of spatial orbitals of the *global* state vector.
+            nelec: either a single integer for a spinless system, or a pair of integers storing the
+                numbers of spin alpha and spin beta fermions.
+            copy: whether to copy the vector before operating on it.
+            freg_indices: the absolute (global) mode indices that this gate's local modes map onto.
+
+        Returns:
+            The transformed vector.
+        """
+        return self._build_definition()._apply_unitary_placed_(vec, norb, nelec, copy, freg_indices)

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -79,6 +79,7 @@ from .synthesis import (
     F2QSynthesisPlugin,
     F2QSynthesisPluginManager,
     GivensDecompositionOrbitalRotationSynthesis,
+    GivensDecompositionSlaterDeterminantSynthesis,
     MapperFnEvolutionSynthesis,
     TrivialOccupationInitializeModesSynthesis,
 )
@@ -90,6 +91,7 @@ __all__ = [
     "F2QSynthesisPlugin",
     "F2QSynthesisPluginManager",
     "GivensDecompositionOrbitalRotationSynthesis",
+    "GivensDecompositionSlaterDeterminantSynthesis",
     "MapperFnEvolutionSynthesis",
     "QDriftTrotterization",
     "RelabelModes",

--- a/python/qiskit_fermions/transpiler/passes/synthesis/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/__init__.py
@@ -16,6 +16,7 @@ from .evolution import MapperFnEvolutionSynthesis
 from .initialize_modes import TrivialOccupationInitializeModesSynthesis
 from .orbital_rotation import GivensDecompositionOrbitalRotationSynthesis
 from .plugin import F2QSynthesisPlugin, F2QSynthesisPluginManager
+from .prepare_slater_determinant import GivensDecompositionSlaterDeterminantSynthesis
 from .synthesis import F2QSynthesis, F2QSynthesisConfig
 
 __all__ = [
@@ -24,6 +25,7 @@ __all__ = [
     "F2QSynthesisPlugin",
     "F2QSynthesisPluginManager",
     "GivensDecompositionOrbitalRotationSynthesis",
+    "GivensDecompositionSlaterDeterminantSynthesis",
     "MapperFnEvolutionSynthesis",
     "TrivialOccupationInitializeModesSynthesis",
 ]

--- a/python/qiskit_fermions/transpiler/passes/synthesis/prepare_slater_determinant.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/prepare_slater_determinant.py
@@ -1,0 +1,101 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Slater determinant preparation synthesis."""
+
+from __future__ import annotations
+
+import numpy as np
+from qiskit.circuit.library import XGate, XXPlusYYGate
+from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+
+from qiskit_fermions.linalg import givens_decomposition_slater
+
+from ... import F2QLayout
+from ..utils import map_node_single_register
+
+
+class GivensDecompositionSlaterDeterminantSynthesis:
+    r"""A :class:`.F2QSynthesisPlugin` for transpiling :class:`.PrepareSlaterDeterminant`.
+
+    This plugin exploits the known reference occupation to synthesize the gate with the rectangular
+    :func:`~qiskit_fermions.linalg.givens_decomposition_slater`: only the :math:`m` occupied orbitals
+    of the rotation need be realized, so at most :math:`m (n - m)` ``XXPlusYYGate`` rotations are
+    emitted (versus the :math:`n (n - 1) / 2` brick-wall plus :math:`n` phase gates that
+    :class:`.GivensDecompositionOrbitalRotationSynthesis` would use for the full
+    :class:`.OrbitalRotation`). The reduced decomposition carries no diagonal phases -- a global phase
+    and any rotation within the occupied space leave the prepared Slater determinant unchanged -- so
+    the state is prepared correct up to a global phase.
+
+    .. note::
+       :func:`~qiskit_fermions.linalg.givens_decomposition_slater` is defined against a fixed
+       *leading*-:math:`m` reference (the first :math:`m` modes occupied). The emitted ``XGate``\ s
+       therefore always seed the first :math:`m` qubits, **not** the qubits pointed to by
+       ``occupation`` -- the Givens sweep then transports the occupation onto the physical target
+       orbitals. The positions of ``occupation``'s occupied modes enter only through which columns of
+       ``rotation_unitary`` are selected (``rotation_unitary[:, occupied]``); their *count* :math:`m`
+       determines the reference. The final prepared state is correct for any occupation, contiguous
+       or not.
+
+    .. warning::
+       This transpilation pass plugin makes the following assumptions:
+
+       - an occupation-basis encoding (like Jordan-Wigner)
+       - a trivial fermion-to-qubit layout (i.e. no change in their register lengths)
+       - a 1-to-1 mapping of fermionic mode indices to qubit indices
+    """
+
+    def run(self, in_node: DAGOpNode, out_dag: DAGCircuit, *, f2q_layout: F2QLayout) -> None:
+        """Runs this transpilation plugin.
+
+        Args:
+            in_node: the input fermion-based circuit instruction. When this plugin gets called, the
+                ``in_node.op`` attribute `must` be of type :class:`.PrepareSlaterDeterminant`.
+            out_dag: the output qubit-based circuit.
+            f2q_layout: the global transpilation :class:`~qiskit_fermions.transpiler.F2QLayout`
+                setting.
+
+        .. seealso::
+           The documentation of :class:`.F2QSynthesisPlugin` for more detailed explanations of the
+           arguments.
+
+        Raises:
+            NotImplementedError: when ``in_node`` acts on fermionic modes that are spread across
+                multiple :type:`~qiskit_fermions.circuit.FermionicRegister` instances.
+        """
+        freg_indices, qreg = map_node_single_register(in_node, f2q_layout)
+
+        occupation = in_node.op.occupation
+        rotation_unitary = in_node.op.rotation_unitary
+
+        # the occupied local modes select the occupied orbitals; their columns of the rotation
+        # unitary (following a†_i ↦ Σ_j U_ji a†_j) span the prepared Slater determinant's occupied
+        # space. ``givens_decomposition_slater`` takes them as the m rows of an m x n matrix.
+        occupied = np.nonzero(occupation)[0]
+        orbital_coeffs = rotation_unitary[:, occupied].T
+
+        # the decomposition prepares the target from the reference in which the first m orbitals are
+        # occupied; seed that reference by setting the first m modes of the register occupied. The
+        # Givens sweep below then moves the occupation onto the physical target orbitals.
+        for i in range(len(occupied)):
+            out_dag.apply_operation_back(XGate(), (qreg[freg_indices[i]],))
+
+        # apply the Givens rotations in order (same XXPlusYYGate convention as the square plugin).
+        # No phase gates: the reduced decomposition carries none, so the state is prepared up to a
+        # global phase (physically irrelevant for state preparation).
+        for c, s, i, j in givens_decomposition_slater(orbital_coeffs):
+            c_angle = np.acos(c)
+            if not np.isclose(c_angle, 0.0):
+                out_dag.apply_operation_back(
+                    XXPlusYYGate(2 * c_angle, np.angle(s) - 0.5 * np.pi),
+                    (qreg[freg_indices[i]], qreg[freg_indices[j]]),
+                )

--- a/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
+++ b/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
@@ -40,6 +40,7 @@ def generate_preset_jw_pass_manager(**kwargs) -> MultiStagePassManager:
         "Evolution": ("MapperFn", (jordan_wigner,)),
         "InitializeModes": "TrivialOccupation",
         "OrbitalRotation": "GivensDecomposition",
+        "PrepareSlaterDeterminant": "GivensDecompositionSlater",
     }
     synth = F2QSynthesis(config)
 

--- a/tests/python/circuit/library/test_orbital_rotation.py
+++ b/tests/python/circuit/library/test_orbital_rotation.py
@@ -1,0 +1,43 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the OrbitalRotation gate."""
+
+from __future__ import annotations
+
+import numpy as np
+from qiskit_fermions.circuit import FermionicCircuit
+from qiskit_fermions.circuit.library import OrbitalRotation
+from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager
+
+from ...utils import random_unitary
+
+
+def test_orbital_rotation_coerces_real_dtype():
+    """A real-dtype rotation matrix is coerced to complex on construction.
+
+    The synthesis path (``givens_decomposition``) requires a complex matrix; without coercion a
+    real-valued unitary reaches the Rust binding and raises an opaque cast error. Constructing from a
+    real array must store a complex ``rotation_unitary`` and synthesize without error.
+    """
+    num_modes = 4
+    # a real-valued orthogonal matrix (real special case of a unitary)
+    real_rotation = np.linalg.qr(random_unitary(num_modes, seed=3).real)[0]
+    assert real_rotation.dtype.kind == "f"
+
+    gate = OrbitalRotation(real_rotation)
+    assert gate.rotation_unitary.dtype == np.complex128
+
+    circ = FermionicCircuit(num_modes)
+    circ.append(gate, circ.modes)
+    # lowering must not raise (previously: "'ndarray' object cannot be cast as 'ndarray'")
+    generate_preset_jw_pass_manager().run(circ)

--- a/tests/python/circuit/library/test_prepare_slater_determinant.py
+++ b/tests/python/circuit/library/test_prepare_slater_determinant.py
@@ -1,0 +1,61 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Structural tests for the PrepareSlaterDeterminant gate."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from qiskit_fermions.circuit import FermionicCircuit
+from qiskit_fermions.circuit.library import (
+    InitializeModes,
+    OrbitalRotation,
+    PrepareSlaterDeterminant,
+)
+
+from ...utils import random_unitary
+
+
+def test_prepare_slater_determinant_gate():
+    """The gate stores its occupation and rotation and reports the right mode count."""
+    occupation = [True, True, False, False]
+    rotation = random_unitary(4, seed=0)
+    gate = PrepareSlaterDeterminant(occupation, rotation)
+
+    assert gate.num_modes == 4
+    np.testing.assert_array_equal(gate.occupation, np.asarray(occupation, dtype=bool))
+    np.testing.assert_allclose(gate.rotation_unitary, rotation)
+
+    circ = FermionicCircuit(4)
+    circ.append(gate, circ.modes)
+    assert circ.count_ops() == {"PrepareSlaterDeterminant": 1}
+
+
+def test_prepare_slater_determinant_rejects_shape_mismatch():
+    """A rotation whose dimension disagrees with the occupation length is rejected."""
+    with pytest.raises(ValueError, match="to match the occupation length"):
+        PrepareSlaterDeterminant([True, False, False], random_unitary(4, seed=1))
+
+
+def test_prepare_slater_determinant_definition():
+    """The gate's definition is an InitializeModes validator followed by the OrbitalRotation."""
+    occupation = [True, False, True]
+    rotation = random_unitary(3, seed=2)
+    definition = PrepareSlaterDeterminant(occupation, rotation)._build_definition()
+
+    ops = list(definition._inner.data)
+    assert [type(instr.operation) for instr in ops] == [InitializeModes, OrbitalRotation]
+    np.testing.assert_array_equal(ops[0].operation.occupation, np.asarray(occupation, dtype=bool))
+    np.testing.assert_allclose(ops[1].operation.rotation_unitary, rotation)
+    # every sub-instruction acts on the full register
+    assert all(len(instr.qubits) == 3 for instr in ops)

--- a/tests/python/circuit/library/test_prepare_slater_determinant_apply_unitary.py
+++ b/tests/python/circuit/library/test_prepare_slater_determinant_apply_unitary.py
@@ -1,0 +1,151 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for applying a PrepareSlaterDeterminant gate to an ffsim state vector.
+
+The gate is validate-then-rotate: given a reference state vector confined to its occupation
+subspace, the leading :class:`.InitializeModes` validates (and returns it unchanged) and the
+:class:`.OrbitalRotation` rotates it. These tests pin the correctness contract that matters for the
+later merge optimization pass: applying the merged gate to a reference vector must yield the *exact
+same* final state as applying an :class:`.InitializeModes` and an :class:`.OrbitalRotation`
+separately.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from qiskit_fermions.circuit import FermionicCircuit
+from qiskit_fermions.circuit.library import (
+    InitializeModes,
+    OrbitalRotation,
+    PrepareSlaterDeterminant,
+)
+
+from ...utils import random_unitary
+
+ffsim = pytest.importorskip("ffsim")
+
+
+def _block_diag(mat_a: np.ndarray, mat_b: np.ndarray) -> np.ndarray:
+    """Assembles a block-spin orbital rotation from independent alpha/beta rotations."""
+    norb = mat_a.shape[0]
+    full = np.zeros((2 * norb, 2 * norb), dtype=complex)
+    full[:norb, :norb] = mat_a
+    full[norb:, norb:] = mat_b
+    return full
+
+
+def test_prepare_slater_determinant_apply_unitary_spinless_matches_ffsim():
+    """The spinless gate validates the reference and applies the rotation (== ffsim rotation)."""
+    norb = 5
+    nelec = 2
+    occupation = [i < nelec for i in range(norb)]
+    rotation = random_unitary(norb, seed=3)
+
+    reference = ffsim.slater_determinant(norb, list(range(nelec)))
+    reference_before = reference.copy()
+
+    gate = PrepareSlaterDeterminant(occupation, rotation)
+    result = gate._apply_unitary_(reference, norb, nelec, copy=True)
+
+    # InitializeModes only validates (no-op on a valid reference), so the effect is the rotation
+    expected = ffsim.apply_orbital_rotation(reference.copy(), rotation, norb=norb, nelec=nelec)
+    np.testing.assert_allclose(result, expected, atol=1e-10)
+    # copy=True must leave the input untouched
+    np.testing.assert_array_equal(reference, reference_before)
+
+
+def test_prepare_slater_determinant_apply_unitary_spinful_matches_ffsim():
+    """The spinful (block-spin) gate matches ffsim's per-spin orbital rotation."""
+    norb = 3
+    nelec = (2, 1)
+    occupation = [i < nelec[0] for i in range(norb)] + [i < nelec[1] for i in range(norb)]
+    rot_a = random_unitary(norb, seed=1)
+    rot_b = random_unitary(norb, seed=2)
+    full = _block_diag(rot_a, rot_b)
+
+    reference = ffsim.slater_determinant(norb, ([0, 1], [0]))
+
+    gate = PrepareSlaterDeterminant(occupation, full)
+    result = gate._apply_unitary_(reference, norb, nelec, copy=True)
+
+    expected = ffsim.apply_orbital_rotation(
+        reference.copy(), (rot_a, rot_b), norb=norb, nelec=nelec
+    )
+    np.testing.assert_allclose(result, expected, atol=1e-10)
+
+
+def test_prepare_slater_determinant_matches_separate_init_and_rotation():
+    """The merge-invariance contract: the merged gate equals Init then Rotation applied separately.
+
+    This is the property the later optimization pass relies on -- fusing an ``InitializeModes`` and an
+    ``OrbitalRotation`` into a single ``PrepareSlaterDeterminant`` must leave the simulated state
+    exactly unchanged.
+    """
+    norb = 4
+    nelec = 2
+    occupation = [i < nelec for i in range(norb)]
+    rotation = random_unitary(norb, seed=7)
+
+    reference = ffsim.slater_determinant(norb, list(range(nelec)))
+
+    # separate: InitializeModes (validate) then OrbitalRotation (rotate)
+    unmerged = FermionicCircuit(norb)
+    unmerged.append(InitializeModes(occupation), unmerged.modes)
+    unmerged.append(OrbitalRotation(rotation), unmerged.modes)
+    expected = unmerged._apply_unitary_(reference, norb, nelec, copy=True)
+
+    # merged
+    merged = PrepareSlaterDeterminant(occupation, rotation)
+    result = merged._apply_unitary_(reference, norb, nelec, copy=True)
+
+    np.testing.assert_allclose(result, expected, atol=1e-12)
+
+
+def test_prepare_slater_determinant_apply_unitary_rejects_wrong_reference():
+    """A reference vector outside the occupation subspace is rejected by the leading validator."""
+    norb = 4
+    nelec = 2
+    # occupation names orbital 0 occupied, but the reference occupies orbitals 2 and 3
+    occupation = [True, True, False, False]
+    rotation = random_unitary(norb, seed=9)
+    wrong_reference = ffsim.slater_determinant(norb, [2, 3])
+
+    gate = PrepareSlaterDeterminant(occupation, rotation)
+    with pytest.raises(ValueError, match="amplitude outside the subspace"):
+        gate._apply_unitary_(wrong_reference, norb, nelec, copy=True)
+
+
+def test_prepare_slater_determinant_apply_unitary_with_placement():
+    """A subset-placed gate is embedded onto its global modes and applied correctly.
+
+    Placing the gate on the alpha modes of a block-spin register validates+rotates only that sector.
+    """
+    norb = 3
+    nelec = (2, 1)
+    occupation = [i < nelec[0] for i in range(norb)]  # local alpha occupation
+    rotation = random_unitary(norb, seed=5)
+
+    reference = ffsim.slater_determinant(norb, ([0, 1], [0]))
+
+    circ = FermionicCircuit(2 * norb)
+    circ.append(
+        PrepareSlaterDeterminant(occupation, rotation),
+        [circ.modes[i] for i in range(norb)],
+    )
+    result = circ._apply_unitary_(reference, norb, nelec, copy=True)
+
+    expected = ffsim.apply_orbital_rotation(
+        reference.copy(), (rotation, None), norb=norb, nelec=nelec
+    )
+    np.testing.assert_allclose(result, expected, atol=1e-10)

--- a/tests/python/transpiler/passes/test_prepare_slater_determinant_synthesis.py
+++ b/tests/python/transpiler/passes/test_prepare_slater_determinant_synthesis.py
@@ -1,0 +1,150 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Slater determinant preparation synthesis tests."""
+
+from __future__ import annotations
+
+import numpy as np
+from qiskit.passmanager import MultiStagePassManager
+from qiskit.quantum_info import Statevector
+from qiskit_fermions.circuit import FermionicCircuit
+from qiskit_fermions.circuit.library import (
+    InitializeModes,
+    OrbitalRotation,
+    PrepareSlaterDeterminant,
+)
+from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
+from qiskit_fermions.transpiler.passes import (
+    F2QSynthesis,
+    GivensDecompositionOrbitalRotationSynthesis,
+    GivensDecompositionSlaterDeterminantSynthesis,
+    TrivialF2QLayout,
+    TrivialOccupationInitializeModesSynthesis,
+)
+
+from ...utils import random_unitary
+
+
+def _synthesize(circ: FermionicCircuit, synth: F2QSynthesis):
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
+    return pm.run(circ)
+
+
+def _slater_synth() -> F2QSynthesis:
+    synth = F2QSynthesis()
+    synth.methods["PrepareSlaterDeterminant"] = GivensDecompositionSlaterDeterminantSynthesis()
+    return synth
+
+
+def _reference_synth() -> F2QSynthesis:
+    """Synthesizes the equivalent InitializeModes + OrbitalRotation via the trusted square path."""
+    synth = F2QSynthesis()
+    synth.methods["InitializeModes"] = TrivialOccupationInitializeModesSynthesis()
+    synth.methods["OrbitalRotation"] = GivensDecompositionOrbitalRotationSynthesis()
+    return synth
+
+
+def _assert_equal_up_to_global_phase(qc_a, qc_b):
+    sv_a = Statevector(qc_a).data
+    sv_b = Statevector(qc_b).data
+    # align the global phase on the largest-magnitude amplitude, then compare
+    k = int(np.argmax(np.abs(sv_b)))
+    phase = sv_a[k] / sv_b[k]
+    np.testing.assert_allclose(sv_a, phase * sv_b, atol=1e-10)
+
+
+def test_prepare_slater_determinant_synthesis_matches_reference():
+    """The reduced Slater synthesis prepares the same state as the full InitializeModes+rotation."""
+    num_modes = 6
+    occupation = [True, True, True, False, False, False]
+    rotation = random_unitary(num_modes, seed=42)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    qc_slater = _synthesize(slater, _slater_synth())
+
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    qc_reference = _synthesize(reference, _reference_synth())
+
+    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+
+
+def test_prepare_slater_determinant_synthesis_scattered_occupation():
+    """A non-leading, non-contiguous occupation still prepares the correct state.
+
+    The reduced decomposition seeds a *leading*-``m`` reference (X gates on the first ``m`` modes)
+    regardless of where the occupied modes actually sit; ``occupation``'s positions enter only via
+    the column selection ``rotation_unitary[:, occupied]``. This checks that this leading-reference
+    convention is nonetheless correct for an occupation whose ``True`` entries are neither leading
+    nor contiguous.
+    """
+    num_modes = 6
+    occupation = [False, True, False, True, True, False]
+    rotation = random_unitary(num_modes, seed=7)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    qc_slater = _synthesize(slater, _slater_synth())
+
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    qc_reference = _synthesize(reference, _reference_synth())
+
+    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+
+
+def test_prepare_slater_determinant_synthesis_reduced_gate_count():
+    """The Slater synthesis uses fewer gates than the full orbital rotation and emits no phases."""
+    num_modes = 6
+    nocc = 3
+    occupation = [i < nocc for i in range(num_modes)]
+    rotation = random_unitary(num_modes, seed=1)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    ops = _synthesize(slater, _slater_synth()).count_ops()
+
+    # at most m(n-m) XXPlusYYGates, m X gates, and crucially no phase gates
+    assert ops.get("xx_plus_yy", 0) <= nocc * (num_modes - nocc)
+    assert ops.get("x", 0) == nocc
+    assert "p" not in ops
+
+    # the full orbital-rotation synthesis of the same rotation uses the n(n-1)/2 brick-wall + phases
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    ref_ops = _synthesize(reference, _reference_synth()).count_ops()
+    assert ops.get("xx_plus_yy", 0) < ref_ops.get("xx_plus_yy", 0)
+
+
+def test_prepare_slater_determinant_synthesis_full_occupation():
+    """A fully occupied reference (m == n) needs no Givens rotations, only the X gates."""
+    num_modes = 4
+    occupation = [True] * num_modes
+    rotation = random_unitary(num_modes, seed=2)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    ops = _synthesize(slater, _slater_synth()).count_ops()
+
+    # m == n: the occupied space is the whole space, so any rotation within it is discarded
+    assert ops.get("x", 0) == num_modes
+    assert ops.get("xx_plus_yy", 0) == 0

--- a/tests/python/transpiler/presets/test_jordan_wigner.py
+++ b/tests/python/transpiler/presets/test_jordan_wigner.py
@@ -19,10 +19,17 @@ from qiskit import QuantumCircuit
 from qiskit.circuit.library import PauliEvolutionGate, XXPlusYYGate
 from qiskit.quantum_info import Statevector
 from qiskit_fermions.circuit import FermionicCircuit
-from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
+from qiskit_fermions.circuit.library import (
+    Evolution,
+    InitializeModes,
+    OrbitalRotation,
+    PrepareSlaterDeterminant,
+)
 from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager
+
+from ...utils import random_unitary
 
 
 def test_preset_jordan_wigner():
@@ -99,3 +106,30 @@ def test_preset_jordan_wigner_identity_rotation():
     expected = Statevector(reference)
 
     assert Statevector(generate_preset_jw_pass_manager().run(orbital)) == expected
+
+
+def test_preset_jordan_wigner_prepare_slater_determinant():
+    """The preset lowers a PrepareSlaterDeterminant to the reduced Slater synthesis.
+
+    The prepared state must agree (up to a global phase, which the reduced decomposition drops) with
+    the equivalent separate InitializeModes + OrbitalRotation lowered by the same preset.
+    """
+    num_modes = 6
+    occupation = [True, True, True, False, False, False]
+    rotation = random_unitary(num_modes, seed=42)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+
+    unmerged = FermionicCircuit(num_modes)
+    unmerged.append(InitializeModes(occupation), unmerged.modes)
+    unmerged.append(OrbitalRotation(rotation), unmerged.modes)
+
+    pm = generate_preset_jw_pass_manager()
+    sv_slater = Statevector(pm.run(slater)).data
+    sv_unmerged = Statevector(pm.run(unmerged)).data
+
+    # align the global phase on the largest-magnitude amplitude, then compare
+    k = int(np.argmax(np.abs(sv_unmerged)))
+    phase = sv_slater[k] / sv_unmerged[k]
+    np.testing.assert_allclose(sv_slater, phase * sv_unmerged, atol=1e-10)


### PR DESCRIPTION
This PR adds the new `PrepareSlaterDeterminant` gate to the circuit library (along with a preset synthesis plugin for the Jordan-Wigner case).

```python
import numpy as np
from qiskit_fermions.circuit import FermionicCircuit
from qiskit_fermions.circuit.library import (
    InitializeModes,
    OrbitalRotation,
    PrepareSlaterDeterminant,
)
from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager

norb = 6
occupation = [True, True, True, False, False, False]     # 3 occupied, 3 virtual
rotation = np.linalg.qr(np.random.randn(norb, norb))[0]  # some orbital rotation U

# NEW: a single gate for "reference occupation, then rotate" — a Slater determinant.
slater = FermionicCircuit(norb)
slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)

# The equivalent, written out as the two gates it composes.
unmerged = FermionicCircuit(norb)
unmerged.append(InitializeModes(occupation), unmerged.modes)
unmerged.append(OrbitalRotation(rotation), unmerged.modes)

# The JW preset lowers PrepareSlaterDeterminant via the reduced (rectangular) Givens
# decomposition: only the m occupied orbitals are realized, so it emits far fewer
# two-qubit rotations (<= m(n-m)) and no phase gates.
pm = generate_preset_jw_pass_manager()
print(pm.run(slater).count_ops())    # {'xx_plus_yy': 9,  'x': 3}   (<= m(n-m) = 9, no phases)
print(pm.run(unmerged).count_ops())  # {'xx_plus_yy': 15, 'x': 3, 'p': 6} (full n(n-1)/2 brick-wall + phase gates)
```

A follow-up PR is going to introduce a new transpiler pass for the `optimization` stage which automatically merges compatible `InitializeModes` and `OrbitalRotation` gates (such that e.g. UCJ-based circuits can also leverage this new gate with its reduced gate-count synthesis).

Closes #55 