### PR TITLE
feat(transpiler): fuse `InitializeModes` + `OrbitalRotation` into `PrepareSlaterDeterminant`

### DIFF
--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -44,4 +44,18 @@ this package:
    mappers
    circuit
    transpilation
+
+How-Tos
+=======
+
+This section lists goal-oriented guides for accomplishing specific tasks with
+particular components of this package:
+
+Transpiler passes
+-----------------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
    merge_slater_determinant

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -44,3 +44,4 @@ this package:
    mappers
    circuit
    transpilation
+   merge_slater_determinant

--- a/docs/guides/merge_slater_determinant.rst
+++ b/docs/guides/merge_slater_determinant.rst
@@ -1,0 +1,223 @@
+.. _merge_slater_determinant_explanation:
+
+Merge a mode initialization and rotation into a Slater determinant preparation
+==============================================================================
+
+.. important::
+
+   The concepts in this guide are currently available only in the Python API.
+   Equivalent functionality will be made available via the C API in a future release.
+
+An :class:`.InitializeModes` gate declares a reference mode occupation; an
+:class:`.OrbitalRotation` gate rotates the single-particle basis. Placed back to back, the two
+gates *prepare a Slater determinant*: the modes start in the reference determinant and are then
+rotated into the target orbitals. The :class:`.PrepareSlaterDeterminant` gate captures exactly that
+composition -- and because it knows the reference occupation, transpiling it can use the rectangular
+:func:`~qiskit_fermions.linalg.givens_decomposition_slater`, which realizes only the *occupied*
+orbitals, instead of the full square decomposition an :class:`.OrbitalRotation` alone requires. That
+is a strictly cheaper synthesis (see the payoff at the end of this guide).
+
+The :class:`.MergeSlaterDeterminantPreparation` transpiler pass detects the
+:class:`.InitializeModes`-then-:class:`.OrbitalRotation` pattern in a :class:`.FermionicCircuit` and
+rewrites it into :class:`.PrepareSlaterDeterminant` gate(s), so a later synthesis stage picks up the
+reduced decomposition automatically. Under simulation the rewrite is a no-op on the state:
+:class:`.PrepareSlaterDeterminant` is *validate-then-rotate* (it validates the reference occupation
+and then applies the rotation, exactly as the two separate gates do), so the merge only unlocks the
+cheaper synthesis without changing the prepared state.
+
+Throughout this guide we inspect a circuit by listing its fermionic gates and the modes they act on,
+before and after the pass. This small helper does that by running the pass on a copy of the circuit
+and walking the resulting :class:`.FermionicDAGCircuit`:
+
+.. doctest::
+
+   >>> from qiskit_fermions.transpiler import FermionicCircuitToDAG
+   >>> from qiskit_fermions.transpiler.passes import MergeSlaterDeterminantPreparation
+   >>>
+   >>> def show_merged(circuit):
+   ...     dag = FermionicCircuitToDAG().run(circuit)
+   ...     merged = MergeSlaterDeterminantPreparation().run(dag)
+   ...     for node in merged.topological_op_nodes():
+   ...         modes = sorted(merged.find_bit(qubit).index for qubit in node.qargs)
+   ...         print(f"{node.op.name} on modes {modes}")
+
+What gets merged
+----------------
+
+The pass recognizes three patterns, all keyed off the block-spin mode convention that
+:class:`.InitializeModes` and :class:`.OrbitalRotation` use: for a system with ``norb`` spatial
+orbitals the modes ``0..norb`` are the spin-alpha sector and ``norb..2*norb`` are the spin-beta
+sector. Slater determinant preparation is done per spin sector because each sector has its own
+(electrons, orbitals) shape.
+
+Full-register (or spinless)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The simplest pattern: an :class:`.InitializeModes` immediately followed by an
+:class:`.OrbitalRotation` on the *same* modes. This is the spinless case (one determinant over all
+modes) and also a spinful circuit whose rotation spans both sectors at once.
+
+.. doctest::
+
+   >>> import numpy as np
+   >>> from qiskit_fermions.circuit import FermionicCircuit
+   >>> from qiskit_fermions.circuit.library import InitializeModes, OrbitalRotation
+   >>>
+   >>> circuit = FermionicCircuit(4)
+   >>> circuit.append(InitializeModes([1, 1, 0, 0]), circuit.modes)
+   >>> circuit.append(OrbitalRotation(np.eye(4)), circuit.modes)
+   >>> show_merged(circuit)
+   PrepareSlaterDeterminant on modes [0, 1, 2, 3]
+
+Per spin sector
+~~~~~~~~~~~~~~~
+
+The same shape restricted to one spin half. Here two independent initialize-then-rotate pairs, one
+per sector, each fuse on their own into a :class:`.PrepareSlaterDeterminant`:
+
+.. doctest::
+
+   >>> circuit = FermionicCircuit(6)  # norb = 3: alpha modes 0..3, beta modes 3..6
+   >>> circuit.append(InitializeModes([1, 1, 0]), circuit.modes[:3])
+   >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[:3])
+   >>> circuit.append(InitializeModes([1, 0, 0]), circuit.modes[3:])
+   >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[3:])
+   >>> show_merged(circuit)
+   PrepareSlaterDeterminant on modes [0, 1, 2]
+   PrepareSlaterDeterminant on modes [3, 4, 5]
+
+Global initialization, per-spin rotations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A single full-register (``2 * norb``) :class:`.InitializeModes` followed by *two*
+:class:`.OrbitalRotation`\ s, one on each contiguous spin half. The pass splits the global
+occupation at the sector boundary and emits **two** :class:`.PrepareSlaterDeterminant` gates. The
+two rotations may appear in either order.
+
+This is the shape produced by the LUCJ workflow (see the :ref:`LUCJ guide <lucj_getting_started>`):
+a user places an :class:`.InitializeModes` -- typically the Hartree-Fock reference via
+:meth:`~qiskit_fermions.circuit.library.InitializeModes.from_hartree_fock` -- at the front of the
+circuit and appends a :class:`.UCJ` ansatz, whose first two per-spin orbital rotations directly
+follow the initialization once the ansatz is decomposed.
+
+.. doctest::
+
+   >>> circuit = FermionicCircuit(6)  # norb = 3, nelec = (2, 1)
+   >>> circuit.append(InitializeModes.from_hartree_fock(3, (2, 1)), circuit.modes)
+   >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[:3])
+   >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[3:])
+   >>> show_merged(circuit)
+   PrepareSlaterDeterminant on modes [0, 1, 2]
+   PrepareSlaterDeterminant on modes [3, 4, 5]
+
+What is left untouched
+----------------------
+
+The pass is deliberately conservative: it only fuses when the two gates genuinely compose into a
+Slater determinant preparation, and copies everything else through unchanged. "Immediately
+followed" is understood over the circuit's data-flow graph -- the :class:`.OrbitalRotation` fuses
+only when the :class:`.InitializeModes` is its *sole* predecessor across all of its modes.
+
+An operation in between
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If any gate touches the modes between the initialization and the rotation, they no longer compose
+into a bare preparation, so nothing is merged:
+
+.. doctest::
+
+   >>> from qiskit_fermions.circuit.library import Evolution
+   >>> from qiskit_fermions.operators import FermionOperator, ann, cre
+   >>>
+   >>> circuit = FermionicCircuit(4)
+   >>> circuit.append(InitializeModes([1, 1, 0, 0]), circuit.modes)
+   >>> number_op = FermionOperator.from_dict({(cre(0), ann(0)): 1.0})
+   >>> circuit.append(Evolution(4, number_op, time=0.5), circuit.modes)
+   >>> circuit.append(OrbitalRotation(np.eye(4)), circuit.modes)
+   >>> show_merged(circuit)
+   InitializeModes on modes [0, 1, 2, 3]
+   Evolution on modes [0, 1, 2, 3]
+   OrbitalRotation on modes [0, 1, 2, 3]
+
+Mismatched mode sets
+~~~~~~~~~~~~~~~~~~~~~
+
+A rotation covering fewer modes than the initialization is not a full preparation of those modes.
+Merging it would silently drop the initialization's role on the modes the rotation leaves out, so
+the pass leaves both gates in place:
+
+.. doctest::
+
+   >>> circuit = FermionicCircuit(4)
+   >>> circuit.append(InitializeModes([1, 1, 0, 0]), circuit.modes)
+   >>> circuit.append(OrbitalRotation(np.eye(2)), circuit.modes[:2])
+   >>> show_merged(circuit)
+   InitializeModes on modes [0, 1, 2, 3]
+   OrbitalRotation on modes [0, 1]
+
+Only one of the two per-spin rotations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For the global-initialization pattern, the pass fires only when *both* spin halves are rotated by
+gates that directly follow the initialization. With only one half rotated, fusing would drop the
+initialization's validation on the other half, so the whole pattern is left untouched:
+
+.. doctest::
+
+   >>> circuit = FermionicCircuit(6)
+   >>> circuit.append(InitializeModes.from_hartree_fock(3, (2, 1)), circuit.modes)
+   >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[:3])
+   >>> show_merged(circuit)
+   InitializeModes on modes [0, 1, 2, 3, 4, 5]
+   OrbitalRotation on modes [0, 1, 2]
+
+Why it matters: the synthesis payoff
+-------------------------------------
+
+The merge is worthwhile because :class:`.PrepareSlaterDeterminant` synthesizes to far fewer gates
+than the :class:`.OrbitalRotation` it absorbs. An :math:`m`-electron determinant over :math:`n`
+orbitals needs at most :math:`m(n-m)` two-qubit rotations and **no** diagonal phase gates, versus the
+:math:`n(n-1)/2` rotations plus :math:`n` phases of the full square orbital rotation.
+
+The preset Jordan-Wigner pass manager runs :class:`.MergeSlaterDeterminantPreparation` in its
+optimization stage, so this reduction happens automatically. Here we transpile a two-electron,
+six-orbital preparation all the way to a :class:`~qiskit.circuit.QuantumCircuit` and count its gates:
+
+.. doctest::
+
+   >>> from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager
+   >>>
+   >>> # a reproducible random 6 x 6 orbital rotation
+   >>> rng = np.random.default_rng(1)
+   >>> z = rng.standard_normal((6, 6)) + 1j * rng.standard_normal((6, 6))
+   >>> q, r = np.linalg.qr(z)
+   >>> rotation = q * (np.diagonal(r) / np.abs(np.diagonal(r)))
+   >>>
+   >>> circuit = FermionicCircuit(6)
+   >>> circuit.append(InitializeModes([1, 1, 0, 0, 0, 0]), circuit.modes)
+   >>> circuit.append(OrbitalRotation(rotation), circuit.modes)
+   >>>
+   >>> pm = generate_preset_jw_pass_manager()
+   >>> print(dict(sorted(pm.run(circuit).count_ops().items())))
+   {'x': 2, 'xx_plus_yy': 8}
+
+Compare that to synthesizing the same orbital rotation on its own -- with no preceding
+initialization there is nothing to merge, so the preset falls back to the full square
+decomposition, which is both deeper and carries diagonal phase gates:
+
+.. doctest::
+
+   >>> reference = FermionicCircuit(6)
+   >>> reference.append(OrbitalRotation(rotation), reference.modes)
+   >>> print(dict(sorted(pm.run(reference).count_ops().items())))
+   {'p': 6, 'xx_plus_yy': 15}
+
+The reduced decomposition drops all six phase gates and nearly halves the two-qubit rotation count.
+The prepared determinant is correct up to a global phase -- physically irrelevant for state
+preparation -- which is exactly what the phase gates would have fixed.
+
+.. seealso::
+   :class:`.PrepareSlaterDeterminant`, :class:`.InitializeModes`, :class:`.OrbitalRotation`,
+   :class:`.GivensDecompositionSlaterDeterminantSynthesis`, and the
+   :ref:`LUCJ guide <lucj_getting_started>` for the workflow that produces the global-initialization
+   pattern.

--- a/docs/guides/merge_slater_determinant.rst
+++ b/docs/guides/merge_slater_determinant.rst
@@ -1,7 +1,7 @@
 .. _merge_slater_determinant_explanation:
 
-Merge a mode initialization and rotation into a Slater determinant preparation
-==============================================================================
+Optimize Slater determinant preparation
+=======================================
 
 .. important::
 
@@ -25,21 +25,48 @@ reduced decomposition automatically. Under simulation the rewrite is a no-op on 
 and then applies the rotation, exactly as the two separate gates do), so the merge only unlocks the
 cheaper synthesis without changing the prepared state.
 
-Throughout this guide we inspect a circuit by listing its fermionic gates and the modes they act on,
-before and after the pass. This small helper does that by running the pass on a copy of the circuit
-and walking the resulting :class:`.FermionicDAGCircuit`:
+Throughout this guide we draw a circuit before and after the pass, side by side: the input on the
+left, and on the right the result of running the pass on it. These two helpers do that -- ``merge``
+runs the pass on a copy of the circuit (via its :class:`.FermionicDAGCircuit`) and converts the
+result back to a drawable :class:`.FermionicCircuit`, and ``draw_merge`` draws both halves into a
+single before/after figure:
 
-.. doctest::
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
 
+   >>> import matplotlib.pyplot as plt
+   >>> import numpy as np
+   >>>
+   >>> from qiskit_fermions.circuit import FermionicCircuit
+   >>> from qiskit_fermions.circuit.library import InitializeModes, OrbitalRotation
    >>> from qiskit_fermions.transpiler import FermionicCircuitToDAG
+   >>> from qiskit_fermions.transpiler.converters import FermionicDAGToCircuit
    >>> from qiskit_fermions.transpiler.passes import MergeSlaterDeterminantPreparation
    >>>
-   >>> def show_merged(circuit):
+   >>> def merge(circuit):
    ...     dag = FermionicCircuitToDAG().run(circuit)
    ...     merged = MergeSlaterDeterminantPreparation().run(dag)
-   ...     for node in merged.topological_op_nodes():
-   ...         modes = sorted(merged.find_bit(qubit).index for qubit in node.qargs)
-   ...         print(f"{node.op.name} on modes {modes}")
+   ...     return FermionicDAGToCircuit().run(merged)
+   >>>
+   >>> def natural_size(circuit):
+   ...     # the figure size Qiskit picks for a circuit on its own (discard the probe figure)
+   ...     probe = circuit.draw("mpl")
+   ...     size = probe.get_size_inches()
+   ...     plt.close(probe)
+   ...     return size
+   >>>
+   >>> def draw_merge(circuit):
+   ...     merged = merge(circuit)
+   ...     # let Qiskit size each half naturally, then lay them out side by side
+   ...     (bw, bh), (aw, ah) = natural_size(circuit), natural_size(merged)
+   ...     fig, (before, after) = plt.subplots(1, 2, figsize=(bw + aw, max(bh, ah)))
+   ...     circuit.draw("mpl", ax=before)
+   ...     merged.draw("mpl", ax=after)
+   ...     before.set_title("before")
+   ...     after.set_title("after")
+   ...     return fig
 
 What gets merged
 ----------------
@@ -55,19 +82,19 @@ Full-register (or spinless)
 
 The simplest pattern: an :class:`.InitializeModes` immediately followed by an
 :class:`.OrbitalRotation` on the *same* modes. This is the spinless case (one determinant over all
-modes) and also a spinful circuit whose rotation spans both sectors at once.
+modes) and also a spinful circuit whose rotation spans both sectors at once. The two gates fuse into
+a single :class:`.PrepareSlaterDeterminant`:
 
-.. doctest::
+.. plot::
+   :alt: A mode initialization and rotation fusing into one Slater determinant preparation.
+   :context: close-figs
+   :include-source:
 
-   >>> import numpy as np
-   >>> from qiskit_fermions.circuit import FermionicCircuit
-   >>> from qiskit_fermions.circuit.library import InitializeModes, OrbitalRotation
-   >>>
    >>> circuit = FermionicCircuit(4)
    >>> circuit.append(InitializeModes([1, 1, 0, 0]), circuit.modes)
    >>> circuit.append(OrbitalRotation(np.eye(4)), circuit.modes)
-   >>> show_merged(circuit)
-   PrepareSlaterDeterminant on modes [0, 1, 2, 3]
+   >>> draw_merge(circuit)
+   <Figure size ... with 2 Axes>
 
 Per spin sector
 ~~~~~~~~~~~~~~~
@@ -75,16 +102,18 @@ Per spin sector
 The same shape restricted to one spin half. Here two independent initialize-then-rotate pairs, one
 per sector, each fuse on their own into a :class:`.PrepareSlaterDeterminant`:
 
-.. doctest::
+.. plot::
+   :alt: Two per-sector initialize-and-rotate pairs, each fusing into its own preparation.
+   :context: close-figs
+   :include-source:
 
    >>> circuit = FermionicCircuit(6)  # norb = 3: alpha modes 0..3, beta modes 3..6
    >>> circuit.append(InitializeModes([1, 1, 0]), circuit.modes[:3])
    >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[:3])
    >>> circuit.append(InitializeModes([1, 0, 0]), circuit.modes[3:])
    >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[3:])
-   >>> show_merged(circuit)
-   PrepareSlaterDeterminant on modes [0, 1, 2]
-   PrepareSlaterDeterminant on modes [3, 4, 5]
+   >>> draw_merge(circuit)
+   <Figure size ... with 2 Axes>
 
 Global initialization, per-spin rotations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -100,15 +129,17 @@ a user places an :class:`.InitializeModes` -- typically the Hartree-Fock referen
 circuit and appends a :class:`.UCJ` ansatz, whose first two per-spin orbital rotations directly
 follow the initialization once the ansatz is decomposed.
 
-.. doctest::
+.. plot::
+   :alt: A global initialization with two per-spin rotations fusing into two preparations.
+   :context: close-figs
+   :include-source:
 
    >>> circuit = FermionicCircuit(6)  # norb = 3, nelec = (2, 1)
    >>> circuit.append(InitializeModes.from_hartree_fock(3, (2, 1)), circuit.modes)
    >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[:3])
    >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[3:])
-   >>> show_merged(circuit)
-   PrepareSlaterDeterminant on modes [0, 1, 2]
-   PrepareSlaterDeterminant on modes [3, 4, 5]
+   >>> draw_merge(circuit)
+   <Figure size ... with 2 Axes>
 
 This pattern also fires when only *one* spin half is rotated by a gate directly following the
 initialization -- the shape produced when just one spin sector's orbital rotation happens to sit at
@@ -118,14 +149,16 @@ synthesizes to nothing more than the reference X gates the :class:`.InitializeMo
 emitted for that half anyway, so padding it costs no extra gates while still unlocking the reduced
 Slater synthesis on the rotated half:
 
-.. doctest::
+.. plot::
+   :alt: A global initialization with a single per-spin rotation fusing into two preparations.
+   :context: close-figs
+   :include-source:
 
    >>> circuit = FermionicCircuit(6)
    >>> circuit.append(InitializeModes.from_hartree_fock(3, (2, 1)), circuit.modes)
    >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[:3])
-   >>> show_merged(circuit)
-   PrepareSlaterDeterminant on modes [0, 1, 2]
-   PrepareSlaterDeterminant on modes [3, 4, 5]
+   >>> draw_merge(circuit)
+   <Figure size ... with 2 Axes>
 
 What is left untouched
 ----------------------
@@ -133,7 +166,8 @@ What is left untouched
 The pass is deliberately conservative: it only fuses when the two gates genuinely compose into a
 Slater determinant preparation, and copies everything else through unchanged. "Immediately
 followed" is understood over the circuit's data-flow graph -- the :class:`.OrbitalRotation` fuses
-only when the :class:`.InitializeModes` is its *sole* predecessor across all of its modes.
+only when the :class:`.InitializeModes` is its *sole* predecessor across all of its modes. In the
+figures below the before and after are identical: nothing fused.
 
 An operation in between
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -141,7 +175,10 @@ An operation in between
 If any gate touches the modes between the initialization and the rotation, they no longer compose
 into a bare preparation, so nothing is merged:
 
-.. doctest::
+.. plot::
+   :alt: An operation between the initialization and rotation blocks the merge.
+   :context: close-figs
+   :include-source:
 
    >>> from qiskit_fermions.circuit.library import Evolution
    >>> from qiskit_fermions.operators import FermionOperator, ann, cre
@@ -151,10 +188,8 @@ into a bare preparation, so nothing is merged:
    >>> number_op = FermionOperator.from_dict({(cre(0), ann(0)): 1.0})
    >>> circuit.append(Evolution(4, number_op, time=0.5), circuit.modes)
    >>> circuit.append(OrbitalRotation(np.eye(4)), circuit.modes)
-   >>> show_merged(circuit)
-   InitializeModes on modes [0, 1, 2, 3]
-   Evolution on modes [0, 1, 2, 3]
-   OrbitalRotation on modes [0, 1, 2, 3]
+   >>> draw_merge(circuit)
+   <Figure size ... with 2 Axes>
 
 A partial rotation that is not a spin half
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -165,14 +200,16 @@ initialization and not one of its two spin halves, such as a sub-range straddlin
 boundary -- is not a per-sector preparation. Merging it would silently drop the initialization's
 role on the modes it leaves out, so the pass leaves both gates in place:
 
-.. doctest::
+.. plot::
+   :alt: A partial rotation that is not a spin half is left unmerged.
+   :context: close-figs
+   :include-source:
 
    >>> circuit = FermionicCircuit(4)  # norb = 2: the only spin halves are modes [0, 1] and [2, 3]
    >>> circuit.append(InitializeModes([1, 1, 0, 0]), circuit.modes)
    >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[:3])
-   >>> show_merged(circuit)
-   InitializeModes on modes [0, 1, 2, 3]
-   OrbitalRotation on modes [0, 1, 2]
+   >>> draw_merge(circuit)
+   <Figure size ... with 2 Axes>
 
 Why it matters: the synthesis payoff
 -------------------------------------
@@ -186,7 +223,10 @@ The preset Jordan-Wigner pass manager runs :class:`.MergeSlaterDeterminantPrepar
 optimization stage, so this reduction happens automatically. Here we transpile a two-electron,
 six-orbital preparation all the way to a :class:`~qiskit.circuit.QuantumCircuit` and count its gates:
 
-.. doctest::
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
 
    >>> from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager
    >>>
@@ -201,19 +241,40 @@ six-orbital preparation all the way to a :class:`~qiskit.circuit.QuantumCircuit`
    >>> circuit.append(OrbitalRotation(rotation), circuit.modes)
    >>>
    >>> pm = generate_preset_jw_pass_manager()
-   >>> print(dict(sorted(pm.run(circuit).count_ops().items())))
+   >>> prepared = pm.run(circuit)
+   >>> print(dict(sorted(prepared.count_ops().items())))
    {'x': 2, 'xx_plus_yy': 8}
+
+.. plot::
+   :alt: The synthesized merged Slater determinant preparation.
+   :context: close-figs
+   :include-source:
+
+   >>> prepared.draw("mpl", fold=-1)
+   <Figure size ... with 1 Axes>
 
 Compare that to synthesizing the same orbital rotation on its own -- with no preceding
 initialization there is nothing to merge, so the preset falls back to the full square
 decomposition, which is both deeper and carries diagonal phase gates:
 
-.. doctest::
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
 
    >>> reference = FermionicCircuit(6)
    >>> reference.append(OrbitalRotation(rotation), reference.modes)
-   >>> print(dict(sorted(pm.run(reference).count_ops().items())))
+   >>> reference_prepared = pm.run(reference)
+   >>> print(dict(sorted(reference_prepared.count_ops().items())))
    {'p': 6, 'xx_plus_yy': 15}
+
+.. plot::
+   :alt: The synthesized bare orbital rotation, with its extra phase gates.
+   :context: close-figs
+   :include-source:
+
+   >>> reference_prepared.draw("mpl", fold=-1)
+   <Figure size ... with 1 Axes>
 
 The reduced decomposition drops all six phase gates and nearly halves the two-qubit rotation count.
 The prepared determinant is correct up to a global phase -- physically irrelevant for state

--- a/docs/guides/merge_slater_determinant.rst
+++ b/docs/guides/merge_slater_determinant.rst
@@ -110,6 +110,23 @@ follow the initialization once the ansatz is decomposed.
    PrepareSlaterDeterminant on modes [0, 1, 2]
    PrepareSlaterDeterminant on modes [3, 4, 5]
 
+This pattern also fires when only *one* spin half is rotated by a gate directly following the
+initialization -- the shape produced when just one spin sector's orbital rotation happens to sit at
+the front of the circuit. The rotated half becomes a :class:`.PrepareSlaterDeterminant` with its
+rotation, and the other half is prepared with an *identity* rotation. The identity preparation
+synthesizes to nothing more than the reference X gates the :class:`.InitializeModes` would have
+emitted for that half anyway, so padding it costs no extra gates while still unlocking the reduced
+Slater synthesis on the rotated half:
+
+.. doctest::
+
+   >>> circuit = FermionicCircuit(6)
+   >>> circuit.append(InitializeModes.from_hartree_fock(3, (2, 1)), circuit.modes)
+   >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[:3])
+   >>> show_merged(circuit)
+   PrepareSlaterDeterminant on modes [0, 1, 2]
+   PrepareSlaterDeterminant on modes [3, 4, 5]
+
 What is left untouched
 ----------------------
 
@@ -139,36 +156,22 @@ into a bare preparation, so nothing is merged:
    Evolution on modes [0, 1, 2, 3]
    OrbitalRotation on modes [0, 1, 2, 3]
 
-Mismatched mode sets
-~~~~~~~~~~~~~~~~~~~~~
+A partial rotation that is not a spin half
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A rotation covering fewer modes than the initialization is not a full preparation of those modes.
-Merging it would silently drop the initialization's role on the modes the rotation leaves out, so
-the pass leaves both gates in place:
+A rotation covering exactly one contiguous spin half of a full-register initialization *does* fuse
+(see the previous section). But a rotation on any *other* partial mode set -- fewer modes than the
+initialization and not one of its two spin halves, such as a sub-range straddling the sector
+boundary -- is not a per-sector preparation. Merging it would silently drop the initialization's
+role on the modes it leaves out, so the pass leaves both gates in place:
 
 .. doctest::
 
-   >>> circuit = FermionicCircuit(4)
+   >>> circuit = FermionicCircuit(4)  # norb = 2: the only spin halves are modes [0, 1] and [2, 3]
    >>> circuit.append(InitializeModes([1, 1, 0, 0]), circuit.modes)
-   >>> circuit.append(OrbitalRotation(np.eye(2)), circuit.modes[:2])
-   >>> show_merged(circuit)
-   InitializeModes on modes [0, 1, 2, 3]
-   OrbitalRotation on modes [0, 1]
-
-Only one of the two per-spin rotations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For the global-initialization pattern, the pass fires only when *both* spin halves are rotated by
-gates that directly follow the initialization. With only one half rotated, fusing would drop the
-initialization's validation on the other half, so the whole pattern is left untouched:
-
-.. doctest::
-
-   >>> circuit = FermionicCircuit(6)
-   >>> circuit.append(InitializeModes.from_hartree_fock(3, (2, 1)), circuit.modes)
    >>> circuit.append(OrbitalRotation(np.eye(3)), circuit.modes[:3])
    >>> show_merged(circuit)
-   InitializeModes on modes [0, 1, 2, 3, 4, 5]
+   InitializeModes on modes [0, 1, 2, 3]
    OrbitalRotation on modes [0, 1, 2]
 
 Why it matters: the synthesis payoff

--- a/docs/guides/merge_slater_determinant.rst
+++ b/docs/guides/merge_slater_determinant.rst
@@ -223,6 +223,15 @@ The preset Jordan-Wigner pass manager runs :class:`.MergeSlaterDeterminantPrepar
 optimization stage, so this reduction happens automatically. Here we transpile a two-electron,
 six-orbital preparation all the way to a :class:`~qiskit.circuit.QuantumCircuit` and count its gates:
 
+.. note::
+   The preset runs :class:`.MergeOrbitalRotations` immediately before
+   :class:`.MergeSlaterDeterminantPreparation`. This matters when a *run* of consecutive
+   :class:`.OrbitalRotation` gates follows the initialization: the earlier pass first collapses the
+   run into a single rotation, which :class:`.MergeSlaterDeterminantPreparation` then contracts with
+   the initialization into one :class:`.PrepareSlaterDeterminant`. Without that ordering only the
+   first rotation of the run would be absorbed and the rest would synthesize with the full square
+   decomposition.
+
 .. plot::
    :context:
    :nofigs:
@@ -282,6 +291,7 @@ preparation -- which is exactly what the phase gates would have fixed.
 
 .. seealso::
    :class:`.PrepareSlaterDeterminant`, :class:`.InitializeModes`, :class:`.OrbitalRotation`,
+   :class:`.MergeOrbitalRotations`,
    :class:`.GivensDecompositionSlaterDeterminantSynthesis`, and the
    :ref:`LUCJ guide <lucj_getting_started>` for the workflow that produces the global-initialization
    pattern.

--- a/python/qiskit_fermions/transpiler/passes/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/__init__.py
@@ -32,6 +32,7 @@ These passes provide different kinds of optimization of :class:`.FermionicDAGCir
    :toctree: ../stubs/
 
    MergeOrbitalRotations
+   MergeSlaterDeterminantPreparation
    QDriftTrotterization
    RelabelModes
 
@@ -75,6 +76,7 @@ The main logic for mapping a :class:`.FermionicDAGCircuit` to a
 from .layout import CustomF2QLayout, TrivialF2QLayout
 from .optimization import (
     MergeOrbitalRotations,
+    MergeSlaterDeterminantPreparation,
     QDriftTrotterization,
     RelabelModes,
 )
@@ -99,6 +101,7 @@ __all__ = [
     "GivensDecompositionSlaterDeterminantSynthesis",
     "MapperFnEvolutionSynthesis",
     "MergeOrbitalRotations",
+    "MergeSlaterDeterminantPreparation",
     "QDriftTrotterization",
     "RelabelModes",
     "TrivialF2QLayout",

--- a/python/qiskit_fermions/transpiler/passes/optimization/__init__.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/__init__.py
@@ -12,12 +12,14 @@
 
 """Optimization passes."""
 
+from .merge_initialize_rotation import MergeSlaterDeterminantPreparation
 from .merge_orbital_rotations import MergeOrbitalRotations
 from .qdrift import QDriftTrotterization
 from .relabel_modes import RelabelModes
 
 __all__ = [
     "MergeOrbitalRotations",
+    "MergeSlaterDeterminantPreparation",
     "QDriftTrotterization",
     "RelabelModes",
 ]

--- a/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
@@ -70,12 +70,26 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
     above -- non-adjacent gates, mismatched mode sets, or an :class:`.OrbitalRotation` with no
     preceding :class:`.InitializeModes` -- is left untouched.
 
+    .. important::
+       Run this pass **after** :class:`.MergeOrbitalRotations`. The fusion contracts a *single*
+       :class:`.OrbitalRotation` immediately following the :class:`.InitializeModes`. Faced with an
+       initialization followed by a *run* of two or more consecutive rotations, this pass only sees
+       the first rotation immediately following the initialization -- it fuses that one into a
+       :class:`.PrepareSlaterDeterminant` but leaves the remaining rotations of the run as separate
+       trailing :class:`.OrbitalRotation` gates, which synthesize with their full (phase-carrying)
+       square decomposition. Running :class:`.MergeOrbitalRotations` first collapses the whole run
+       into one rotation, so this pass can then contract the entire run into a single
+       :class:`.PrepareSlaterDeterminant` and the cheaper Slater synthesis covers all of it. The
+       preset Jordan-Wigner pipeline (:func:`.generate_preset_jw_pass_manager`) wires the two passes
+       in this order.
+
     .. caution::
        This is an early development prototype. Beware of changes to its interface without warning
        during the pre-release development of this package.
 
     .. seealso::
-       :class:`.PrepareSlaterDeterminant`, :class:`.InitializeModes`, :class:`.OrbitalRotation`, and
+       :class:`.PrepareSlaterDeterminant`, :class:`.InitializeModes`, :class:`.OrbitalRotation`,
+       :class:`.MergeOrbitalRotations`, and
        :class:`.GivensDecompositionSlaterDeterminantSynthesis`.
     """
 

--- a/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
@@ -1,0 +1,204 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""An optimization pass fusing InitializeModes + OrbitalRotation into PrepareSlaterDeterminant."""
+
+from __future__ import annotations
+
+from qiskit.dagcircuit import DAGOpNode
+
+from qiskit_fermions.circuit import FermionicDAGCircuit
+from qiskit_fermions.circuit.library import (
+    InitializeModes,
+    OrbitalRotation,
+    PrepareSlaterDeterminant,
+)
+
+from ... import FermionicDAGCircuitPass
+
+
+class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
+    r"""A transpilation pass fusing an initialization and rotation into a Slater determinant prep.
+
+    An :class:`.InitializeModes` immediately followed by an :class:`.OrbitalRotation` prepares a
+    Slater determinant: the modes start in the reference occupation and are then rotated into the
+    target single-particle basis. This pass detects that pattern in a :class:`.FermionicDAGCircuit`
+    and rewrites it into a single :class:`.PrepareSlaterDeterminant` gate, which a later synthesis
+    stage can lower with the reduced-gate-count :func:`.givens_decomposition_slater` (via
+    :class:`.GivensDecompositionSlaterDeterminantSynthesis`) rather than the full square orbital
+    rotation.
+
+    Because :class:`.PrepareSlaterDeterminant` is *validate-then-rotate* under simulation -- it
+    validates the reference occupation and then applies the rotation, exactly as the separate
+    :class:`.InitializeModes` and :class:`.OrbitalRotation` gates do -- the rewrite leaves the
+    simulated state vector unchanged; it only unlocks the cheaper synthesis.
+
+    Three patterns are recognized, all keyed off the block-spin mode convention
+    (modes ``0..norb`` are the alpha sector, ``norb..2*norb`` the beta sector):
+
+    1. **Full-register / spinless** -- an :class:`.InitializeModes` on a mode set immediately
+       followed by an :class:`.OrbitalRotation` on the *same* mode set fuses into one
+       :class:`.PrepareSlaterDeterminant`.
+    2. **Per-sector** -- the same shape as pattern 1 but on a single spin half; it fuses into one
+       :class:`.PrepareSlaterDeterminant` per sector.
+    3. **Global init + per-spin rotations** -- a full-register (``2*norb``) :class:`.InitializeModes`
+       immediately followed by two :class:`.OrbitalRotation`\ s, one on each contiguous spin half
+       (in either order), splits the occupation per sector and emits **two**
+       :class:`.PrepareSlaterDeterminant` gates. This is the shape produced by placing an
+       :class:`.InitializeModes` (e.g. :meth:`.InitializeModes.from_hartree_fock`) at the front of a
+       circuit and appending a decomposed :class:`.UCJ`, whose first two per-spin rotations directly
+       follow the initialization.
+
+    "Immediately followed" is understood over the DAG: an :class:`.OrbitalRotation` node fuses only
+    when the :class:`.InitializeModes` is its *sole* predecessor across all of its modes, i.e. no
+    other operation intervenes on those wires. Any arrangement not matching one of the three shapes
+    above -- non-adjacent gates, mismatched mode sets, an :class:`.OrbitalRotation` with no preceding
+    :class:`.InitializeModes`, or only one of the two per-spin rotations present -- is left untouched.
+
+    .. caution::
+       This is an early development prototype. Beware of changes to its interface without warning
+       during the pre-release development of this package.
+
+    .. seealso::
+       :class:`.PrepareSlaterDeterminant`, :class:`.InitializeModes`, :class:`.OrbitalRotation`, and
+       :class:`.GivensDecompositionSlaterDeterminantSynthesis`.
+    """
+
+    def run(self, dag: FermionicDAGCircuit) -> FermionicDAGCircuit:
+        """Runs this transpilation pass.
+
+        Walks the input DAG in topological order, rewriting each matched
+        :class:`.InitializeModes`-then-:class:`.OrbitalRotation` pattern into
+        :class:`.PrepareSlaterDeterminant` gate(s) and copying every other node through unchanged.
+
+        Args:
+            dag: the input circuit with fermion-based instructions. Only
+                :class:`~qiskit.dagcircuit.DAGOpNode` with :class:`.FermionicGate` instances as their
+                :attr:`~qiskit.dagcircuit.DAGOpNode.op` are supported.
+
+        Returns:
+            The output circuit which is still acting on a fermionic register.
+
+        Raises:
+            NotImplementedError: when the provided input circuit has more than a single register.
+        """
+        if len(dag.qregs) > 1:
+            raise NotImplementedError(
+                "Cannot apply the MergeSlaterDeterminantPreparation pass to a circuit with more "
+                "than a single register."
+            )
+
+        # Plan the rewrites before emitting anything: map each matched InitializeModes node to the
+        # replacement gate(s) it produces, and collect the OrbitalRotation nodes those replacements
+        # consume so they are not re-emitted when the topological walk reaches them.
+        replacements: dict[int, list[tuple[PrepareSlaterDeterminant, list[int]]]] = {}
+        consumed: set[int] = set()
+        for node in dag.topological_op_nodes():
+            if not isinstance(node.op, InitializeModes) or node._node_id in consumed:
+                continue
+            match = self._match(dag, node)
+            if match is None:
+                continue
+            gates, consumed_rotations = match
+            replacements[node._node_id] = gates
+            consumed.update(consumed_rotations)
+
+        out_dag = dag.copy_empty_like()
+        (register,) = out_dag.qregs.values()
+        for node in dag.topological_op_nodes():
+            if node._node_id in consumed:
+                # an OrbitalRotation already folded into a PrepareSlaterDeterminant at its init
+                continue
+            if node._node_id in replacements:
+                for gate, modes in replacements[node._node_id]:
+                    out_dag.apply_operation_back(gate, qargs=[register[m] for m in modes])
+                continue
+            out_dag.apply_operation_back(node.op, qargs=node.qargs)
+
+        return out_dag
+
+    def _match(
+        self, dag: FermionicDAGCircuit, init_node: DAGOpNode
+    ) -> tuple[list[tuple[PrepareSlaterDeterminant, list[int]]], list[int]] | None:
+        """Matches one of the three fusion patterns rooted at an ``InitializeModes`` node.
+
+        Returns ``None`` when nothing matches. Otherwise returns a pair ``(gates, consumed)`` where
+        ``gates`` is the list of ``(PrepareSlaterDeterminant, modes)`` replacements to emit in place
+        of the initialization and ``consumed`` the node ids of the ``OrbitalRotation`` nodes folded
+        into them.
+        """
+        init_modes = self._modes(dag, init_node)
+
+        # gather the OrbitalRotation successors for which this InitializeModes is the sole predecessor
+        # across all their wires (i.e. they immediately follow it, nothing intervening)
+        rotations = [
+            succ
+            for succ in dag.quantum_successors(init_node)
+            if isinstance(succ, DAGOpNode)
+            and isinstance(succ.op, OrbitalRotation)
+            and self._immediately_follows(dag, init_node, succ)
+        ]
+
+        occupation = init_node.op.occupation
+
+        # Pattern 1 / 2: a single rotation on exactly the initialized modes.
+        if len(rotations) == 1:
+            (rotation,) = rotations
+            if self._modes(dag, rotation) == init_modes:
+                gate = PrepareSlaterDeterminant(occupation, rotation.op.rotation_unitary)
+                return [(gate, init_modes)], [rotation._node_id]
+            return None
+
+        # Pattern 3: a full-register init split by two per-spin rotations on the two contiguous halves.
+        if len(rotations) == 2:
+            num_modes = len(init_modes)
+            if num_modes % 2 != 0 or init_modes != list(range(num_modes)):
+                return None
+            norb = num_modes // 2
+            alpha_modes = list(range(norb))
+            beta_modes = list(range(norb, num_modes))
+
+            by_modes = {tuple(self._modes(dag, rot)): rot for rot in rotations}
+            alpha_rot = by_modes.get(tuple(alpha_modes))
+            beta_rot = by_modes.get(tuple(beta_modes))
+            if alpha_rot is None or beta_rot is None:
+                return None
+
+            alpha_gate = PrepareSlaterDeterminant(occupation[:norb], alpha_rot.op.rotation_unitary)
+            beta_gate = PrepareSlaterDeterminant(occupation[norb:], beta_rot.op.rotation_unitary)
+            return (
+                [(alpha_gate, alpha_modes), (beta_gate, beta_modes)],
+                [alpha_rot._node_id, beta_rot._node_id],
+            )
+
+        return None
+
+    @staticmethod
+    def _modes(dag: FermionicDAGCircuit, node: DAGOpNode) -> list[int]:
+        """Returns the sorted global mode indices a node acts on."""
+        return sorted(dag.find_bit(qubit).index for qubit in node.qargs)
+
+    @staticmethod
+    def _immediately_follows(
+        dag: FermionicDAGCircuit, init_node: DAGOpNode, rotation: DAGOpNode
+    ) -> bool:
+        """Whether ``rotation`` directly follows ``init_node`` on every one of its wires.
+
+        This holds exactly when the only quantum predecessor of ``rotation`` is ``init_node``: any
+        intervening operation on one of ``rotation``'s modes would appear as a different predecessor,
+        so requiring a single predecessor guarantees the initialization feeds the rotation directly
+        and covers all of its modes.
+        """
+        predecessors = [
+            pred for pred in dag.quantum_predecessors(rotation) if isinstance(pred, DAGOpNode)
+        ]
+        return len(predecessors) == 1 and predecessors[0]._node_id == init_node._node_id

--- a/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
@@ -123,7 +123,7 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
         replacements: dict[int, list[tuple[PrepareSlaterDeterminant, list[int]]]] = {}
         consumed: set[int] = set()
         for node in dag.topological_op_nodes():
-            if not isinstance(node.op, InitializeModes) or node._node_id in consumed:
+            if not isinstance(node.op, InitializeModes):
                 continue
             match = self._match(dag, node)
             if match is None:
@@ -228,12 +228,15 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
     def _immediately_follows(
         dag: FermionicDAGCircuit, init_node: DAGOpNode, rotation: DAGOpNode
     ) -> bool:
-        """Whether ``rotation`` directly follows ``init_node`` on every one of its wires.
+        """Whether ``init_node`` is the sole operation feeding ``rotation``, nothing intervening.
 
-        This holds exactly when the only quantum predecessor of ``rotation`` is ``init_node``: any
-        intervening operation on one of ``rotation``'s modes would appear as a different predecessor,
-        so requiring a single predecessor guarantees the initialization feeds the rotation directly
-        and covers all of its modes.
+        This holds exactly when the only quantum-predecessor *op node* of ``rotation`` is
+        ``init_node``: any operation intervening on one of ``rotation``'s modes would appear as a
+        different predecessor. (Register-boundary ``DAGInNode`` predecessors are filtered out first,
+        so a rotation wire that the initialization does not cover contributes no op-predecessor
+        rather than a disqualifying one -- this check therefore does *not* by itself guarantee the
+        initialization covers all of the rotation's modes; :meth:`_match` enforces that separately
+        via its per-pattern mode-set checks before fusing.)
         """
         predecessors = [
             pred for pred in dag.quantum_predecessors(rotation) if isinstance(pred, DAGOpNode)

--- a/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
@@ -119,9 +119,10 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
 
         # Plan the rewrites before emitting anything: map each matched InitializeModes node to the
         # replacement gate(s) it produces, and collect the OrbitalRotation nodes those replacements
-        # consume so they are not re-emitted when the topological walk reaches them.
-        replacements: dict[int, list[tuple[PrepareSlaterDeterminant, list[int]]]] = {}
-        consumed: set[int] = set()
+        # consume so they are not re-emitted when the topological walk reaches them. DAG nodes are
+        # hashable and compare by identity (node id), so we key on the nodes directly.
+        replacements: dict[DAGOpNode, list[tuple[PrepareSlaterDeterminant, list[int]]]] = {}
+        consumed: set[DAGOpNode] = set()
         for node in dag.topological_op_nodes():
             if not isinstance(node.op, InitializeModes):
                 continue
@@ -129,17 +130,17 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
             if match is None:
                 continue
             gates, consumed_rotations = match
-            replacements[node._node_id] = gates
+            replacements[node] = gates
             consumed.update(consumed_rotations)
 
         out_dag = dag.copy_empty_like()
         (register,) = out_dag.qregs.values()
         for node in dag.topological_op_nodes():
-            if node._node_id in consumed:
+            if node in consumed:
                 # an OrbitalRotation already folded into a PrepareSlaterDeterminant at its init
                 continue
-            if node._node_id in replacements:
-                for gate, modes in replacements[node._node_id]:
+            if node in replacements:
+                for gate, modes in replacements[node]:
                     out_dag.apply_operation_back(gate, qargs=[register[m] for m in modes])
                 continue
             out_dag.apply_operation_back(node.op, qargs=node.qargs)
@@ -148,13 +149,12 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
 
     def _match(
         self, dag: FermionicDAGCircuit, init_node: DAGOpNode
-    ) -> tuple[list[tuple[PrepareSlaterDeterminant, list[int]]], list[int]] | None:
+    ) -> tuple[list[tuple[PrepareSlaterDeterminant, list[int]]], list[DAGOpNode]] | None:
         """Matches one of the three fusion patterns rooted at an ``InitializeModes`` node.
 
         Returns ``None`` when nothing matches. Otherwise returns a pair ``(gates, consumed)`` where
         ``gates`` is the list of ``(PrepareSlaterDeterminant, modes)`` replacements to emit in place
-        of the initialization and ``consumed`` the node ids of the ``OrbitalRotation`` nodes folded
-        into them.
+        of the initialization and ``consumed`` the ``OrbitalRotation`` nodes folded into them.
         """
         init_modes = self._modes(dag, init_node)
 
@@ -179,7 +179,7 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
             (rotation,) = rotations
             if self._modes(dag, rotation) == init_modes:
                 gate = PrepareSlaterDeterminant(occupation, rotation.op.rotation_unitary)
-                return [(gate, init_modes)], [rotation._node_id]
+                return [(gate, init_modes)], [rotation]
             # otherwise fall through: it may be a per-spin rotation on one half of a full register
 
         # Pattern 3: a full-register init whose two contiguous spin halves are rotated by per-spin
@@ -205,7 +205,7 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
             return None
 
         gates: list[tuple[PrepareSlaterDeterminant, list[int]]] = []
-        consumed: list[int] = []
+        consumed: list[DAGOpNode] = []
         for rot, modes, occ in (
             (alpha_rot, alpha_modes, occupation[:norb]),
             (beta_rot, beta_modes, occupation[norb:]),
@@ -214,7 +214,7 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
                 unitary = np.eye(norb, dtype=complex)
             else:
                 unitary = rot.op.rotation_unitary
-                consumed.append(rot._node_id)
+                consumed.append(rot)
             gates.append((PrepareSlaterDeterminant(occ, unitary), modes))
 
         return gates, consumed
@@ -241,4 +241,6 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
         predecessors = [
             pred for pred in dag.quantum_predecessors(rotation) if isinstance(pred, DAGOpNode)
         ]
-        return len(predecessors) == 1 and predecessors[0]._node_id == init_node._node_id
+        # DAG nodes compare by identity (node id), so `==` matches the same node even when the DAG
+        # hands back a distinct wrapper instance for it.
+        return len(predecessors) == 1 and predecessors[0] == init_node

--- a/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
@@ -38,10 +38,8 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
     :class:`.GivensDecompositionSlaterDeterminantSynthesis`) rather than the full square orbital
     rotation.
 
-    Because :class:`.PrepareSlaterDeterminant` is *validate-then-rotate* under simulation -- it
-    validates the reference occupation and then applies the rotation, exactly as the separate
-    :class:`.InitializeModes` and :class:`.OrbitalRotation` gates do -- the rewrite leaves the
-    simulated state vector unchanged; it only unlocks the cheaper synthesis.
+    The rewrite is state-preserving: it only unlocks the cheaper synthesis and leaves the prepared
+    state unchanged (see the *validate-then-rotate* semantics of :class:`.PrepareSlaterDeterminant`).
 
     Three patterns are recognized, all keyed off the block-spin mode convention
     (modes ``0..norb`` are the alpha sector, ``norb..2*norb`` the beta sector):
@@ -61,6 +59,10 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
        shape produced by placing an :class:`.InitializeModes` (e.g.
        :meth:`.InitializeModes.from_hartree_fock`) at the front of a circuit and appending a decomposed
        :class:`.UCJ`, whose first per-spin rotations directly follow the initialization.
+
+    .. seealso::
+       The :ref:`Slater determinant preparation guide <merge_slater_determinant_explanation>` walks
+       through each of these patterns with before/after circuit drawings.
 
     "Immediately followed" is understood over the DAG: an :class:`.OrbitalRotation` node fuses only
     when the :class:`.InitializeModes` is its *sole* predecessor across all of its modes, i.e. no

--- a/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/merge_initialize_rotation.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 from qiskit.dagcircuit import DAGOpNode
 
 from qiskit_fermions.circuit import FermionicDAGCircuit
@@ -51,18 +52,21 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
     2. **Per-sector** -- the same shape as pattern 1 but on a single spin half; it fuses into one
        :class:`.PrepareSlaterDeterminant` per sector.
     3. **Global init + per-spin rotations** -- a full-register (``2*norb``) :class:`.InitializeModes`
-       immediately followed by two :class:`.OrbitalRotation`\ s, one on each contiguous spin half
-       (in either order), splits the occupation per sector and emits **two**
-       :class:`.PrepareSlaterDeterminant` gates. This is the shape produced by placing an
-       :class:`.InitializeModes` (e.g. :meth:`.InitializeModes.from_hartree_fock`) at the front of a
-       circuit and appending a decomposed :class:`.UCJ`, whose first two per-spin rotations directly
-       follow the initialization.
+       immediately followed by an :class:`.OrbitalRotation` on *either or both* contiguous spin halves
+       (in either order) splits the occupation per sector and emits **two**
+       :class:`.PrepareSlaterDeterminant` gates. A half that has no rotation is prepared with an
+       identity rotation, which synthesizes to only the reference X gates -- exactly what the
+       :class:`.InitializeModes` would have emitted for that half anyway -- so padding it costs no
+       extra gates while still unlocking the reduced Slater synthesis on the rotated half. This is the
+       shape produced by placing an :class:`.InitializeModes` (e.g.
+       :meth:`.InitializeModes.from_hartree_fock`) at the front of a circuit and appending a decomposed
+       :class:`.UCJ`, whose first per-spin rotations directly follow the initialization.
 
     "Immediately followed" is understood over the DAG: an :class:`.OrbitalRotation` node fuses only
     when the :class:`.InitializeModes` is its *sole* predecessor across all of its modes, i.e. no
     other operation intervenes on those wires. Any arrangement not matching one of the three shapes
-    above -- non-adjacent gates, mismatched mode sets, an :class:`.OrbitalRotation` with no preceding
-    :class:`.InitializeModes`, or only one of the two per-spin rotations present -- is left untouched.
+    above -- non-adjacent gates, mismatched mode sets, or an :class:`.OrbitalRotation` with no
+    preceding :class:`.InitializeModes` -- is left untouched.
 
     .. caution::
        This is an early development prototype. Beware of changes to its interface without warning
@@ -148,6 +152,10 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
             and self._immediately_follows(dag, init_node, succ)
         ]
 
+        if not rotations:
+            # a bare InitializeModes with no rotation immediately following it: nothing to fuse
+            return None
+
         occupation = init_node.op.occupation
 
         # Pattern 1 / 2: a single rotation on exactly the initialized modes.
@@ -156,31 +164,44 @@ class MergeSlaterDeterminantPreparation(FermionicDAGCircuitPass):
             if self._modes(dag, rotation) == init_modes:
                 gate = PrepareSlaterDeterminant(occupation, rotation.op.rotation_unitary)
                 return [(gate, init_modes)], [rotation._node_id]
+            # otherwise fall through: it may be a per-spin rotation on one half of a full register
+
+        # Pattern 3: a full-register init whose two contiguous spin halves are rotated by per-spin
+        # OrbitalRotations. Fires with one *or* both halves rotated -- an unrotated half is prepared
+        # with an identity rotation, which synthesizes to just the reference X gates (no extra gates),
+        # so padding the missing half costs nothing while still unlocking the reduced Slater synthesis
+        # on the rotated half.
+        num_modes = len(init_modes)
+        if num_modes % 2 != 0 or init_modes != list(range(num_modes)):
+            return None
+        norb = num_modes // 2
+        alpha_modes = list(range(norb))
+        beta_modes = list(range(norb, num_modes))
+
+        by_modes = {tuple(self._modes(dag, rot)): rot for rot in rotations}
+        alpha_rot = by_modes.get(tuple(alpha_modes))
+        beta_rot = by_modes.get(tuple(beta_modes))
+        # every gathered rotation must sit on exactly one of the two halves -- otherwise this is not
+        # the per-spin shape (e.g. a rotation on a partial sub-range straddling the sector boundary).
+        # At least one rotation exists here (bare inits returned above), so this also guarantees at
+        # least one half is rotated.
+        if len(rotations) != (alpha_rot is not None) + (beta_rot is not None):
             return None
 
-        # Pattern 3: a full-register init split by two per-spin rotations on the two contiguous halves.
-        if len(rotations) == 2:
-            num_modes = len(init_modes)
-            if num_modes % 2 != 0 or init_modes != list(range(num_modes)):
-                return None
-            norb = num_modes // 2
-            alpha_modes = list(range(norb))
-            beta_modes = list(range(norb, num_modes))
+        gates: list[tuple[PrepareSlaterDeterminant, list[int]]] = []
+        consumed: list[int] = []
+        for rot, modes, occ in (
+            (alpha_rot, alpha_modes, occupation[:norb]),
+            (beta_rot, beta_modes, occupation[norb:]),
+        ):
+            if rot is None:
+                unitary = np.eye(norb, dtype=complex)
+            else:
+                unitary = rot.op.rotation_unitary
+                consumed.append(rot._node_id)
+            gates.append((PrepareSlaterDeterminant(occ, unitary), modes))
 
-            by_modes = {tuple(self._modes(dag, rot)): rot for rot in rotations}
-            alpha_rot = by_modes.get(tuple(alpha_modes))
-            beta_rot = by_modes.get(tuple(beta_modes))
-            if alpha_rot is None or beta_rot is None:
-                return None
-
-            alpha_gate = PrepareSlaterDeterminant(occupation[:norb], alpha_rot.op.rotation_unitary)
-            beta_gate = PrepareSlaterDeterminant(occupation[norb:], beta_rot.op.rotation_unitary)
-            return (
-                [(alpha_gate, alpha_modes), (beta_gate, beta_modes)],
-                [alpha_rot._node_id, beta_rot._node_id],
-            )
-
-        return None
+        return gates, consumed
 
     @staticmethod
     def _modes(dag: FermionicDAGCircuit, node: DAGOpNode) -> list[int]:

--- a/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
+++ b/python/qiskit_fermions/transpiler/presets/jordan_wigner.py
@@ -22,6 +22,7 @@ from ..passes import (
     F2QSynthesis,
     F2QSynthesisConfig,
     MergeOrbitalRotations,
+    MergeSlaterDeterminantPreparation,
     TrivialF2QLayout,
 )
 
@@ -37,9 +38,15 @@ def generate_preset_jw_pass_manager(**kwargs) -> MultiStagePassManager:
     Returns:
         The preset staged fermion-to-qubit transpiler pipeline.
     """
-    # merge any run of consecutive OrbitalRotation gates into a single rotation, so the synthesis
-    # stage below lowers one decomposition per run rather than one per gate
-    optimization = FermionicPassManager(MergeOrbitalRotations())
+    # First merge any run of consecutive OrbitalRotation gates into a single rotation, so the
+    # synthesis stage below lowers one decomposition per run rather than one per gate. Then fuse an
+    # InitializeModes followed by an OrbitalRotation into a single PrepareSlaterDeterminant so that
+    # synthesis can lower it with the reduced Slater decomposition rather than the full square
+    # orbital rotation. The order matters: merging the rotations first exposes the single rotation
+    # immediately following the initialization, which the Slater-prep fusion then contracts into it.
+    optimization = FermionicPassManager(
+        [MergeOrbitalRotations(), MergeSlaterDeterminantPreparation()]
+    )
 
     layout = FermionicPassManager(TrivialF2QLayout())
 

--- a/tests/python/transpiler/passes/test_merge_initialize_rotation.py
+++ b/tests/python/transpiler/passes/test_merge_initialize_rotation.py
@@ -1,0 +1,272 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the MergeSlaterDeterminantPreparation optimization pass."""
+
+from __future__ import annotations
+
+import numpy as np
+from qiskit.passmanager import MultiStagePassManager
+from qiskit.quantum_info import Statevector
+from qiskit_fermions.circuit import FermionicCircuit
+from qiskit_fermions.circuit.library import (
+    UCJ,
+    Evolution,
+    InitializeModes,
+    OrbitalRotation,
+    PrepareSlaterDeterminant,
+)
+from qiskit_fermions.operators import FermionOperator
+from qiskit_fermions.operators.fermion_action import ann, cre
+from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
+from qiskit_fermions.transpiler.passes import (
+    F2QSynthesis,
+    GivensDecompositionOrbitalRotationSynthesis,
+    GivensDecompositionSlaterDeterminantSynthesis,
+    MergeSlaterDeterminantPreparation,
+    TrivialF2QLayout,
+    TrivialOccupationInitializeModesSynthesis,
+)
+
+from ...utils import random_unitary
+
+
+def _nodes(dag) -> list[tuple[str, list[int]]]:
+    """Returns the ``(op name, sorted global mode indices)`` of a DAG in topological order."""
+    return [
+        (node.op.name, sorted(dag.find_bit(qubit).index for qubit in node.qargs))
+        for node in dag.topological_op_nodes()
+    ]
+
+
+def _merge(circ: FermionicCircuit) -> list[tuple[str, list[int]]]:
+    """Runs the merge pass on ``circ`` and returns its post-merge node list."""
+    dag = FermionicCircuitToDAG().run(circ)
+    out = MergeSlaterDeterminantPreparation().run(dag)
+    return _nodes(out)
+
+
+def _block_diag(mat_a: np.ndarray, mat_b: np.ndarray) -> np.ndarray:
+    """Assembles a block-spin orbital rotation from independent alpha/beta rotations."""
+    norb = mat_a.shape[0]
+    full = np.zeros((2 * norb, 2 * norb), dtype=complex)
+    full[:norb, :norb] = mat_a
+    full[norb:, norb:] = mat_b
+    return full
+
+
+# --- positive cases: the three supported patterns fuse -----------------------------------------
+
+
+def test_merge_full_sector():
+    """An InitializeModes followed by an OrbitalRotation on the same modes fuses into one gate."""
+    circ = FermionicCircuit(4)
+    circ.append(InitializeModes([1, 1, 0, 0]), circ.modes)
+    circ.append(OrbitalRotation(random_unitary(4, seed=1)), circ.modes)
+
+    assert _merge(circ) == [("PrepareSlaterDeterminant", [0, 1, 2, 3])]
+
+
+def test_merge_per_sector():
+    """Two separate per-sector init+rotation pairs each fuse independently."""
+    circ = FermionicCircuit(4)
+    circ.append(InitializeModes([1, 0]), circ.modes[:2])
+    circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes[:2])
+    circ.append(InitializeModes([1, 0]), circ.modes[2:])
+    circ.append(OrbitalRotation(random_unitary(2, seed=2)), circ.modes[2:])
+
+    assert _merge(circ) == [
+        ("PrepareSlaterDeterminant", [0, 1]),
+        ("PrepareSlaterDeterminant", [2, 3]),
+    ]
+
+
+def test_merge_global_init_per_spin_rotations():
+    """A full-register init split by two per-spin rotations emits two gates (one per sector)."""
+    circ = FermionicCircuit(4)
+    circ.append(InitializeModes([1, 0, 1, 0]), circ.modes)
+    circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes[:2])
+    circ.append(OrbitalRotation(random_unitary(2, seed=2)), circ.modes[2:])
+
+    assert _merge(circ) == [
+        ("PrepareSlaterDeterminant", [0, 1]),
+        ("PrepareSlaterDeterminant", [2, 3]),
+    ]
+
+
+def test_merge_global_init_per_spin_rotations_beta_first():
+    """Pattern 3 fires regardless of the order the two per-spin rotations appear in."""
+    circ = FermionicCircuit(4)
+    circ.append(InitializeModes([1, 0, 1, 0]), circ.modes)
+    circ.append(OrbitalRotation(random_unitary(2, seed=2)), circ.modes[2:])
+    circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes[:2])
+
+    assert _merge(circ) == [
+        ("PrepareSlaterDeterminant", [0, 1]),
+        ("PrepareSlaterDeterminant", [2, 3]),
+    ]
+
+
+def test_merge_splits_occupation_per_sector():
+    """Pattern 3 splits the global occupation at the sector boundary onto the two gates."""
+    circ = FermionicCircuit(4)
+    circ.append(InitializeModes([True, False, False, True]), circ.modes)
+    circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes[:2])
+    circ.append(OrbitalRotation(random_unitary(2, seed=2)), circ.modes[2:])
+
+    dag = FermionicCircuitToDAG().run(circ)
+    out = MergeSlaterDeterminantPreparation().run(dag)
+    gates = [node.op for node in out.topological_op_nodes()]
+
+    assert all(isinstance(gate, PrepareSlaterDeterminant) for gate in gates)
+    alpha, beta = gates
+    np.testing.assert_array_equal(alpha.occupation, [True, False])
+    np.testing.assert_array_equal(beta.occupation, [False, True])
+
+
+# --- negative cases: unmatched shapes are left untouched ----------------------------------------
+
+
+def test_no_merge_when_not_adjacent():
+    """An operation between the init and rotation blocks the fusion."""
+    circ = FermionicCircuit(2)
+    circ.append(InitializeModes([1, 0]), circ.modes)
+    number_op = FermionOperator.from_dict({(cre(0), ann(0)): 1.0})
+    circ.append(Evolution(2, number_op, time=0.5), circ.modes)
+    circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes)
+
+    assert _merge(circ) == [
+        ("InitializeModes", [0, 1]),
+        ("Evolution", [0, 1]),
+        ("OrbitalRotation", [0, 1]),
+    ]
+
+
+def test_no_merge_when_mode_sets_mismatch():
+    """A single rotation covering fewer modes than the init does not fuse."""
+    circ = FermionicCircuit(4)
+    circ.append(InitializeModes([1, 1, 0, 0]), circ.modes)
+    circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes[:2])
+
+    assert _merge(circ) == [
+        ("InitializeModes", [0, 1, 2, 3]),
+        ("OrbitalRotation", [0, 1]),
+    ]
+
+
+def test_no_merge_rotation_without_init():
+    """An OrbitalRotation with no preceding InitializeModes is left untouched."""
+    circ = FermionicCircuit(2)
+    circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes)
+
+    assert _merge(circ) == [("OrbitalRotation", [0, 1])]
+
+
+def test_no_merge_only_one_per_spin_rotation():
+    """A full-register init followed by only one per-spin rotation does not fuse.
+
+    Fusing here would drop the init's validation on the beta half, so the pass conservatively
+    leaves the whole pattern untouched.
+    """
+    circ = FermionicCircuit(4)
+    circ.append(InitializeModes([1, 0, 1, 0]), circ.modes)
+    circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes[:2])
+
+    assert _merge(circ) == [
+        ("InitializeModes", [0, 1, 2, 3]),
+        ("OrbitalRotation", [0, 1]),
+    ]
+
+
+# --- equivalence + payoff -----------------------------------------------------------------------
+
+
+def _reference_synth() -> F2QSynthesis:
+    """The trusted square path for a separate InitializeModes + OrbitalRotation."""
+    synth = F2QSynthesis()
+    synth.methods["InitializeModes"] = TrivialOccupationInitializeModesSynthesis()
+    synth.methods["OrbitalRotation"] = GivensDecompositionOrbitalRotationSynthesis()
+    return synth
+
+
+def _merged_synth() -> F2QSynthesis:
+    """The reduced Slater path plus the square fallbacks for anything not fused."""
+    synth = _reference_synth()
+    synth.methods["PrepareSlaterDeterminant"] = GivensDecompositionSlaterDeterminantSynthesis()
+    return synth
+
+
+def _assert_equal_up_to_global_phase(qc_a, qc_b):
+    sv_a = Statevector(qc_a).data
+    sv_b = Statevector(qc_b).data
+    k = int(np.argmax(np.abs(sv_b)))
+    phase = sv_a[k] / sv_b[k]
+    np.testing.assert_allclose(sv_a, phase * sv_b, atol=1e-10)
+
+
+def test_merge_preserves_state_and_reduces_gate_count():
+    """Transpiling the merged circuit yields the same state, with fewer gates and no phases."""
+    circ = FermionicCircuit(4)
+    circ.append(InitializeModes([1, 1, 0, 0]), circ.modes)
+    circ.append(OrbitalRotation(random_unitary(4, seed=9)), circ.modes)
+
+    reference = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=_reference_synth(),
+        output=QuantumDAGToCircuit(),
+    ).run(circ)
+    merged = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        optimization=MergeSlaterDeterminantPreparation(),
+        layout=TrivialF2QLayout(),
+        synthesis=_merged_synth(),
+        output=QuantumDAGToCircuit(),
+    ).run(circ)
+
+    _assert_equal_up_to_global_phase(reference, merged)
+
+    ref_ops = reference.count_ops()
+    merged_ops = merged.count_ops()
+    assert merged_ops.get("xx_plus_yy", 0) < ref_ops.get("xx_plus_yy", 0)
+    # the reduced decomposition carries no diagonal phase gates
+    assert "p" not in merged_ops
+
+
+def test_merge_ucj_workflow():
+    """The InitializeModes.from_hartree_fock + decomposed UCJ workflow fuses (pattern 3).
+
+    A user places an :class:`.InitializeModes` at the front and appends a :class:`.UCJ`. After
+    ``decompose()`` the ansatz expands to per-spin rotations and evolutions; the leading init and
+    the ansatz's first two per-spin rotations directly follow one another and must fuse into two
+    :class:`.PrepareSlaterDeterminant` gates. The later rotations follow an :class:`.Evolution`, not
+    the init, and are correctly left untouched.
+    """
+    norb, nelec, n_reps = 2, (1, 1), 1
+    diag_coulomb_mats = np.zeros((n_reps, 2, norb, norb))
+    orbital_rotations = np.stack([random_unitary(norb, seed=5) for _ in range(n_reps)])
+    ucj = UCJ(norb, nelec, diag_coulomb_mats, orbital_rotations)
+
+    circ = FermionicCircuit(2 * norb)
+    circ.append(InitializeModes.from_hartree_fock(norb, nelec), circ.modes)
+    circ.append(ucj, circ.modes)
+
+    merged = _merge(circ.decompose())
+
+    # the two leading per-spin rotations fused; the post-Evolution rotations remain
+    assert merged[:2] == [
+        ("PrepareSlaterDeterminant", [0, 1]),
+        ("PrepareSlaterDeterminant", [2, 3]),
+    ]
+    assert ("Evolution", [0, 1, 2, 3]) in merged
+    assert merged.count(("OrbitalRotation", [0, 1])) == 1
+    assert merged.count(("OrbitalRotation", [2, 3])) == 1

--- a/tests/python/transpiler/passes/test_merge_initialize_rotation.py
+++ b/tests/python/transpiler/passes/test_merge_initialize_rotation.py
@@ -151,15 +151,15 @@ def test_no_merge_when_not_adjacent():
     ]
 
 
-def test_no_merge_when_mode_sets_mismatch():
-    """A single rotation covering fewer modes than the init does not fuse."""
-    circ = FermionicCircuit(4)
+def test_no_merge_when_rotation_is_not_a_spin_half():
+    """A single rotation on a partial sub-range that is not a contiguous spin half does not fuse."""
+    circ = FermionicCircuit(4)  # norb = 2: the only valid halves are [0, 1] and [2, 3]
     circ.append(InitializeModes([1, 1, 0, 0]), circ.modes)
-    circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes[:2])
+    circ.append(OrbitalRotation(random_unitary(3, seed=1)), circ.modes[:3])
 
     assert _merge(circ) == [
         ("InitializeModes", [0, 1, 2, 3]),
-        ("OrbitalRotation", [0, 1]),
+        ("OrbitalRotation", [0, 1, 2]),
     ]
 
 
@@ -171,20 +171,62 @@ def test_no_merge_rotation_without_init():
     assert _merge(circ) == [("OrbitalRotation", [0, 1])]
 
 
-def test_no_merge_only_one_per_spin_rotation():
-    """A full-register init followed by only one per-spin rotation does not fuse.
+def test_merge_only_one_per_spin_rotation():
+    """A full-register init with only one per-spin rotation fuses, identity-padding the other half.
 
-    Fusing here would drop the init's validation on the beta half, so the pass conservatively
-    leaves the whole pattern untouched.
+    The unrotated (beta) half is prepared with an identity rotation, which synthesizes to just its
+    reference X gates -- so the fusion still emits two :class:`.PrepareSlaterDeterminant` gates at no
+    extra gate cost while unlocking the reduced Slater synthesis on the rotated (alpha) half.
     """
     circ = FermionicCircuit(4)
     circ.append(InitializeModes([1, 0, 1, 0]), circ.modes)
     circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes[:2])
 
     assert _merge(circ) == [
-        ("InitializeModes", [0, 1, 2, 3]),
-        ("OrbitalRotation", [0, 1]),
+        ("PrepareSlaterDeterminant", [0, 1]),
+        ("PrepareSlaterDeterminant", [2, 3]),
     ]
+
+
+def test_merge_only_one_per_spin_rotation_beta():
+    """The single-rotation fusion also works when it is the beta half that is rotated."""
+    circ = FermionicCircuit(4)
+    circ.append(InitializeModes([1, 0, 1, 0]), circ.modes)
+    circ.append(OrbitalRotation(random_unitary(2, seed=1)), circ.modes[2:])
+
+    assert _merge(circ) == [
+        ("PrepareSlaterDeterminant", [0, 1]),
+        ("PrepareSlaterDeterminant", [2, 3]),
+    ]
+
+
+def test_merge_single_rotation_identity_pad_preserves_state():
+    """Identity-padding the unrotated half preserves the state up to a global phase, no phase gates.
+
+    Compares the merged circuit (one reduced Slater prep + one identity-padded prep) against the
+    unmerged InitializeModes + single OrbitalRotation reference lowered by the same square path.
+    """
+    circ = FermionicCircuit(4)
+    circ.append(InitializeModes([1, 0, 1, 0]), circ.modes)
+    circ.append(OrbitalRotation(random_unitary(2, seed=3)), circ.modes[:2])
+
+    reference = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=_reference_synth(),
+        output=QuantumDAGToCircuit(),
+    ).run(circ)
+    merged = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        optimization=MergeSlaterDeterminantPreparation(),
+        layout=TrivialF2QLayout(),
+        synthesis=_merged_synth(),
+        output=QuantumDAGToCircuit(),
+    ).run(circ)
+
+    _assert_equal_up_to_global_phase(reference, merged)
+    # the identity-padded half adds no gates; the reduced decomposition carries no phase gates
+    assert "p" not in merged.count_ops()
 
 
 # --- equivalence + payoff -----------------------------------------------------------------------

--- a/tests/python/transpiler/presets/test_jordan_wigner.py
+++ b/tests/python/transpiler/presets/test_jordan_wigner.py
@@ -239,3 +239,53 @@ def test_preset_jordan_wigner_merges_single_per_spin_rotation():
     assert merged.count_ops().get("xx_plus_yy", 0) < lowered_reference.count_ops().get(
         "xx_plus_yy", 0
     )
+
+
+def test_preset_jordan_wigner_merges_rotation_run_then_slater_prep():
+    """The preset merges a rotation run first, then contracts it into a Slater determinant prep.
+
+    This exercises the ordering of the two optimization passes: for an InitializeModes followed by a
+    *run* of consecutive OrbitalRotations, MergeSlaterDeterminantPreparation on its own would only
+    contract the first rotation and leave the rest of the run as trailing OrbitalRotation gates
+    (which synthesize with their phase-carrying square decomposition). Running MergeOrbitalRotations
+    first collapses the whole run into a single rotation, which MergeSlaterDeterminantPreparation
+    then contracts with the initialization into a single PrepareSlaterDeterminant. The preset wires
+    the passes in exactly that order, so the run must lower entirely with the reduced Slater
+    synthesis (no diagonal phase gates) while matching the state of the equivalent pre-composed
+    InitializeModes + single OrbitalRotation (up to a global phase).
+    """
+    num_modes = 6
+    occupation = [True, True, True, False, False, False]
+    u1 = random_unitary(num_modes, seed=21)
+    u2 = random_unitary(num_modes, seed=22)
+
+    circ = FermionicCircuit(num_modes)
+    circ.append(InitializeModes(occupation), circ.modes)
+    circ.append(OrbitalRotation(u1), circ.modes)
+    circ.append(OrbitalRotation(u2), circ.modes)
+
+    pm = generate_preset_jw_pass_manager()
+    merged = pm.run(circ)
+
+    # the run was merged and then contracted into a PrepareSlaterDeterminant, so it lowers with the
+    # reduced Slater synthesis, which drops the diagonal phase gates a full orbital rotation emits
+    assert "p" not in merged.count_ops()
+
+    # equivalent reference: the run pre-composed into a single rotation directly following the init,
+    # i.e. exactly the shape the two passes produce -- it fuses into the same PrepareSlaterDeterminant
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(u2 @ u1), reference.modes)
+    lowered_reference = pm.run(reference)
+
+    sv_merged = Statevector(merged).data
+    sv_reference = Statevector(lowered_reference).data
+    k = int(np.argmax(np.abs(sv_reference)))
+    phase = sv_merged[k] / sv_reference[k]
+    np.testing.assert_allclose(sv_merged, phase * sv_reference, atol=1e-10)
+
+    # the run + Slater-prep fusion lowers to the same gate count as the pre-composed reference,
+    # rather than the two separate decompositions two unmerged rotations would require
+    assert merged.count_ops().get("xx_plus_yy", 0) == lowered_reference.count_ops().get(
+        "xx_plus_yy", 0
+    )

--- a/tests/python/transpiler/presets/test_jordan_wigner.py
+++ b/tests/python/transpiler/presets/test_jordan_wigner.py
@@ -172,3 +172,31 @@ def test_preset_jordan_wigner_merges_rotation_run():
     assert merged.count_ops().get("xx_plus_yy", 0) == lowered_reference.count_ops().get(
         "xx_plus_yy", 0
     )
+
+
+def test_preset_jordan_wigner_merges_initialize_rotation():
+    """The preset's optimization stage fuses InitializeModes + OrbitalRotation.
+
+    An InitializeModes immediately followed by an OrbitalRotation is merged into a
+    PrepareSlaterDeterminant and lowered with the reduced Slater synthesis, so the preset yields
+    the same state (up to a global phase) as the unmerged pair but with fewer gates and no phases.
+    """
+    num_modes = 6
+    occupation = [True, True, True, False, False, False]
+    rotation = random_unitary(num_modes, seed=17)
+
+    circ = FermionicCircuit(num_modes)
+    circ.append(InitializeModes(occupation), circ.modes)
+    circ.append(OrbitalRotation(rotation), circ.modes)
+
+    pm = generate_preset_jw_pass_manager()
+    merged = pm.run(circ)
+
+    # the reduced decomposition drops the diagonal phase gates the full orbital rotation would emit
+    assert "p" not in merged.count_ops()
+
+    # equivalent reference lowered without the merge (a bare OrbitalRotation keeps its phases)
+    reference = FermionicCircuit(num_modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    ref_ops = pm.run(reference).count_ops()
+    assert merged.count_ops().get("xx_plus_yy", 0) < ref_ops.get("xx_plus_yy", 0)

--- a/tests/python/transpiler/presets/test_jordan_wigner.py
+++ b/tests/python/transpiler/presets/test_jordan_wigner.py
@@ -200,3 +200,42 @@ def test_preset_jordan_wigner_merges_initialize_rotation():
     reference.append(OrbitalRotation(rotation), reference.modes)
     ref_ops = pm.run(reference).count_ops()
     assert merged.count_ops().get("xx_plus_yy", 0) < ref_ops.get("xx_plus_yy", 0)
+
+
+def test_preset_jordan_wigner_merges_single_per_spin_rotation():
+    """The preset fuses a global init with a single per-spin rotation, identity-padding the rest.
+
+    A full-register InitializeModes followed by an OrbitalRotation on only one spin half fuses into
+    two PrepareSlaterDeterminant gates (the rotated half plus an identity-padded half). The result
+    matches the state of the equivalent block-diagonal OrbitalRotation (up to a global phase) while
+    emitting strictly fewer two-qubit rotations and no phase gates.
+    """
+    norb = 3
+    rotation = random_unitary(norb, seed=7)
+
+    circ = FermionicCircuit(2 * norb)
+    circ.append(InitializeModes.from_hartree_fock(norb, (2, 1)), circ.modes)
+    circ.append(OrbitalRotation(rotation), circ.modes[:norb])
+
+    pm = generate_preset_jw_pass_manager()
+    merged = pm.run(circ)
+
+    # equivalent reference: the same rotation as a full-register block-diagonal OrbitalRotation
+    # (alpha half rotated, beta half identity), with nothing to merge into so it takes the square path
+    block_diag = np.eye(2 * norb, dtype=complex)
+    block_diag[:norb, :norb] = rotation
+    reference = FermionicCircuit(2 * norb)
+    reference.append(InitializeModes.from_hartree_fock(norb, (2, 1)), reference.modes)
+    reference.append(OrbitalRotation(block_diag), reference.modes)
+    lowered_reference = pm.run(reference)
+
+    sv_merged = Statevector(merged).data
+    sv_reference = Statevector(lowered_reference).data
+    k = int(np.argmax(np.abs(sv_reference)))
+    phase = sv_merged[k] / sv_reference[k]
+    np.testing.assert_allclose(sv_merged, phase * sv_reference, atol=1e-10)
+
+    assert "p" not in merged.count_ops()
+    assert merged.count_ops().get("xx_plus_yy", 0) < lowered_reference.count_ops().get(
+        "xx_plus_yy", 0
+    )


### PR DESCRIPTION
## Summary

An `InitializeModes` immediately followed by an `OrbitalRotation` is a Slater determinant preparation: the modes start in the reference occupation and are then rotated into the target single-particle basis. This PR adds a transpiler pass, `MergeSlaterDeterminantPreparation`, that detects that pattern in a `FermionicDAGCircuit` and rewrites it into a single `PrepareSlaterDeterminant` gate.

The payoff is a strictly cheaper synthesis: because `PrepareSlaterDeterminant` knows the reference occupation, a later synthesis stage can lower it with the rectangular `givens_decomposition_slater` (which realizes only the occupied orbitals) instead of the full square decomposition an `OrbitalRotation` alone requires. The rewrite is state-preserving — `PrepareSlaterDeterminant` is validate-then-rotate, so it leaves the prepared state unchanged (up to a physically irrelevant global phase) and only unlocks the cheaper synthesis.

The pass is wired into the preset Jordan–Wigner pipeline, ordered after `MergeOrbitalRotations` so a whole run of consecutive rotations first collapses into one rotation that the Slater-prep fusion can then contract in full.

### Example

```python
import numpy as np
from qiskit_fermions.circuit import FermionicCircuit
from qiskit_fermions.circuit.library import InitializeModes, OrbitalRotation
from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager

# a random 6x6 orbital rotation applied to a 2-electron reference
rng = np.random.default_rng(1)
z = rng.standard_normal((6, 6)) + 1j * rng.standard_normal((6, 6))
q, r = np.linalg.qr(z)
rotation = q * (np.diagonal(r) / np.abs(np.diagonal(r)))

circuit = FermionicCircuit(6)
circuit.append(InitializeModes([1, 1, 0, 0, 0, 0]), circuit.modes)
circuit.append(OrbitalRotation(rotation), circuit.modes)

pm = generate_preset_jw_pass_manager()
prepared = pm.run(circuit)
print(dict(sorted(prepared.count_ops().items())))
# {'x': 2, 'xx_plus_yy': 8}

# the same rotation with nothing to merge falls back to the full square decomposition:
reference = FermionicCircuit(6)
reference.append(OrbitalRotation(rotation), reference.modes)
print(dict(sorted(pm.run(reference).count_ops().items())))
# {'p': 6, 'xx_plus_yy': 15}
```

The reduced decomposition drops all six phase gates and nearly halves the two-qubit rotation count.

### Patterns recognized

Keyed off the block-spin mode convention (modes `0..norb` = alpha, `norb..2*norb` = beta):

1. Full-register / spinless — an init immediately followed by a rotation on the same modes → one `PrepareSlaterDeterminant`.
2. Per-sector — the same shape on a single spin half → one `PrepareSlaterDeterminant` per sector.
3. Global init + per-spin rotations — a full-register init followed by an `OrbitalRotation` on either or both contiguous spin halves → two `PrepareSlaterDeterminant` gates. An unrotated half is identity-padded, which synthesizes to just the reference `X` gates (no extra gates). This is the shape produced by an `InitializeModes.from_hartree_fock` at the front of a decomposed `UCJ`.