### PR TITLE
fix(transpiler): compensate JW Z-string for interleaved peeled modes in Slater synthesis

### DIFF
--- a/python/qiskit_fermions/transpiler/passes/synthesis/prepare_slater_determinant.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/prepare_slater_determinant.py
@@ -125,6 +125,13 @@ class GivensDecompositionSlaterDeterminantSynthesis:
        When the whole occupied space is a signed permutation every orbital peels and no
        ``XXPlusYYGate`` is emitted at all.
 
+       A peeled mode may sit *between* the physical endpoints of a sweep rotation, making that
+       ``XXPlusYYGate`` act on physically non-adjacent qubits. Because a peeled mode is an occupied
+       unit-orbital, the Jordan-Wigner Z-string it would contribute is folded back into the sign of
+       the ``XXPlusYYGate`` phase when an odd number of peeled modes lies strictly between the
+       endpoints, so the prepared state stays correct regardless of how the peeled modes interleave
+       the mixing space.
+
     .. warning::
        This transpilation pass plugin makes the following assumptions:
 
@@ -187,10 +194,25 @@ class GivensDecompositionSlaterDeterminantSynthesis:
         # remapping each local sweep index through ``kept_modes`` to its physical mode. No phase
         # gates: the reduced decomposition carries none, so the state is prepared up to a global phase
         # (physically irrelevant for state preparation).
+        #
+        # Jordan-Wigner Z-string compensation. A bare ``XXPlusYYGate`` on adjacent qubits is the
+        # correct JW fermionic hop only when the two modes are physically adjacent; the framework
+        # relies on this (no explicit Z-string is emitted). The reduced sweep guarantees adjacency in
+        # *reduced-local* (kept-mode) indexing, but the ``kept_modes`` remap can place a rotation's
+        # physical endpoints across one or more *peeled* modes. Every peeled mode is an occupied
+        # unit-orbital, so each one strictly between the endpoints contributes a JW sign; the missing
+        # Z-string over an odd number of them flips the hop's sign. We fold that sign back into the
+        # ``XXPlusYYGate`` phase, which is ``-pi/2`` for an even Z-string parity and ``+pi/2`` for an
+        # odd one (the two differ by ``pi``, and the gate is ``2 pi``-periodic in its phase). Only
+        # *peeled* modes need counting: any *kept* mode between the endpoints is itself swept, so its
+        # Z-string is already carried implicitly by the nearest-neighbor chain in reduced-local space.
         for c, s, i, j in givens_decomposition_slater(reduced):
             c_angle = np.acos(c)
             if not np.isclose(c_angle, 0.0):
+                mode_i, mode_j = kept_modes[i], kept_modes[j]
+                lo, hi = min(mode_i, mode_j), max(mode_i, mode_j)
+                z_string_sign = -1 if sum(1 for p in peel_modes if lo < p < hi) % 2 == 0 else 1
                 out_dag.apply_operation_back(
-                    XXPlusYYGate(2 * c_angle, np.angle(s) - 0.5 * np.pi),
-                    (qreg[freg_indices[kept_modes[i]]], qreg[freg_indices[kept_modes[j]]]),
+                    XXPlusYYGate(2 * c_angle, np.angle(s) + z_string_sign * 0.5 * np.pi),
+                    (qreg[freg_indices[mode_i]], qreg[freg_indices[mode_j]]),
                 )

--- a/tests/python/transpiler/passes/test_prepare_slater_determinant_synthesis.py
+++ b/tests/python/transpiler/passes/test_prepare_slater_determinant_synthesis.py
@@ -31,6 +31,9 @@ from qiskit_fermions.transpiler.passes import (
     TrivialF2QLayout,
     TrivialOccupationInitializeModesSynthesis,
 )
+from qiskit_fermions.transpiler.passes.synthesis.prepare_slater_determinant import (
+    _peel_disjoint_unit_orbitals,
+)
 
 from ...utils import random_unitary
 
@@ -274,3 +277,133 @@ def test_prepare_slater_determinant_synthesis_full_occupation():
     # m == n: the occupied space is the whole space, so any rotation within it is discarded
     assert ops.get("x", 0) == num_modes
     assert ops.get("xx_plus_yy", 0) == 0
+
+
+def _block_rotation(num_modes: int, mixing_modes: list[int], *, seed: int) -> np.ndarray:
+    """Identity except for a random unitary block on ``mixing_modes`` (which may be non-adjacent).
+
+    Unlike :func:`_givens_2mode` (which only ever mixes an *adjacent* pair), this places a genuine
+    mixing block across arbitrary -- possibly non-contiguous -- modes. Occupying a peeled unit-orbital
+    on a mode strictly between two of the mixing modes is what drives a sweep ``XXPlusYYGate`` onto
+    physically non-adjacent qubits, exercising the Jordan-Wigner Z-string compensation.
+    """
+    rotation = np.eye(num_modes, dtype=complex)
+    block = random_unitary(len(mixing_modes), seed=seed)
+    for a, mode_a in enumerate(mixing_modes):
+        for b, mode_b in enumerate(mixing_modes):
+            rotation[mode_a, mode_b] = block[a, b]
+    return rotation
+
+
+def test_prepare_slater_determinant_synthesis_interleaved_peel_odd_parity():
+    """A single peeled unit-orbital between two mixing modes still prepares the correct state.
+
+    This is the regression case for the Jordan-Wigner Z-string bug: the rotation mixes the
+    *non-adjacent* modes 0 and 2 (occupying column 0 keeps a genuine two-mode rotation), while mode 1
+    is an occupied disjoint unit-orbital that peels. The reduced sweep emits an ``XXPlusYYGate`` on the
+    physically non-adjacent qubits (0, 2); the occupied peeled mode 1 sits strictly between them, so
+    its Jordan-Wigner Z-string (odd parity) must be folded in as a ``pi`` phase shift. Without that
+    compensation the prepared state is wrong (overlap ~0.078 vs. the faithful reference).
+    """
+    num_modes = 3
+    occupation = [True, True, False]
+    rotation = _block_rotation(num_modes, [0, 2], seed=3)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    qc_slater = _synthesize(slater, _slater_synth())
+    ops = qc_slater.count_ops()
+
+    # mode 1 peels; the genuine 0-2 mixing emits a single XXPlusYYGate on non-adjacent qubits
+    assert ops.get("xx_plus_yy", 0) == 1
+    assert ops.get("x", 0) == 2
+
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    qc_reference = _synthesize(reference, _reference_synth())
+    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+
+
+def test_prepare_slater_determinant_synthesis_interleaved_peel_even_parity():
+    """Two peeled unit-orbitals between the mixing endpoints leave the sweep uncompensated.
+
+    Guards against a naive "flip whenever any peel is between the endpoints" fix: the rotation mixes
+    the non-adjacent modes 0 and 3, with occupied unit-orbitals on *both* modes 1 and 2 (even parity).
+    Their two Jordan-Wigner Z-strings cancel, so the ``XXPlusYYGate`` must be emitted with its base
+    phase -- the compensation must stay inert. The prepared state must match the faithful reference.
+    """
+    num_modes = 4
+    occupation = [True, True, True, False]
+    rotation = _block_rotation(num_modes, [0, 3], seed=5)
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    qc_slater = _synthesize(slater, _slater_synth())
+    ops = qc_slater.count_ops()
+
+    # modes 1 and 2 peel; a single XXPlusYYGate on the non-adjacent mixing pair (0, 3)
+    assert ops.get("xx_plus_yy", 0) == 1
+    assert ops.get("x", 0) == 3
+
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    qc_reference = _synthesize(reference, _reference_synth())
+    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+
+
+def test_prepare_slater_determinant_synthesis_interleaved_peel_randomized():
+    """Randomized stress test of the interleaved-peel Z-string compensation.
+
+    Builds many occupied spaces that factor into a genuine mixing block on arbitrary (often
+    non-adjacent) modes plus disjoint unit-orbitals -- some of which land *between* the mixing modes,
+    forcing sweep ``XXPlusYYGate``\\ s onto physically non-adjacent qubits. Each synthesized state is
+    checked against the faithful ``InitializeModes + OrbitalRotation`` reference (the trusted square
+    path is Z-string-correct because it never peels). Only *peeled* occupied modes need the
+    compensation: any *kept* mode between a rotation's endpoints is itself swept, so its Z-string is
+    already carried implicitly by the nearest-neighbor chain in reduced-local space.
+
+    The seed is fixed for determinism and chosen so many trials exhibit an interleaved peel (the
+    load-bearing regime); a broken emission that drops the parity term fails a large fraction of them.
+    """
+    rng = np.random.default_rng(20260724)
+    trials = 0
+    interleaved = 0
+    for _ in range(200):
+        num_modes = int(rng.integers(3, 8))
+        perm = rng.permutation(num_modes)
+        block_size = int(rng.integers(2, min(4, num_modes) + 1))
+        mixing_modes = sorted(perm[:block_size].tolist())
+        rest = sorted(perm[block_size:].tolist())
+        # occupy fewer than all mixing columns so the block stays a genuine rotation (occupying every
+        # column would fill the subspace and collapse to a plain permutation), plus some isolated units
+        num_mixing_occ = int(rng.integers(1, len(mixing_modes)))
+        unit_occ = [mode for mode in rest if rng.random() < 0.5]
+        rotation = _block_rotation(num_modes, mixing_modes, seed=int(rng.integers(0, 10**6)))
+        occupied_cols = mixing_modes[:num_mixing_occ] + unit_occ
+        occupation = [i in occupied_cols for i in range(num_modes)]
+        if not any(occupation) or all(occupation):
+            continue
+        trials += 1
+
+        orbital_coeffs = rotation[:, np.nonzero(occupation)[0]].T
+        peel_modes, kept_modes, _ = _peel_disjoint_unit_orbitals(orbital_coeffs)
+        if peel_modes and any(min(kept_modes) < p < max(kept_modes) for p in peel_modes):
+            interleaved += 1
+
+        slater = FermionicCircuit(num_modes)
+        slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+        qc_slater = _synthesize(slater, _slater_synth())
+
+        reference = FermionicCircuit(num_modes)
+        reference.append(InitializeModes(occupation), reference.modes)
+        reference.append(OrbitalRotation(rotation), reference.modes)
+        qc_reference = _synthesize(reference, _reference_synth())
+
+        _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+
+    # sanity: the seed actually stresses the load-bearing regime (interleaved peels), so this test
+    # genuinely guards the compensation rather than trivially passing on non-interleaved cases
+    assert trials > 100
+    assert interleaved > 20


### PR DESCRIPTION
### Summary

Fixes a correctness bug in `GivensDecompositionSlaterDeterminantSynthesis` introduced with the peeling optimization (#203). The plugin could prepare the wrong Slater determinant whenever a peeled unit-orbital was interleaved with the kept mixing modes.

### The bug

The plugin peels each disjoint unit-orbital (a fixed occupied mode) onto a direct `XGate` and hands only the mixing remainder to `givens_decomposition_slater`. The reduced sweep emits rotations adjacent in reduced-local (kept-mode) indexing, but the kept_modes remap can place a rotation's physical endpoints across one or more peeled modes — producing an `XXPlusYYGate` on physically non-adjacent qubits.

The framework relies on a nearest-neighbor `XXPlusYYGate` being the correct Jordan-Wigner fermionic hop with no explicit Z-string. A non-adjacent gate omits the Z-string over the intervening modes; since every peeled mode is an occupied unit-orbital, each one strictly between the endpoints contributes a JW sign. An odd number of them flips the hop's sign and corrupts the state.

Reproduction: n=3, occupied {0.6|0⟩ + 0.8|2⟩, e₁} — mode 1 peels and sits between the mixing pair {0, 2}, so the sweep emits xx_plus_yy on physical qubits [2, 0] → overlap vs. the faithful reference 0.0784 (should be 1.0).

The bug went unnoticed because the shipped peel tests all mix adjacent modes (no interleaving), and the Rust oracle reconstruct_slater reconstructs the single-particle orbital-coefficient matrix and is blind to fermionic parity, so it reported fidelity 1.0 even for broken circuits.

### The fix

For each emitted rotation, count the peeled modes strictly between the physical endpoints and add π to the `XXPlusYYGate` phase when that count is odd, folding the missing Z-string sign back in. This adds zero gates and preserves the full peeling benefit. Only peeled modes are counted — any kept mode between the endpoints is itself swept, so its Z-string is already carried implicitly by the nearest-neighbor chain in reduced-local space.