### PR TITLE
feat(transpiler): block-split the mixing remainder in Slater synthesis

### DIFF
--- a/python/qiskit_fermions/transpiler/passes/synthesis/prepare_slater_determinant.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/prepare_slater_determinant.py
@@ -93,6 +93,83 @@ def _peel_disjoint_unit_orbitals(
     return peel_modes, kept_modes, reduced
 
 
+def _split_mixing_blocks(
+    reduced: np.ndarray,
+    kept_modes: list[int],
+) -> list[tuple[list[int], list[int], np.ndarray]]:
+    r"""Partition the mixing remainder into disjoint-support blocks, one Givens sweep each.
+
+    The leading-reference sweep of :func:`~qiskit_fermions.linalg.givens_decomposition_slater` seeds
+    the occupation on the block's leading modes and transports it out to the physical support; when
+    two mixing orbitals live on *disjoint* mode windows, the modes between their windows (and any
+    empty leading/trailing modes) carry no occupation, and the sweep would spend bare ``SWAP``\ s
+    (``XXPlusYYGate`` with ``c = 0``) shuttling occupation across them. Synthesizing each disjoint
+    cluster on its own contiguous mode window instead drops that inter-cluster transport entirely.
+    (This complements the disjoint-unit-orbital peeling of :func:`_peel_disjoint_unit_orbitals`, which
+    is the degenerate single-mode-window case and is handled *before* this split -- so ``reduced`` is
+    the genuinely-mixing remainder only.)
+
+    Blocks are formed by a classic interval merge on each orbital's **physical-mode window**
+    :math:`[\min\text{-support}, \max\text{-support}]` (mapped through ``kept_modes``): sort by window
+    start, and merge an orbital into the running block whenever its window overlaps. This *must* group
+    on the mode-index window, not the raw support: two orbitals with disjoint support but
+    nested/interleaved windows (e.g. support ``{0, 3}`` and ``{1, 2}``) must share a block, since the
+    window ``[0, 3]`` spans the occupied modes ``1, 2`` -- splitting them would emit a rotation across
+    an occupied mode. The window merge guarantees each block occupies a **contiguous** window whose
+    only occupied modes are the block's own swept modes, so every emitted rotation is physically
+    mode-adjacent within the block and the framework's no-Z-string hop recipe stays valid. (A
+    *peeled* mode may still fall inside a block's window; that Z-string is compensated at emission
+    time by the caller -- see :meth:`GivensDecompositionSlaterDeterminantSynthesis.run`.)
+
+    Args:
+        reduced: the :math:`(m - p) \times k` orthonormal mixing-remainder matrix from
+            :func:`_peel_disjoint_unit_orbitals` (rows in kept-mode-local column space).
+        kept_modes: the length-:math:`k` list mapping each ``reduced`` column to its physical mode.
+
+    Returns:
+        One 3-tuple ``(block_rows, block_modes, sub)`` per block, where ``block_rows`` are the
+        ``reduced`` row indices in the block, ``block_modes`` are the physical modes spanning the
+        block's contiguous window (in ascending order; the first ``len(block_rows)`` of them are the
+        block's leading reference modes), and ``sub`` is the C-contiguous
+        ``len(block_rows) x len(block_modes)`` sub-matrix ready to hand to
+        :func:`~qiskit_fermions.linalg.givens_decomposition_slater`.
+    """
+    num_mixing = reduced.shape[0]
+
+    # each mixing orbital's physical-mode support window [lo, hi]
+    windows: list[tuple[int, int]] = []
+    for row in range(num_mixing):
+        support = [kept_modes[col] for col in np.nonzero(np.abs(reduced[row]) > _PEEL_ATOL)[0]]
+        windows.append((min(support), max(support)))
+
+    # interval merge: sort orbitals by window start, coalesce overlapping windows into one block
+    order = sorted(range(num_mixing), key=lambda row: windows[row][0])
+    grouped_rows: list[list[int]] = [[order[0]]]
+    running_hi = windows[order[0]][1]
+    for row in order[1:]:
+        lo, hi = windows[row]
+        if lo <= running_hi:
+            grouped_rows[-1].append(row)
+            running_hi = max(running_hi, hi)
+        else:
+            grouped_rows.append([row])
+            running_hi = hi
+
+    blocks: list[tuple[list[int], list[int], np.ndarray]] = []
+    for block_rows in grouped_rows:
+        window_lo = min(windows[row][0] for row in block_rows)
+        window_hi = max(windows[row][1] for row in block_rows)
+        # the kept-local columns and physical modes spanning this block's contiguous window
+        local_cols = [
+            col for col in range(len(kept_modes)) if window_lo <= kept_modes[col] <= window_hi
+        ]
+        block_modes = [kept_modes[col] for col in local_cols]
+        # ``np.ascontiguousarray`` guards the FFI boundary (see ``_peel_disjoint_unit_orbitals``).
+        sub = np.ascontiguousarray(reduced[np.ix_(block_rows, local_cols)])
+        blocks.append((block_rows, block_modes, sub))
+    return blocks
+
+
 class GivensDecompositionSlaterDeterminantSynthesis:
     r"""A :class:`.F2QSynthesisPlugin` for transpiling :class:`.PrepareSlaterDeterminant`.
 
@@ -118,8 +195,7 @@ class GivensDecompositionSlaterDeterminantSynthesis:
     .. note::
        Occupied orbitals that are basis vectors on a mode disjoint from every other occupied orbital
        are *peeled off* before the decomposition: their ``XGate`` is placed directly on the target
-       mode and they are excluded from the Givens sweep (see
-       :func:`_peel_disjoint_unit_orbitals`). This avoids the chain of bare ``SWAP``\ s
+       mode and they are excluded from the Givens sweep. This avoids the chain of bare ``SWAP``\ s
        (``XXPlusYYGate`` with ``c = 0``) that the leading-reference sweep would otherwise emit to
        transport such an orbital out to its mode. Only the genuinely-mixing remainder is decomposed.
        When the whole occupied space is a signed permutation every orbital peels and no
@@ -131,6 +207,15 @@ class GivensDecompositionSlaterDeterminantSynthesis:
        the ``XXPlusYYGate`` phase when an odd number of peeled modes lies strictly between the
        endpoints, so the prepared state stays correct regardless of how the peeled modes interleave
        the mixing space.
+
+    .. note::
+       The genuinely-mixing remainder that survives peeling is further partitioned into
+       disjoint-support **blocks**, each synthesized on its own contiguous mode window. When the
+       occupied space splits into several mixing clusters
+       separated by empty (or peeled) modes, this drops the bare ``SWAP``\ s (``XXPlusYYGate`` with
+       ``c = 0``) the single leading-reference sweep would otherwise emit to transport occupation
+       across the gaps between clusters. A single mixing cluster spanning all kept modes is one block
+       and reproduces the plain leading-reference sweep exactly.
 
     .. warning::
        This transpilation pass plugin makes the following assumptions:
@@ -177,42 +262,45 @@ class GivensDecompositionSlaterDeterminantSynthesis:
         for mode in peel_modes:
             out_dag.apply_operation_back(XGate(), (qreg[freg_indices[mode]],))
 
-        # the reduced decomposition prepares the mixing remainder from the reference in which the
-        # first ``m - p`` *kept* modes are occupied (``reduced`` has ``m - p`` rows); seed that
-        # reference. The Givens sweep below then moves the occupation onto the physical target
-        # orbitals within the kept modes.
-        num_mixing = reduced.shape[0]
-        for i in range(num_mixing):
-            out_dag.apply_operation_back(XGate(), (qreg[freg_indices[kept_modes[i]]],))
-
         # a fully-peeled occupied space (e.g. a permutation rotation) leaves no mixing remainder to
         # decompose; the direct X gates above already prepare the state.
-        if num_mixing == 0:
+        if reduced.shape[0] == 0:
             return
 
-        # apply the Givens rotations in order (same XXPlusYYGate convention as the square plugin),
-        # remapping each local sweep index through ``kept_modes`` to its physical mode. No phase
-        # gates: the reduced decomposition carries none, so the state is prepared up to a global phase
-        # (physically irrelevant for state preparation).
-        #
-        # Jordan-Wigner Z-string compensation. A bare ``XXPlusYYGate`` on adjacent qubits is the
-        # correct JW fermionic hop only when the two modes are physically adjacent; the framework
-        # relies on this (no explicit Z-string is emitted). The reduced sweep guarantees adjacency in
-        # *reduced-local* (kept-mode) indexing, but the ``kept_modes`` remap can place a rotation's
-        # physical endpoints across one or more *peeled* modes. Every peeled mode is an occupied
-        # unit-orbital, so each one strictly between the endpoints contributes a JW sign; the missing
-        # Z-string over an odd number of them flips the hop's sign. We fold that sign back into the
-        # ``XXPlusYYGate`` phase, which is ``-pi/2`` for an even Z-string parity and ``+pi/2`` for an
-        # odd one (the two differ by ``pi``, and the gate is ``2 pi``-periodic in its phase). Only
-        # *peeled* modes need counting: any *kept* mode between the endpoints is itself swept, so its
-        # Z-string is already carried implicitly by the nearest-neighbor chain in reduced-local space.
-        for c, s, i, j in givens_decomposition_slater(reduced):
-            c_angle = np.acos(c)
-            if not np.isclose(c_angle, 0.0):
-                mode_i, mode_j = kept_modes[i], kept_modes[j]
-                lo, hi = min(mode_i, mode_j), max(mode_i, mode_j)
-                z_string_sign = -1 if sum(1 for p in peel_modes if lo < p < hi) % 2 == 0 else 1
-                out_dag.apply_operation_back(
-                    XXPlusYYGate(2 * c_angle, np.angle(s) + z_string_sign * 0.5 * np.pi),
-                    (qreg[freg_indices[mode_i]], qreg[freg_indices[mode_j]]),
-                )
+        # partition the genuinely-mixing remainder into disjoint-support blocks and synthesize each on
+        # its own contiguous mode window, dropping the transport SWAPs a single leading sweep would
+        # emit across the gaps between clusters (see ``_split_mixing_blocks``).
+        for block_rows, block_modes, sub in _split_mixing_blocks(reduced, kept_modes):
+            # the reduced decomposition of this block prepares its mixing subspace from the reference
+            # in which the first ``len(block_rows)`` modes of the block's window are occupied (``sub``
+            # has ``len(block_rows)`` rows); seed that reference. The Givens sweep below then moves the
+            # occupation onto the physical target orbitals within the block's window.
+            for i in range(len(block_rows)):
+                out_dag.apply_operation_back(XGate(), (qreg[freg_indices[block_modes[i]]],))
+
+            # apply the block's Givens rotations in order (same XXPlusYYGate convention as the square
+            # plugin), remapping each block-local sweep index through ``block_modes`` to its physical
+            # mode. No phase gates: the reduced decomposition carries none, so the state is prepared up
+            # to a global phase (physically irrelevant for state preparation).
+            #
+            # Jordan-Wigner Z-string compensation. A bare ``XXPlusYYGate`` on adjacent qubits is the
+            # correct JW fermionic hop only when the two modes are physically adjacent; the framework
+            # relies on this (no explicit Z-string is emitted). The sweep is adjacent within the
+            # block's contiguous window, but a *peeled* mode (excluded from ``reduced``) may fall
+            # strictly between a rotation's physical endpoints. Every peeled mode is an occupied
+            # unit-orbital, so each one between the endpoints contributes a JW sign; the missing
+            # Z-string over an odd number of them flips the hop's sign. We fold that sign back into the
+            # ``XXPlusYYGate`` phase, which is ``-pi/2`` for an even Z-string parity and ``+pi/2`` for
+            # an odd one (the two differ by ``pi``, and the gate is ``2 pi``-periodic in its phase).
+            # Only *peeled* modes need counting: any occupied mode inside the block's window is itself
+            # swept, so its Z-string is already carried implicitly by the nearest-neighbor chain.
+            for c, s, i, j in givens_decomposition_slater(sub):
+                c_angle = np.acos(c)
+                if not np.isclose(c_angle, 0.0):
+                    mode_i, mode_j = block_modes[i], block_modes[j]
+                    lo, hi = min(mode_i, mode_j), max(mode_i, mode_j)
+                    z_string_sign = -1 if sum(1 for p in peel_modes if lo < p < hi) % 2 == 0 else 1
+                    out_dag.apply_operation_back(
+                        XXPlusYYGate(2 * c_angle, np.angle(s) + z_string_sign * 0.5 * np.pi),
+                        (qreg[freg_indices[mode_i]], qreg[freg_indices[mode_j]]),
+                    )

--- a/tests/python/transpiler/passes/test_prepare_slater_determinant_synthesis.py
+++ b/tests/python/transpiler/passes/test_prepare_slater_determinant_synthesis.py
@@ -15,6 +15,9 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import XGate, XXPlusYYGate
 from qiskit.passmanager import MultiStagePassManager
 from qiskit.quantum_info import Statevector
 from qiskit_fermions.circuit import FermionicCircuit
@@ -23,6 +26,7 @@ from qiskit_fermions.circuit.library import (
     OrbitalRotation,
     PrepareSlaterDeterminant,
 )
+from qiskit_fermions.linalg import givens_decomposition_slater
 from qiskit_fermions.transpiler import FermionicCircuitToDAG, QuantumDAGToCircuit
 from qiskit_fermions.transpiler.passes import (
     F2QSynthesis,
@@ -33,6 +37,7 @@ from qiskit_fermions.transpiler.passes import (
 )
 from qiskit_fermions.transpiler.passes.synthesis.prepare_slater_determinant import (
     _peel_disjoint_unit_orbitals,
+    _split_mixing_blocks,
 )
 
 from ...utils import random_unitary
@@ -71,22 +76,32 @@ def _assert_equal_up_to_global_phase(qc_a, qc_b):
     np.testing.assert_allclose(sv_a, phase * sv_b, atol=1e-10)
 
 
+def _reference_circuit(num_modes, occupation, rotation):
+    """The faithful InitializeModes + OrbitalRotation synthesis (never peels or block-splits)."""
+    reference = FermionicCircuit(num_modes)
+    reference.append(InitializeModes(occupation), reference.modes)
+    reference.append(OrbitalRotation(rotation), reference.modes)
+    return _synthesize(reference, _reference_synth())
+
+
+def _assert_matches_reference(num_modes, occupation, rotation):
+    """Synthesize via the Slater plugin and assert it matches the faithful reference path.
+
+    Returns the synthesized Slater circuit so callers can additionally inspect its gate counts.
+    """
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    qc_slater = _synthesize(slater, _slater_synth())
+    _assert_equal_up_to_global_phase(qc_slater, _reference_circuit(num_modes, occupation, rotation))
+    return qc_slater
+
+
 def test_prepare_slater_determinant_synthesis_matches_reference():
     """The reduced Slater synthesis prepares the same state as the full InitializeModes+rotation."""
     num_modes = 6
     occupation = [True, True, True, False, False, False]
     rotation = random_unitary(num_modes, seed=42)
-
-    slater = FermionicCircuit(num_modes)
-    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
-    qc_slater = _synthesize(slater, _slater_synth())
-
-    reference = FermionicCircuit(num_modes)
-    reference.append(InitializeModes(occupation), reference.modes)
-    reference.append(OrbitalRotation(rotation), reference.modes)
-    qc_reference = _synthesize(reference, _reference_synth())
-
-    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+    _assert_matches_reference(num_modes, occupation, rotation)
 
 
 def test_prepare_slater_determinant_synthesis_scattered_occupation():
@@ -101,17 +116,7 @@ def test_prepare_slater_determinant_synthesis_scattered_occupation():
     num_modes = 6
     occupation = [False, True, False, True, True, False]
     rotation = random_unitary(num_modes, seed=7)
-
-    slater = FermionicCircuit(num_modes)
-    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
-    qc_slater = _synthesize(slater, _slater_synth())
-
-    reference = FermionicCircuit(num_modes)
-    reference.append(InitializeModes(occupation), reference.modes)
-    reference.append(OrbitalRotation(rotation), reference.modes)
-    qc_reference = _synthesize(reference, _reference_synth())
-
-    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+    _assert_matches_reference(num_modes, occupation, rotation)
 
 
 def test_prepare_slater_determinant_synthesis_reduced_gate_count():
@@ -131,10 +136,7 @@ def test_prepare_slater_determinant_synthesis_reduced_gate_count():
     assert "p" not in ops
 
     # the full orbital-rotation synthesis of the same rotation uses the n(n-1)/2 brick-wall + phases
-    reference = FermionicCircuit(num_modes)
-    reference.append(InitializeModes(occupation), reference.modes)
-    reference.append(OrbitalRotation(rotation), reference.modes)
-    ref_ops = _synthesize(reference, _reference_synth()).count_ops()
+    ref_ops = _reference_circuit(num_modes, occupation, rotation).count_ops()
     assert ops.get("xx_plus_yy", 0) < ref_ops.get("xx_plus_yy", 0)
 
 
@@ -152,6 +154,30 @@ def _givens_2mode(theta: float, p: int, q: int, num_modes: int) -> np.ndarray:
     return rot
 
 
+def _multi_block_rotation(num_modes: int, blocks: list[list[int]], *, seed: int) -> np.ndarray:
+    """Identity except for an independent random unitary on each mode group in ``blocks``.
+
+    Each group may span arbitrary -- possibly non-contiguous -- modes. Placing several genuinely-mixing
+    clusters on disjoint mode windows (with empty modes between them) builds the targets that
+    block-splitting exists to handle: each cluster synthesizes on its own contiguous window instead of
+    being transported across the whole line by a single leading sweep. Passing a single non-contiguous
+    group (e.g. ``[[0, 2]]``) instead exercises the Jordan-Wigner Z-string compensation: a peeled
+    unit-orbital occupied on a mode strictly between two of the mixing modes drives a sweep
+    ``XXPlusYYGate`` onto physically non-adjacent qubits.
+    """
+    rotation = np.eye(num_modes, dtype=complex)
+    for offset, modes in enumerate(blocks):
+        block = random_unitary(len(modes), seed=seed + offset)
+        for a, mode_a in enumerate(modes):
+            for b, mode_b in enumerate(modes):
+                rotation[mode_a, mode_b] = block[a, b]
+    return rotation
+
+
+def _two_qubit_count(qc) -> int:
+    return qc.count_ops().get("xx_plus_yy", 0)
+
+
 def test_prepare_slater_determinant_synthesis_peels_disjoint_unit_orbital():
     """A disjoint unit-orbital is placed directly, not transported out with bare SWAPs.
 
@@ -165,20 +191,12 @@ def test_prepare_slater_determinant_synthesis_peels_disjoint_unit_orbital():
     occupation = [False, True, False, True]
     rotation = _givens_2mode(0.6, 0, 1, num_modes)
 
-    slater = FermionicCircuit(num_modes)
-    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
-    qc_slater = _synthesize(slater, _slater_synth())
+    qc_slater = _assert_matches_reference(num_modes, occupation, rotation)
     ops = qc_slater.count_ops()
 
     # only the genuine 0-1 mixing survives; no bare-SWAP transport of the e_3 orbital
     assert ops.get("xx_plus_yy", 0) == 1
     assert ops.get("x", 0) == 2
-
-    reference = FermionicCircuit(num_modes)
-    reference.append(InitializeModes(occupation), reference.modes)
-    reference.append(OrbitalRotation(rotation), reference.modes)
-    qc_reference = _synthesize(reference, _reference_synth())
-    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
 
 
 def test_prepare_slater_determinant_synthesis_permutation_no_two_qubit_gates():
@@ -192,20 +210,12 @@ def test_prepare_slater_determinant_synthesis_permutation_no_two_qubit_gates():
     occupation = [False, True, False, True]
     rotation = np.eye(num_modes, dtype=complex)
 
-    slater = FermionicCircuit(num_modes)
-    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
-    qc_slater = _synthesize(slater, _slater_synth())
+    qc_slater = _assert_matches_reference(num_modes, occupation, rotation)
     ops = qc_slater.count_ops()
 
     assert ops.get("xx_plus_yy", 0) == 0
     assert ops.get("x", 0) == 2
     assert "p" not in ops
-
-    reference = FermionicCircuit(num_modes)
-    reference.append(InitializeModes(occupation), reference.modes)
-    reference.append(OrbitalRotation(rotation), reference.modes)
-    qc_reference = _synthesize(reference, _reference_synth())
-    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
 
 
 def test_prepare_slater_determinant_synthesis_multiple_disjoint_units():
@@ -221,19 +231,11 @@ def test_prepare_slater_determinant_synthesis_multiple_disjoint_units():
     occupation = [True, False, False, False, True, True]
     rotation = _givens_2mode(0.5, 0, 1, num_modes)
 
-    slater = FermionicCircuit(num_modes)
-    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
-    qc_slater = _synthesize(slater, _slater_synth())
+    qc_slater = _assert_matches_reference(num_modes, occupation, rotation)
     ops = qc_slater.count_ops()
 
     assert ops.get("xx_plus_yy", 0) == 1
     assert ops.get("x", 0) == 3
-
-    reference = FermionicCircuit(num_modes)
-    reference.append(InitializeModes(occupation), reference.modes)
-    reference.append(OrbitalRotation(rotation), reference.modes)
-    qc_reference = _synthesize(reference, _reference_synth())
-    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
 
 
 def test_prepare_slater_determinant_synthesis_generic_rotation_not_peeled():
@@ -248,20 +250,12 @@ def test_prepare_slater_determinant_synthesis_generic_rotation_not_peeled():
     occupation = [i < nocc for i in range(num_modes)]
     rotation = random_unitary(num_modes, seed=42)
 
-    slater = FermionicCircuit(num_modes)
-    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
-    qc_slater = _synthesize(slater, _slater_synth())
+    qc_slater = _assert_matches_reference(num_modes, occupation, rotation)
     ops = qc_slater.count_ops()
 
     # nothing peels: the full leading-reference sweep runs (up to m(n-m) two-qubit gates, m X gates)
     assert ops.get("x", 0) == nocc
     assert 0 < ops.get("xx_plus_yy", 0) <= nocc * (num_modes - nocc)
-
-    reference = FermionicCircuit(num_modes)
-    reference.append(InitializeModes(occupation), reference.modes)
-    reference.append(OrbitalRotation(rotation), reference.modes)
-    qc_reference = _synthesize(reference, _reference_synth())
-    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
 
 
 def test_prepare_slater_determinant_synthesis_full_occupation():
@@ -279,20 +273,61 @@ def test_prepare_slater_determinant_synthesis_full_occupation():
     assert ops.get("xx_plus_yy", 0) == 0
 
 
-def _block_rotation(num_modes: int, mixing_modes: list[int], *, seed: int) -> np.ndarray:
-    """Identity except for a random unitary block on ``mixing_modes`` (which may be non-adjacent).
+# --- correctness across occupied-space structures --------------------------------------------------
+#
+# Each case is (label, num_modes, occupied_columns, rotation-builder). ``occupied_columns`` selects
+# the rotation columns that become the occupied orbitals; the builder controls how the rotation mixes
+# modes. Together they exercise: disjoint multi-mode mixing blocks (with an empty gap between them --
+# the block-split payoff), adjacent multi-mode blocks, a nested-window mixing pair, an
+# interleaved-window mixing pair, a dense single mixing block, a pure permutation (everything peels),
+# and the #206 peel-bug shape (a peeled unit strictly between a mixing pair's physical endpoints).
 
-    Unlike :func:`_givens_2mode` (which only ever mixes an *adjacent* pair), this places a genuine
-    mixing block across arbitrary -- possibly non-contiguous -- modes. Occupying a peeled unit-orbital
-    on a mode strictly between two of the mixing modes is what drives a sweep ``XXPlusYYGate`` onto
-    physically non-adjacent qubits, exercising the Jordan-Wigner Z-string compensation.
+_STRUCTURE_CASES = [
+    # disjoint multi-mode blocks {0,1} and {5,6} on an 8-line, one orbital occupied per block
+    (
+        "disjoint_multimode_blocks",
+        8,
+        [0, 5],
+        lambda: _multi_block_rotation(8, [[0, 1], [5, 6]], seed=11),
+    ),
+    # two adjacent multi-mode blocks {0,1} and {2,3} (windows touch but do not overlap)
+    (
+        "adjacent_multimode_blocks",
+        6,
+        [0, 2],
+        lambda: _multi_block_rotation(6, [[0, 1], [2, 3]], seed=13),
+    ),
+    # nested windows: mixing {0,3} and mixing {1,2} -- window [0,3] spans modes 1,2 so they MUST merge
+    ("nested_windows", 4, [0, 1], lambda: _multi_block_rotation(4, [[0, 3], [1, 2]], seed=17)),
+    # interleaved windows: mixing {0,4} and mixing {1,5} -- windows overlap, must merge into one block
+    ("interleaved_windows", 6, [0, 1], lambda: _multi_block_rotation(6, [[0, 4], [1, 5]], seed=19)),
+    # a single dense mixing block spanning every mode (one contiguous window, reproduces leading)
+    ("dense_single_block", 5, [0, 1, 2], lambda: random_unitary(5, seed=23)),
+    # a pure permutation: identity rotation, scattered occupation -- every orbital peels
+    ("pure_permutation", 6, [1, 3, 4], lambda: np.eye(6, dtype=complex)),
+    # the #206 peel-bug shape: mixing {0,2} with a peeled unit on the interior mode 1
+    ("peel_bug_interior_unit", 3, [0, 1], lambda: _multi_block_rotation(3, [[0, 2]], seed=3)),
+]
+
+
+@pytest.mark.parametrize(
+    "label,num_modes,occupied_columns,build_rotation",
+    _STRUCTURE_CASES,
+    ids=[case[0] for case in _STRUCTURE_CASES],
+)
+def test_prepare_slater_determinant_synthesis_structures(
+    label, num_modes, occupied_columns, build_rotation
+):
+    """Peel + block-split prepares the correct state across occupied-space structures.
+
+    Covers disjoint and adjacent multi-mode mixing blocks, nested/interleaved windows (which must
+    share a block or a rotation crosses an occupied mode), a dense single block, a pure permutation,
+    and the #206 peel-bug shape. Every case is checked against the faithful ``InitializeModes +
+    OrbitalRotation`` reference up to a global phase.
     """
-    rotation = np.eye(num_modes, dtype=complex)
-    block = random_unitary(len(mixing_modes), seed=seed)
-    for a, mode_a in enumerate(mixing_modes):
-        for b, mode_b in enumerate(mixing_modes):
-            rotation[mode_a, mode_b] = block[a, b]
-    return rotation
+    rotation = build_rotation()
+    occupation = [i in occupied_columns for i in range(num_modes)]
+    _assert_matches_reference(num_modes, occupation, rotation)
 
 
 def test_prepare_slater_determinant_synthesis_interleaved_peel_odd_parity():
@@ -307,22 +342,14 @@ def test_prepare_slater_determinant_synthesis_interleaved_peel_odd_parity():
     """
     num_modes = 3
     occupation = [True, True, False]
-    rotation = _block_rotation(num_modes, [0, 2], seed=3)
+    rotation = _multi_block_rotation(num_modes, [[0, 2]], seed=3)
 
-    slater = FermionicCircuit(num_modes)
-    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
-    qc_slater = _synthesize(slater, _slater_synth())
+    qc_slater = _assert_matches_reference(num_modes, occupation, rotation)
     ops = qc_slater.count_ops()
 
     # mode 1 peels; the genuine 0-2 mixing emits a single XXPlusYYGate on non-adjacent qubits
     assert ops.get("xx_plus_yy", 0) == 1
     assert ops.get("x", 0) == 2
-
-    reference = FermionicCircuit(num_modes)
-    reference.append(InitializeModes(occupation), reference.modes)
-    reference.append(OrbitalRotation(rotation), reference.modes)
-    qc_reference = _synthesize(reference, _reference_synth())
-    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
 
 
 def test_prepare_slater_determinant_synthesis_interleaved_peel_even_parity():
@@ -335,75 +362,334 @@ def test_prepare_slater_determinant_synthesis_interleaved_peel_even_parity():
     """
     num_modes = 4
     occupation = [True, True, True, False]
-    rotation = _block_rotation(num_modes, [0, 3], seed=5)
+    rotation = _multi_block_rotation(num_modes, [[0, 3]], seed=5)
 
-    slater = FermionicCircuit(num_modes)
-    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
-    qc_slater = _synthesize(slater, _slater_synth())
+    qc_slater = _assert_matches_reference(num_modes, occupation, rotation)
     ops = qc_slater.count_ops()
 
     # modes 1 and 2 peel; a single XXPlusYYGate on the non-adjacent mixing pair (0, 3)
     assert ops.get("xx_plus_yy", 0) == 1
     assert ops.get("x", 0) == 3
 
-    reference = FermionicCircuit(num_modes)
-    reference.append(InitializeModes(occupation), reference.modes)
-    reference.append(OrbitalRotation(rotation), reference.modes)
-    qc_reference = _synthesize(reference, _reference_synth())
-    _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+
+def test_prepare_slater_determinant_synthesis_interleaved_peel_no_overhead():
+    """A peeled unit sitting mid-window does not raise the two-qubit-gate count.
+
+    Directly answers the maintainer's question: when a peeled unit-orbital lands strictly between a
+    mixing rotation's physical endpoints, peeling still peels it out (one free ``XGate``) rather than
+    absorbing it into a denser block. So the emitted two-qubit-gate count equals the count of the same
+    mixing block synthesized *alone* -- the interior peel adds no transport SWAPs. Checked for a small
+    mixing pair with one interior peel and for a wider block with three interior peels.
+    """
+    for mixing_modes, unit_modes in (([0, 2], [1]), ([0, 4], [1, 2, 3])):
+        num_modes = max(*mixing_modes, *unit_modes) + 1
+        rotation = _multi_block_rotation(num_modes, [mixing_modes], seed=29)
+
+        # occupy the first mixing column (a genuine mixing orbital) plus the interior units
+        occupied_columns = [mixing_modes[0], *unit_modes]
+        occupation = [i in occupied_columns for i in range(num_modes)]
+        qc_interleaved = _assert_matches_reference(num_modes, occupation, rotation)
+
+        # the same mixing orbital with the interior units *removed* (no peel between the endpoints):
+        # its two-qubit-gate count is the floor the interleaved case must not exceed
+        occupation_alone = [i == mixing_modes[0] for i in range(num_modes)]
+        slater_alone = FermionicCircuit(num_modes)
+        slater_alone.append(
+            PrepareSlaterDeterminant(occupation_alone, rotation), slater_alone.modes
+        )
+        qc_alone = _synthesize(slater_alone, _slater_synth())
+
+        assert _two_qubit_count(qc_interleaved) <= _two_qubit_count(qc_alone)
 
 
-def test_prepare_slater_determinant_synthesis_interleaved_peel_randomized():
-    """Randomized stress test of the interleaved-peel Z-string compensation.
+def test_prepare_slater_determinant_synthesis_intra_block_gates_mode_adjacent():
+    """Every emitted two-qubit gate is either mode-adjacent or a compensated interior-peel gate.
 
-    Builds many occupied spaces that factor into a genuine mixing block on arbitrary (often
-    non-adjacent) modes plus disjoint unit-orbitals -- some of which land *between* the mixing modes,
-    forcing sweep ``XXPlusYYGate``\\ s onto physically non-adjacent qubits. Each synthesized state is
-    checked against the faithful ``InitializeModes + OrbitalRotation`` reference (the trusted square
-    path is Z-string-correct because it never peels). Only *peeled* occupied modes need the
-    compensation: any *kept* mode between a rotation's endpoints is itself swept, so its Z-string is
-    already carried implicitly by the nearest-neighbor chain in reduced-local space.
+    Block-split guarantees intra-block gates act on physically adjacent qubits; the only non-adjacent
+    gate the plugin ever emits spans a peeled interior mode, and then only with the Jordan-Wigner
+    Z-string folded into its phase. Assert exactly that: each ``XXPlusYYGate`` has ``|i - j| == 1`` or
+    an odd number of peeled occupied modes strictly between its endpoints.
+    """
+    num_modes = 8
+    # disjoint mixing clusters {0,1} and {5,6} plus a peeled interior unit on mode 3
+    rotation = _multi_block_rotation(num_modes, [[0, 1], [5, 6]], seed=31)
+    occupied_columns = [0, 3, 5]
+    occupation = [i in occupied_columns for i in range(num_modes)]
 
-    The seed is fixed for determinism and chosen so many trials exhibit an interleaved peel (the
-    load-bearing regime); a broken emission that drops the parity term fails a large fraction of them.
+    orbital_coeffs = rotation[:, np.nonzero(occupation)[0]].T
+    peel_modes, _, _ = _peel_disjoint_unit_orbitals(orbital_coeffs)
+
+    qc_slater = _assert_matches_reference(num_modes, occupation, rotation)
+
+    for instruction in qc_slater.data:
+        if instruction.operation.name != "xx_plus_yy":
+            continue
+        i, j = (qc_slater.find_bit(qubit).index for qubit in instruction.qubits)
+        lo, hi = min(i, j), max(i, j)
+        peels_between = sum(1 for p in peel_modes if lo < p < hi)
+        assert hi - lo == 1 or peels_between % 2 == 1
+
+
+def test_prepare_slater_determinant_synthesis_block_split_reduces_two_qubit_gates():
+    """Block-split emits strictly fewer two-qubit gates than a single leading sweep would.
+
+    On an 8-line with two disjoint mixing clusters {0,1} and {5,6} plus a peeled unit on mode 3, a
+    single leading-reference sweep transports both clusters across the whole line; block-splitting
+    synthesizes each cluster on its own contiguous window. This asserts the actual payoff: the
+    plugin's two-qubit-gate count is strictly below what one leading sweep over all kept modes emits.
+    """
+    num_modes = 8
+    rotation = _multi_block_rotation(num_modes, [[0, 1], [5, 6]], seed=31)
+    occupied_columns = [0, 3, 5]
+    occupation = [i in occupied_columns for i in range(num_modes)]
+
+    qc_slater = _assert_matches_reference(num_modes, occupation, rotation)
+
+    # what a single leading sweep over the mixing remainder (no block split) would emit: peel the unit,
+    # then hand the whole kept-mode remainder to one givens_decomposition_slater call
+    orbital_coeffs = rotation[:, np.nonzero(occupation)[0]].T
+    _, _, reduced = _peel_disjoint_unit_orbitals(orbital_coeffs)
+    single_sweep = sum(
+        1 for c, _, _, _ in givens_decomposition_slater(reduced) if not np.isclose(np.acos(c), 0.0)
+    )
+
+    assert _two_qubit_count(qc_slater) < single_sweep
+
+
+# --- seeded randomized sweep + negative controls ---------------------------------------------------
+
+
+def _draw_multi_block_target(rng):
+    """Draw a random multi-block occupied-space target that may include interleaved peels.
+
+    Returns ``(num_modes, occupation, rotation, is_multi_block, is_interleaved_peel)`` where the two
+    flags record whether the drawn target genuinely stresses block-splitting (more than one mixing
+    cluster) and the #206 interior-peel compensation (a peeled occupied mode strictly inside the kept
+    mixing span). ``None`` is returned for a degenerate draw (empty or full occupation).
+    """
+    num_modes = int(rng.integers(4, 9))
+
+    # lay one or two mixing clusters out left-to-right on *contiguous* mode ranges separated by
+    # random gaps: this keeps their physical windows genuinely disjoint (exercising block-splitting)
+    # while the gap modes host scattered unit-orbitals -- and occupying fewer than all of a cluster's
+    # columns lets a peeled unit land *inside* a cluster's window (an interleaved peel).
+    num_blocks = int(rng.integers(1, 3))
+    blocks: list[list[int]] = []
+    rest: list[int] = []
+    cursor = 0
+    for block in range(num_blocks):
+        remaining_blocks = num_blocks - block
+        # leave room for the remaining clusters (>=2 modes each) plus optional gaps
+        if num_modes - cursor < 2 * remaining_blocks:
+            break
+        # a random leading gap whose modes become candidate unit-orbitals
+        max_gap = num_modes - cursor - 2 * remaining_blocks
+        gap = int(rng.integers(0, max_gap + 1))
+        rest += list(range(cursor, cursor + gap))
+        cursor += gap
+        size = int(rng.integers(2, min(4, num_modes - cursor - 2 * (remaining_blocks - 1)) + 1))
+        blocks.append(list(range(cursor, cursor + size)))
+        cursor += size
+    rest += list(range(cursor, num_modes))
+
+    rotation = np.eye(num_modes, dtype=complex)
+    for offset, block_modes in enumerate(blocks):
+        sub = random_unitary(len(block_modes), seed=int(rng.integers(0, 10**6)) + offset)
+        for a, mode_a in enumerate(block_modes):
+            for b, mode_b in enumerate(block_modes):
+                rotation[mode_a, mode_b] = sub[a, b]
+
+    # occupy fewer than all columns of each mixing block (occupying all would fill the subspace and
+    # collapse to a permutation), plus some isolated units -- interior ones drive interleaved peels
+    occupied_columns: list[int] = []
+    for block_modes in blocks:
+        num_occ = int(rng.integers(1, len(block_modes)))
+        occupied_columns += block_modes[:num_occ]
+    occupied_columns += [mode for mode in rest if rng.random() < 0.5]
+
+    occupation = [i in occupied_columns for i in range(num_modes)]
+    if not any(occupation) or all(occupation):
+        return None
+
+    orbital_coeffs = rotation[:, np.nonzero(occupation)[0]].T
+    peel_modes, kept_modes, reduced = _peel_disjoint_unit_orbitals(orbital_coeffs)
+
+    is_multi_block = False
+    if reduced.shape[0] > 0:
+        windows = []
+        for row in range(reduced.shape[0]):
+            support = [kept_modes[col] for col in np.nonzero(np.abs(reduced[row]) > 1e-10)[0]]
+            windows.append((min(support), max(support)))
+        order = sorted(range(len(windows)), key=lambda r: windows[r][0])
+        running_hi = windows[order[0]][1]
+        for r in order[1:]:
+            lo, hi = windows[r]
+            if lo > running_hi:
+                is_multi_block = True
+            running_hi = max(running_hi, hi)
+
+    is_interleaved_peel = bool(
+        reduced.shape[0] > 0
+        and peel_modes
+        and any(min(kept_modes) < p < max(kept_modes) for p in peel_modes)
+    )
+    return num_modes, occupation, rotation, is_multi_block, is_interleaved_peel
+
+
+def test_prepare_slater_determinant_synthesis_randomized_sweep():
+    """Randomized stress test of peel + block-split against the faithful reference.
+
+    Draws many multi-block occupied spaces -- mixing single- and multi-mode clusters on disjoint
+    windows, plus disjoint unit-orbitals, some of which land *between* a mixing cluster's endpoints.
+    Each synthesized state is checked against the faithful ``InitializeModes + OrbitalRotation``
+    reference (which never peels or block-splits). The seed is fixed for determinism and asserted to
+    genuinely exercise both load-bearing regimes -- multiple mixing blocks (block-splitting) and
+    interleaved peels (the #206 Z-string compensation) -- so the test cannot pass trivially.
     """
     rng = np.random.default_rng(20260724)
     trials = 0
-    interleaved = 0
-    for _ in range(200):
-        num_modes = int(rng.integers(3, 8))
-        perm = rng.permutation(num_modes)
-        block_size = int(rng.integers(2, min(4, num_modes) + 1))
-        mixing_modes = sorted(perm[:block_size].tolist())
-        rest = sorted(perm[block_size:].tolist())
-        # occupy fewer than all mixing columns so the block stays a genuine rotation (occupying every
-        # column would fill the subspace and collapse to a plain permutation), plus some isolated units
-        num_mixing_occ = int(rng.integers(1, len(mixing_modes)))
-        unit_occ = [mode for mode in rest if rng.random() < 0.5]
-        rotation = _block_rotation(num_modes, mixing_modes, seed=int(rng.integers(0, 10**6)))
-        occupied_cols = mixing_modes[:num_mixing_occ] + unit_occ
-        occupation = [i in occupied_cols for i in range(num_modes)]
-        if not any(occupation) or all(occupation):
+    multi_block = 0
+    interleaved_peel = 0
+    for _ in range(300):
+        drawn = _draw_multi_block_target(rng)
+        if drawn is None:
             continue
+        num_modes, occupation, rotation, is_multi_block, is_interleaved_peel = drawn
         trials += 1
+        multi_block += is_multi_block
+        interleaved_peel += is_interleaved_peel
 
-        orbital_coeffs = rotation[:, np.nonzero(occupation)[0]].T
-        peel_modes, kept_modes, _ = _peel_disjoint_unit_orbitals(orbital_coeffs)
-        if peel_modes and any(min(kept_modes) < p < max(kept_modes) for p in peel_modes):
-            interleaved += 1
+        _assert_matches_reference(num_modes, occupation, rotation)
 
-        slater = FermionicCircuit(num_modes)
-        slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
-        qc_slater = _synthesize(slater, _slater_synth())
+    # the seed genuinely stresses both load-bearing regimes, so the sweep guards them rather than
+    # trivially passing on structureless draws
+    assert trials > 150
+    assert multi_block > 20
+    assert interleaved_peel > 10
 
-        reference = FermionicCircuit(num_modes)
-        reference.append(InitializeModes(occupation), reference.modes)
-        reference.append(OrbitalRotation(rotation), reference.modes)
-        qc_reference = _synthesize(reference, _reference_synth())
 
-        _assert_equal_up_to_global_phase(qc_slater, qc_reference)
+def _synthesize_with_support_grouping(num_modes, occupation, rotation):
+    """Negative control: synthesize grouping mixing orbitals by raw SUPPORT overlap, not window.
 
-    # sanity: the seed actually stresses the load-bearing regime (interleaved peels), so this test
-    # genuinely guards the compensation rather than trivially passing on non-interleaved cases
-    assert trials > 100
-    assert interleaved > 20
+    This deliberately-wrong variant reproduces the plugin's peel + emission recipe exactly but groups
+    the mixing remainder by whether orbital *supports* intersect instead of whether their physical
+    *windows* overlap. Nested/interleaved windows (disjoint support, overlapping window) then split
+    into separate blocks and emit a rotation across an occupied mode -- preparing the wrong state.
+    """
+    occupied = np.nonzero(occupation)[0]
+    orbital_coeffs = rotation[:, occupied].T
+    peel_modes, kept_modes, reduced = _peel_disjoint_unit_orbitals(orbital_coeffs)
+
+    qc = QuantumCircuit(num_modes)
+    for mode in peel_modes:
+        qc.append(XGate(), [mode])
+    if reduced.shape[0] == 0:
+        return qc
+
+    # group by raw support overlap (WRONG): union-find over shared kept-mode columns
+    supports = [
+        set(np.nonzero(np.abs(reduced[row]) > 1e-10)[0].tolist()) for row in range(reduced.shape[0])
+    ]
+    parent = list(range(len(supports)))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a in range(len(supports)):
+        for b in range(a + 1, len(supports)):
+            if supports[a] & supports[b]:
+                parent[find(a)] = find(b)
+    groups: dict[int, list[int]] = {}
+    for row in range(len(supports)):
+        groups.setdefault(find(row), []).append(row)
+
+    for block_rows in groups.values():
+        cols = sorted(set().union(*(supports[row] for row in block_rows)))
+        block_modes = [kept_modes[col] for col in cols]
+        sub = np.ascontiguousarray(reduced[np.ix_(block_rows, cols)])
+        for i in range(len(block_rows)):
+            qc.append(XGate(), [block_modes[i]])
+        for c, s, i, j in givens_decomposition_slater(sub):
+            c_angle = np.acos(c)
+            if not np.isclose(c_angle, 0.0):
+                mode_i, mode_j = block_modes[i], block_modes[j]
+                lo, hi = min(mode_i, mode_j), max(mode_i, mode_j)
+                sign = -1 if sum(1 for p in peel_modes if lo < p < hi) % 2 == 0 else 1
+                qc.append(
+                    XXPlusYYGate(2 * c_angle, np.angle(s) + sign * 0.5 * np.pi), [mode_i, mode_j]
+                )
+    return qc
+
+
+def _synthesize_without_z_string(num_modes, occupation, rotation):
+    """Negative control: reproduce the plugin exactly but DROP the #206 Z-string sign compensation.
+
+    Groups by physical windows (correct) but always emits the base ``angle(s) - pi/2`` phase, ignoring
+    peeled modes between a rotation's endpoints. An interleaved peel with odd parity then prepares the
+    wrong state.
+    """
+    occupied = np.nonzero(occupation)[0]
+    orbital_coeffs = rotation[:, occupied].T
+    peel_modes, kept_modes, reduced = _peel_disjoint_unit_orbitals(orbital_coeffs)
+
+    qc = QuantumCircuit(num_modes)
+    for mode in peel_modes:
+        qc.append(XGate(), [mode])
+    if reduced.shape[0] == 0:
+        return qc
+
+    for block_rows, block_modes, sub in _split_mixing_blocks(reduced, kept_modes):
+        for i in range(len(block_rows)):
+            qc.append(XGate(), [block_modes[i]])
+        for c, s, i, j in givens_decomposition_slater(sub):
+            c_angle = np.acos(c)
+            if not np.isclose(c_angle, 0.0):
+                mode_i, mode_j = block_modes[i], block_modes[j]
+                # DROP the Z-string sign: always the base phase
+                qc.append(XXPlusYYGate(2 * c_angle, np.angle(s) - 0.5 * np.pi), [mode_i, mode_j])
+    return qc
+
+
+def _overlap(qc, num_modes, occupation, rotation) -> float:
+    qc_reference = _reference_circuit(num_modes, occupation, rotation)
+    return float(abs(Statevector(qc).inner(Statevector(qc_reference))) ** 2)
+
+
+def test_prepare_slater_determinant_synthesis_negative_control_support_grouping():
+    """A support-overlap grouping (instead of window overlap) breaks on nested/interleaved windows.
+
+    Guards the correct-path sweep against a too-gentle formulation: grouping mixing orbitals by raw
+    support overlap rather than physical-window overlap splits a nested-window pair into separate
+    blocks and emits a rotation across an occupied mode -- preparing the wrong state. The target is
+    the canonical nested-window case (mixing ``{0,3}`` and mixing ``{1,2}``: disjoint support, but
+    window ``[0,3]`` spans the occupied modes 1, 2), constructed so the pathology is hit by design.
+    The correct window grouping (the plugin) prepares this same target correctly -- verified by the
+    ``nested_windows`` structure case above.
+    """
+    num_modes = 4
+    rotation = _multi_block_rotation(num_modes, [[0, 3], [1, 2]], seed=17)
+    occupation = [i in (0, 1) for i in range(num_modes)]
+
+    qc_wrong = _synthesize_with_support_grouping(num_modes, occupation, rotation)
+    assert not np.isclose(_overlap(qc_wrong, num_modes, occupation, rotation), 1.0, atol=1e-8)
+
+
+def test_prepare_slater_determinant_synthesis_negative_control_no_z_string():
+    """Dropping the #206 Z-string sign compensation breaks on an odd-parity interleaved peel.
+
+    Guards the correct-path sweep's other load-bearing assumption: emitting the base ``XXPlusYYGate``
+    phase without folding in the Jordan-Wigner Z-string of an odd number of peeled interior modes
+    prepares the wrong state. The target is the #206 peel-bug shape (mixing the non-adjacent modes
+    ``{0,2}`` with a peeled unit on the interior mode 1, odd parity), constructed so the compensation
+    is load-bearing. The compensated plugin prepares this same target correctly -- verified by
+    ``test_..._interleaved_peel_odd_parity`` above.
+    """
+    num_modes = 3
+    rotation = _multi_block_rotation(num_modes, [[0, 2]], seed=3)
+    occupation = [True, True, False]
+
+    qc_wrong = _synthesize_without_z_string(num_modes, occupation, rotation)
+    assert not np.isclose(_overlap(qc_wrong, num_modes, occupation, rotation), 1.0, atol=1e-8)

--- a/tests/python/transpiler/presets/test_jordan_wigner.py
+++ b/tests/python/transpiler/presets/test_jordan_wigner.py
@@ -27,6 +27,7 @@ from qiskit_fermions.circuit.library import (
 )
 from qiskit_fermions.mappers.library import jordan_wigner
 from qiskit_fermions.operators import FermionOperator
+from qiskit_fermions.transpiler import FermionicPassManager
 from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager
 
 from ...utils import random_unitary
@@ -203,12 +204,13 @@ def test_preset_jordan_wigner_merges_initialize_rotation():
 
 
 def test_preset_jordan_wigner_merges_single_per_spin_rotation():
-    """The preset fuses a global init with a single per-spin rotation, identity-padding the rest.
+    """The preset fuses a global init with a single per-spin rotation into a Slater preparation.
 
     A full-register InitializeModes followed by an OrbitalRotation on only one spin half fuses into
-    two PrepareSlaterDeterminant gates (the rotated half plus an identity-padded half). The result
-    matches the state of the equivalent block-diagonal OrbitalRotation (up to a global phase) while
-    emitting strictly fewer two-qubit rotations and no phase gates.
+    a PrepareSlaterDeterminant, which lowers with the reduced Slater decomposition. The result
+    matches the state of lowering the same circuit *without* the merge -- where the rotation lowers
+    via its full square Givens decomposition -- up to a global phase, while emitting strictly fewer
+    two-qubit rotations and no phase gates.
     """
     norb = 3
     rotation = random_unitary(norb, seed=7)
@@ -220,25 +222,25 @@ def test_preset_jordan_wigner_merges_single_per_spin_rotation():
     pm = generate_preset_jw_pass_manager()
     merged = pm.run(circ)
 
-    # equivalent reference: the same rotation as a full-register block-diagonal OrbitalRotation
-    # (alpha half rotated, beta half identity), with nothing to merge into so it takes the square path
-    block_diag = np.eye(2 * norb, dtype=complex)
-    block_diag[:norb, :norb] = rotation
-    reference = FermionicCircuit(2 * norb)
-    reference.append(InitializeModes.from_hartree_fock(norb, (2, 1)), reference.modes)
-    reference.append(OrbitalRotation(block_diag), reference.modes)
-    lowered_reference = pm.run(reference)
+    # baseline: lower the *same* circuit without the merge optimization stage, so the initialization
+    # lowers via TrivialOccupation and the rotation via its full square Givens decomposition (which
+    # carries diagonal phase gates and a denser rotation pattern). This isolates what the fusion into
+    # a PrepareSlaterDeterminant buys -- a reference fed back through the merging preset would be
+    # fused (and block-split) too, flattening the comparison.
+    pm.optimization = FermionicPassManager()
+    unmerged = pm.run(circ)
 
     sv_merged = Statevector(merged).data
-    sv_reference = Statevector(lowered_reference).data
-    k = int(np.argmax(np.abs(sv_reference)))
-    phase = sv_merged[k] / sv_reference[k]
-    np.testing.assert_allclose(sv_merged, phase * sv_reference, atol=1e-10)
+    sv_unmerged = Statevector(unmerged).data
+    k = int(np.argmax(np.abs(sv_unmerged)))
+    phase = sv_merged[k] / sv_unmerged[k]
+    np.testing.assert_allclose(sv_merged, phase * sv_unmerged, atol=1e-10)
 
+    # the fusion drops the diagonal phase gates the square rotation would emit ...
     assert "p" not in merged.count_ops()
-    assert merged.count_ops().get("xx_plus_yy", 0) < lowered_reference.count_ops().get(
-        "xx_plus_yy", 0
-    )
+    assert "p" in unmerged.count_ops()
+    # ... and emits strictly fewer two-qubit rotations than the un-fused square decomposition
+    assert merged.count_ops().get("xx_plus_yy", 0) < unmerged.count_ops().get("xx_plus_yy", 0)
 
 
 def test_preset_jordan_wigner_merges_rotation_run_then_slater_prep():


### PR DESCRIPTION
### Summary

Generalizes the Slater-determinant synthesis plugin to **block-split the genuinely-mixing remainder**. After peeling disjoint unit-orbitals (#206), the remaining mixing orbitals are partitioned into groups whose physical-mode windows are disjoint, and each group is synthesized independently on its own contiguous window. Interior gaps *between* mixing clusters — which peeling alone cannot remove — factor out, so no transport `SWAP`s are ever emitted across them.

### Motivation

The rectangular *leading*-reference Givens sweep (`givens_decomposition_slater`) seeds the occupation on the leading modes and transports it out to the physical support. When the occupied space splits into clusters separated by empty modes, most of the sweep is spent on bare transport `SWAP`s (`XXPlusYYGate` with `c = 0`) shuttling occupation across the gaps. Peeling (#206) removes disjoint *unit*-orbitals but leaves those inter-cluster gaps in the mixing remainder; block-splitting factors them out.

### Example

```python
import numpy as np
from qiskit_fermions.circuit import FermionicCircuit
from qiskit_fermions.circuit.library import PrepareSlaterDeterminant
from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager

# n = 8: mixing cluster on modes {0,1}, a unit-orbital on 3, mixing cluster on {5,6}
occupation = [True, True, False, True, False, True, True, False]
rotation = ...  # block-diagonal: 2x2 mixing on {0,1}, unit on 3, 2x2 mixing on {5,6}

circ = FermionicCircuit(8)
circ.append(PrepareSlaterDeterminant(occupation, rotation), circ.modes)
lowered = generate_preset_jw_pass_manager().run(circ)

# before this PR (peel-only): both clusters swept across the whole line
#   -> 6 XXPlusYYGate
# after this PR (peel + block-split): two independent 2x2 leading sweeps
#   -> 2 XXPlusYYGate
```
