### PR TITLE
perf(transpiler): peel disjoint unit-orbitals in Slater synthesis

### DIFF
--- a/python/qiskit_fermions/transpiler/passes/synthesis/prepare_slater_determinant.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/prepare_slater_determinant.py
@@ -23,6 +23,75 @@ from qiskit_fermions.linalg import givens_decomposition_slater
 from ... import F2QLayout
 from ..utils import map_node_single_register
 
+# Absolute tolerance for treating an O(1) quantity derived from the orthonormal orbital
+# coefficients as equal to its ideal 0/1 value. It gates both halves of the same peeling decision:
+# whether a projector column ``P[:, k]`` equals ``e_k`` (identifying a disjoint unit-orbital), and
+# whether a singular value of the restricted matrix is nonzero (counting the reduced-space rank).
+# Both compare O(1) quantities against a round-off floor of a few ULPs (~1e-15, growing only with the
+# tiny mode count), so a single tolerance well above that floor -- and identical for both tests, so
+# they can never disagree on a borderline mode -- is the sensible choice. The value matches
+# ``EPSILON`` in ``crates/core/src/linalg/givens.rs`` (the "equivalent to zero" cutoff of the Givens
+# sweep that ``reduced`` is handed to): keeping the peeler no looser than that downstream floor means
+# it never declares a mode a clean unit-orbital while the sweep would still treat the residual as
+# nonzero.
+_PEEL_ATOL = 1e-10
+
+
+def _peel_disjoint_unit_orbitals(
+    orbital_coeffs: np.ndarray,
+) -> tuple[list[int], list[int], np.ndarray]:
+    r"""Split the occupied space into disjoint unit-orbitals and a genuinely-mixing remainder.
+
+    An occupied orbital that is a basis vector on a mode disjoint from every other occupied orbital
+    contributes a single fixed occupation on that mode. The reduced Givens sweep would otherwise seed
+    it on a leading mode and transport it out with a chain of bare ``SWAP``\ s
+    (``XXPlusYYGate`` with ``c = 0``); such orbitals can instead be realized by placing an ``XGate``
+    directly on their target mode, and excluded from the decomposition entirely.
+
+    The test is basis-independent: with the :math:`m \times n` occupied-orbital matrix ``A``
+    (``orbital_coeffs``), the occupied-space projector is :math:`P = A^\dagger A` (an :math:`n \times
+    n` rank-:math:`m` projector). Mode :math:`k` is a disjoint unit-orbital iff column :math:`k` of
+    :math:`P` equals :math:`e_k` -- i.e. :math:`e_k` lies in the occupied space *and* is orthogonal to
+    the rest of it.
+
+    Args:
+        orbital_coeffs: the :math:`m \times n` matrix of occupied-orbital coefficients (orthonormal
+            rows), i.e. ``rotation_unitary[:, occupied].T``.
+
+    Returns:
+        A 3-tuple ``(peel_modes, kept_modes, reduced)`` where ``peel_modes`` are the mode indices to
+        seed with a direct ``XGate``, ``kept_modes`` are the remaining mode indices (spanning the
+        genuinely-mixing occupied space), and ``reduced`` is the :math:`(m - p) \times k` orthonormal
+        matrix of that mixing space restricted to ``kept_modes`` (:math:`p` peeled modes,
+        :math:`k = n - p` kept modes; its :math:`m - p` rows are an orthonormal basis of the
+        kept-mode occupied subspace) -- ready to hand to
+        :func:`~qiskit_fermions.linalg.givens_decomposition_slater`. When no mode peels, ``peel_modes``
+        is empty, ``kept_modes`` is ``range(n)`` and ``reduced`` is ``orbital_coeffs`` unchanged.
+    """
+    n = orbital_coeffs.shape[1]
+    projector = orbital_coeffs.conj().T @ orbital_coeffs
+    identity = np.eye(n)
+    peel_modes = [k for k in range(n) if np.allclose(projector[:, k], identity[k], atol=_PEEL_ATOL)]
+
+    if not peel_modes:
+        return peel_modes, list(range(n)), orbital_coeffs
+
+    kept_modes = [k for k in range(n) if k not in peel_modes]
+    # Restrict the occupied space to the ``k = n - p`` kept modes and take an orthonormal basis of
+    # what remains. An SVD is used rather than dropping "the peeled rows" directly: after in-space
+    # mixing a peeled orbital need not appear as a clean single-support row of ``orbital_coeffs``, so
+    # we reduce the subspace rather than individual rows. The ``rank`` right-singular vectors with
+    # nonzero singular value span the kept-mode occupied space with orthonormal rows; peeling ``p``
+    # disjoint unit-orbitals drops ``p`` dimensions, so ``rank == m - p`` and ``reduced`` is
+    # ``(m - p) x k``.
+    restricted = orbital_coeffs[:, kept_modes]
+    _, singular_values, right_vectors = np.linalg.svd(restricted, full_matrices=False)
+    rank = int((singular_values > _PEEL_ATOL).sum())
+    # ``np.ascontiguousarray`` guards the FFI boundary: the sliced SVD output is not guaranteed
+    # C-contiguous, and ``givens_decomposition_slater`` requires a contiguous array.
+    reduced = np.ascontiguousarray(right_vectors[:rank])
+    return peel_modes, kept_modes, reduced
+
 
 class GivensDecompositionSlaterDeterminantSynthesis:
     r"""A :class:`.F2QSynthesisPlugin` for transpiling :class:`.PrepareSlaterDeterminant`.
@@ -39,12 +108,22 @@ class GivensDecompositionSlaterDeterminantSynthesis:
     .. note::
        :func:`~qiskit_fermions.linalg.givens_decomposition_slater` is defined against a fixed
        *leading*-:math:`m` reference (the first :math:`m` modes occupied). The emitted ``XGate``\ s
-       therefore always seed the first :math:`m` qubits, **not** the qubits pointed to by
+       therefore seed the leading modes of the decomposed block, **not** the qubits pointed to by
        ``occupation`` -- the Givens sweep then transports the occupation onto the physical target
        orbitals. The positions of ``occupation``'s occupied modes enter only through which columns of
        ``rotation_unitary`` are selected (``rotation_unitary[:, occupied]``); their *count* :math:`m`
        determines the reference. The final prepared state is correct for any occupation, contiguous
        or not.
+
+    .. note::
+       Occupied orbitals that are basis vectors on a mode disjoint from every other occupied orbital
+       are *peeled off* before the decomposition: their ``XGate`` is placed directly on the target
+       mode and they are excluded from the Givens sweep (see
+       :func:`_peel_disjoint_unit_orbitals`). This avoids the chain of bare ``SWAP``\ s
+       (``XXPlusYYGate`` with ``c = 0``) that the leading-reference sweep would otherwise emit to
+       transport such an orbital out to its mode. Only the genuinely-mixing remainder is decomposed.
+       When the whole occupied space is a signed permutation every orbital peels and no
+       ``XXPlusYYGate`` is emitted at all.
 
     .. warning::
        This transpilation pass plugin makes the following assumptions:
@@ -83,19 +162,35 @@ class GivensDecompositionSlaterDeterminantSynthesis:
         occupied = np.nonzero(occupation)[0]
         orbital_coeffs = rotation_unitary[:, occupied].T
 
-        # the decomposition prepares the target from the reference in which the first m orbitals are
-        # occupied; seed that reference by setting the first m modes of the register occupied. The
-        # Givens sweep below then moves the occupation onto the physical target orbitals.
-        for i in range(len(occupied)):
-            out_dag.apply_operation_back(XGate(), (qreg[freg_indices[i]],))
+        # peel off occupied orbitals that are disjoint unit-orbitals: seed their XGate directly on the
+        # target mode and hand only the genuinely-mixing remainder to the decomposition. ``kept_modes``
+        # maps the reduced decomposition's local indices back to physical mode indices.
+        peel_modes, kept_modes, reduced = _peel_disjoint_unit_orbitals(orbital_coeffs)
 
-        # apply the Givens rotations in order (same XXPlusYYGate convention as the square plugin).
-        # No phase gates: the reduced decomposition carries none, so the state is prepared up to a
-        # global phase (physically irrelevant for state preparation).
-        for c, s, i, j in givens_decomposition_slater(orbital_coeffs):
+        for mode in peel_modes:
+            out_dag.apply_operation_back(XGate(), (qreg[freg_indices[mode]],))
+
+        # the reduced decomposition prepares the mixing remainder from the reference in which the
+        # first ``m - p`` *kept* modes are occupied (``reduced`` has ``m - p`` rows); seed that
+        # reference. The Givens sweep below then moves the occupation onto the physical target
+        # orbitals within the kept modes.
+        num_mixing = reduced.shape[0]
+        for i in range(num_mixing):
+            out_dag.apply_operation_back(XGate(), (qreg[freg_indices[kept_modes[i]]],))
+
+        # a fully-peeled occupied space (e.g. a permutation rotation) leaves no mixing remainder to
+        # decompose; the direct X gates above already prepare the state.
+        if num_mixing == 0:
+            return
+
+        # apply the Givens rotations in order (same XXPlusYYGate convention as the square plugin),
+        # remapping each local sweep index through ``kept_modes`` to its physical mode. No phase
+        # gates: the reduced decomposition carries none, so the state is prepared up to a global phase
+        # (physically irrelevant for state preparation).
+        for c, s, i, j in givens_decomposition_slater(reduced):
             c_angle = np.acos(c)
             if not np.isclose(c_angle, 0.0):
                 out_dag.apply_operation_back(
                     XXPlusYYGate(2 * c_angle, np.angle(s) - 0.5 * np.pi),
-                    (qreg[freg_indices[i]], qreg[freg_indices[j]]),
+                    (qreg[freg_indices[kept_modes[i]]], qreg[freg_indices[kept_modes[j]]]),
                 )

--- a/tests/python/transpiler/passes/test_prepare_slater_determinant_synthesis.py
+++ b/tests/python/transpiler/passes/test_prepare_slater_determinant_synthesis.py
@@ -135,6 +135,132 @@ def test_prepare_slater_determinant_synthesis_reduced_gate_count():
     assert ops.get("xx_plus_yy", 0) < ref_ops.get("xx_plus_yy", 0)
 
 
+def _givens_2mode(theta: float, p: int, q: int, num_modes: int) -> np.ndarray:
+    """A real orbital rotation mixing only modes ``p`` and ``q`` (identity elsewhere).
+
+    Used to build occupied spaces that factor into disjoint unit-orbitals plus a genuinely-mixing
+    block, exercising the peel-off fast path.
+    """
+    rot = np.eye(num_modes, dtype=complex)
+    rot[p, p] = np.cos(theta)
+    rot[p, q] = -np.sin(theta)
+    rot[q, p] = np.sin(theta)
+    rot[q, q] = np.cos(theta)
+    return rot
+
+
+def test_prepare_slater_determinant_synthesis_peels_disjoint_unit_orbital():
+    """A disjoint unit-orbital is placed directly, not transported out with bare SWAPs.
+
+    The rotation mixes only modes 0 and 1; occupying column 3 (a bare basis vector on mode 3) and
+    column 1 (a superposition of modes 0 and 1) factors the occupied space into the disjoint
+    unit-orbital ``e_3`` plus one genuine two-mode rotation. The reduced sweep therefore needs a
+    single ``XXPlusYYGate`` -- the two transport SWAPs the leading-reference sweep would emit for
+    ``e_3`` are peeled away -- while the prepared state is unchanged.
+    """
+    num_modes = 4
+    occupation = [False, True, False, True]
+    rotation = _givens_2mode(0.6, 0, 1, num_modes)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    qc_slater = _synthesize(slater, _slater_synth())
+    ops = qc_slater.count_ops()
+
+    # only the genuine 0-1 mixing survives; no bare-SWAP transport of the e_3 orbital
+    assert ops.get("xx_plus_yy", 0) == 1
+    assert ops.get("x", 0) == 2
+
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    qc_reference = _synthesize(reference, _reference_synth())
+    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+
+
+def test_prepare_slater_determinant_synthesis_permutation_no_two_qubit_gates():
+    """A pure permutation rotation (here the identity) emits only X gates, no ``XXPlusYYGate``.
+
+    With ``rotation`` the identity and a non-leading, non-contiguous occupation the entire occupied
+    space is a signed permutation, so every occupied orbital peels: the state is prepared with X
+    gates placed directly on the occupied modes and zero two-qubit gates.
+    """
+    num_modes = 4
+    occupation = [False, True, False, True]
+    rotation = np.eye(num_modes, dtype=complex)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    qc_slater = _synthesize(slater, _slater_synth())
+    ops = qc_slater.count_ops()
+
+    assert ops.get("xx_plus_yy", 0) == 0
+    assert ops.get("x", 0) == 2
+    assert "p" not in ops
+
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    qc_reference = _synthesize(reference, _reference_synth())
+    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+
+
+def test_prepare_slater_determinant_synthesis_multiple_disjoint_units():
+    """Several disjoint unit-orbitals peel independently around a single mixing block.
+
+    The rotation mixes only the adjacent modes 0 and 1; occupying modes 0, 4, 5 gives two disjoint
+    unit-orbitals (``e_4``, ``e_5``) plus a single occupied orbital spanning the adjacent pair {0, 1}.
+    (Occupying *both* mixed columns 0 and 1 would fill the whole {0, 1} subspace and reduce to a plain
+    permutation -- selecting only column 0 keeps a genuine two-mode rotation.) The two disjoint units
+    peel to direct X gates, leaving a single ``XXPlusYYGate`` on the adjacent mixing pair.
+    """
+    num_modes = 6
+    occupation = [True, False, False, False, True, True]
+    rotation = _givens_2mode(0.5, 0, 1, num_modes)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    qc_slater = _synthesize(slater, _slater_synth())
+    ops = qc_slater.count_ops()
+
+    assert ops.get("xx_plus_yy", 0) == 1
+    assert ops.get("x", 0) == 3
+
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    qc_reference = _synthesize(reference, _reference_synth())
+    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+
+
+def test_prepare_slater_determinant_synthesis_generic_rotation_not_peeled():
+    """A generic entangled rotation has nothing to peel; the sweep is unchanged.
+
+    This guards the fast path against regressing the common case: a fully-mixing occupied space must
+    still be synthesized by the ordinary reduced Givens sweep (its ``m(n-m)`` bound intact) and
+    prepare the correct state.
+    """
+    num_modes = 6
+    nocc = 3
+    occupation = [i < nocc for i in range(num_modes)]
+    rotation = random_unitary(num_modes, seed=42)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    qc_slater = _synthesize(slater, _slater_synth())
+    ops = qc_slater.count_ops()
+
+    # nothing peels: the full leading-reference sweep runs (up to m(n-m) two-qubit gates, m X gates)
+    assert ops.get("x", 0) == nocc
+    assert 0 < ops.get("xx_plus_yy", 0) <= nocc * (num_modes - nocc)
+
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    qc_reference = _synthesize(reference, _reference_synth())
+    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+
+
 def test_prepare_slater_determinant_synthesis_full_occupation():
     """A fully occupied reference (m == n) needs no Givens rotations, only the X gates."""
     num_modes = 4


### PR DESCRIPTION
The reduced Givens sweep in `GivensDecompositionSlaterDeterminantSynthesis` seeds a leading-m reference and transports occupation onto the physical target modes. When an occupied orbital is a basis vector on a mode disjoint from every other occupied orbital, that transport is realized as a chain of bare SWAPs (`XXPlusYYGate` with `c=0`) -- pure classical relabeling that Qiskit's generic transpiler cannot remove (a SWAP is a nontrivial unitary and the JW preset carries no coupling map), so it must be avoided at synthesis time.

Peel off each such disjoint unit-orbital: place its `X` gate directly on the target mode and exclude it from the decomposition, handing only the genuinely-mixing remainder to `givens_decomposition_slater`. The detection is basis-independent -- mode k peels iff column k of the occupied-space projector $P = A^{\dagger} A$ equals $e_k$ -- and generalizes the special case where the whole occupied space is a signed permutation (then every orbital peels and no `XXPlusYYGate` is emitted at all).

The peel helper returns an explicit `(peel_modes, kept_modes, reduced)` triple so a later reference-reseeding optimization -- which would also minimize the transport SWAPs within the mixing remainder -- can build on it without rework.