### PR TITLE
Generalize `jordan_wigner`

### DIFF
--- a/crates/cext/src/mappers/library/jordan_wigner.rs
+++ b/crates/cext/src/mappers/library/jordan_wigner.rs
@@ -13,7 +13,7 @@
 use crate::exit_codes::ExitCode;
 use crate::pointers::const_ptr_as_ref;
 
-use qiskit_fermions_core::mappers::library::jordan_wigner::jordan_wigner;
+use qiskit_fermions_core::mappers::library::jordan_wigner::fermion_jordan_wigner;
 use qiskit_fermions_core::operators::fermion_operator::FermionOperator;
 
 /// @ingroup qf_mapper_library
@@ -70,13 +70,13 @@ use qiskit_fermions_core::operators::fermion_operator::FermionOperator;
 ///
 ///     // and map it to a qubit operator
 ///     QkObs *result;
-///     QfExitCode exit = qf_jordan_wigner(hamil, 4, &result);
+///     QfExitCode exit = qf_ferm_op_jordan_wigner(hamil, 4, &result);
 ///
 ///     assert(exit == QfExitCode_Success);
 ///
 /// @endrst
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qf_jordan_wigner(
+pub unsafe extern "C" fn qf_ferm_op_jordan_wigner(
     op: *const FermionOperator,
     num_qubits: u32,
     out: *mut *mut qiskit_sys::QkObs,
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn qf_jordan_wigner(
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let op = unsafe { const_ptr_as_ref(op) };
 
-    match jordan_wigner(op, num_qubits) {
+    match fermion_jordan_wigner(op, num_qubits) {
         Ok(obs) => {
             // SAFETY: Per documentation, `out` is non-null and aligned.
             unsafe { out.write(obs) };

--- a/crates/core/src/mappers/library/jordan_wigner.rs
+++ b/crates/core/src/mappers/library/jordan_wigner.rs
@@ -78,7 +78,7 @@ unsafe impl Send for Wrapper {}
 
 // TODO: can we clean up the coding pattern of overwriting a data structure in-place to avoid the
 // repetitive re-allocations?
-pub fn jordan_wigner(
+pub fn fermion_jordan_wigner(
     fer_op: &FermionOperator,
     num_qubits: u32,
 ) -> Result<*mut ffi::QkObs, CoherenceError> {
@@ -259,7 +259,7 @@ mod tests {
             ],
             groups: None,
         };
-        let qb_op = jordan_wigner(&fer_op, 4).unwrap();
+        let qb_op = fermion_jordan_wigner(&fer_op, 4).unwrap();
 
         let mut coeffs: Vec<QkComplex64> = vec![
             QkComplex64 {
@@ -378,7 +378,7 @@ mod tests {
         };
 
         // too few qubits must be reported instead of aborting the process
-        let err = jordan_wigner(&fer_op, 3).unwrap_err();
+        let err = fermion_jordan_wigner(&fer_op, 3).unwrap_err();
         assert!(matches!(
             err,
             CoherenceError::NumQubitsTooSmall {
@@ -388,6 +388,6 @@ mod tests {
         ));
 
         // exactly enough qubits succeeds
-        assert!(jordan_wigner(&fer_op, 4).is_ok());
+        assert!(fermion_jordan_wigner(&fer_op, 4).is_ok());
     }
 }

--- a/crates/pyext/src/mappers/library/jordan_wigner.rs
+++ b/crates/pyext/src/mappers/library/jordan_wigner.rs
@@ -13,7 +13,7 @@
 use crate::operators::fermion_operator::PyFermionOperator;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
-use qiskit_fermions_core::mappers::library::jordan_wigner::jordan_wigner;
+use qiskit_fermions_core::mappers::library::jordan_wigner::fermion_jordan_wigner;
 use qiskit_pyo3_ffi as ffi;
 
 /// Map a :class:`.FermionOperator` to a :class:`~qiskit.quantum_info.SparseObservable` under the
@@ -65,7 +65,7 @@ use qiskit_pyo3_ffi as ffi;
 ///
 /// .. doctest::
 ///
-///     >>> from qiskit_fermions.mappers.library import jordan_wigner
+///     >>> from qiskit_fermions.mappers.library import fermion_jordan_wigner
 ///     >>> from qiskit_fermions.operators import FermionOperator
 ///     >>> fop = FermionOperator.from_dict(
 ///     ...     {
@@ -74,7 +74,7 @@ use qiskit_pyo3_ffi as ffi;
 ///     ...         ((True, 1), (False, 2), (True, 2), (False, 1)): -1.0j,
 ///     ...     }
 ///     ... )
-///     >>> qop = jordan_wigner(fop, 4)
+///     >>> qop = fermion_jordan_wigner(fop, 4)
 ///     >>> qop.simplify()
 ///     <SparseObservable with 5 terms on 4 qubits: (2.05-0.25j)() + (-0.05+0j)(Z_0) + (0+0.25j)(Z_1) + (0+0.25j)(Z_2 Z_1) + (0-0.25j)(Z_2)>
 ///
@@ -82,10 +82,10 @@ use qiskit_pyo3_ffi as ffi;
 ///        Zeitschrift für Physik 47, No. 9. (1928), pp. 631–651,
 ///        `doi:10.1007/BF01331938 <https://link.springer.com/article/10.1007/BF01331938>`_.
 #[gen_stub_pyfunction(module = "qiskit_fermions._lib.mappers.mappers_library.jordan_wigner")]
-#[pyfunction(name = "jordan_wigner")]
+#[pyfunction(name = "fermion_jordan_wigner")]
 #[gen_stub(override_return_type(type_repr="qiskit.quantum_info.SparseObservable", imports=("qiskit.quantum_info")))]
-pub fn py_jordan_wigner(op: PyFermionOperator, num_qubits: u32) -> PyResult<Py<PyAny>> {
-    let obs = jordan_wigner(&op.inner, num_qubits).map_err(crate::value_err)?;
+pub fn py_fermion_jordan_wigner(op: PyFermionOperator, num_qubits: u32) -> PyResult<Py<PyAny>> {
+    let obs = fermion_jordan_wigner(&op.inner, num_qubits).map_err(crate::value_err)?;
     unsafe {
         let py = Python::assume_attached();
         let py_obs = ffi::qk_obs_to_python(obs);
@@ -96,5 +96,5 @@ pub fn py_jordan_wigner(op: PyFermionOperator, num_qubits: u32) -> PyResult<Py<P
 #[pymodule]
 pub mod jordan_wigner {
     #[pymodule_export]
-    use super::py_jordan_wigner;
+    use super::py_fermion_jordan_wigner;
 }

--- a/docs/cdoc/qf-mappers-library.rst
+++ b/docs/cdoc/qf-mappers-library.rst
@@ -9,15 +9,15 @@ routines.
 
 .. table::
 
-  ================================ ==================================================
-  :c:func:`qf_jordan_wigner`       Map a :c:struct:`QfFermionOperator` to a
-                                   :external+cqiskit:doc:`QkObs <cdoc/qk-obs>` under the
-                                   Jordan-Wigner transformation.
-  :c:func:`qf_fermion_to_majorana` Map a :c:struct:`QfFermionOperator` to a
-                                   :c:struct:`QfMajoranaOperator`.
-  :c:func:`qf_majorana_to_fermion` Map a :c:struct:`QfMajoranaOperator` to a
-                                   :c:struct:`QfFermionOperator`.
-  ================================ ==================================================
+  ==================================== ==================================================
+  :c:func:`qf_ferm_op_jordan_wigner`   Map a :c:struct:`QfFermionOperator` to a
+                                       :external+cqiskit:doc:`QkObs <cdoc/qk-obs>` under the
+                                       Jordan-Wigner transformation.
+  :c:func:`qf_fermion_to_majorana`     Map a :c:struct:`QfFermionOperator` to a
+                                       :c:struct:`QfMajoranaOperator`.
+  :c:func:`qf_majorana_to_fermion`     Map a :c:struct:`QfMajoranaOperator` to a
+                                       :c:struct:`QfFermionOperator`.
+  ==================================== ==================================================
 
 ----
 

--- a/python/qiskit_fermions/_lib/mappers/mappers_library/jordan_wigner/__init__.pyi
+++ b/python/qiskit_fermions/_lib/mappers/mappers_library/jordan_wigner/__init__.pyi
@@ -5,10 +5,10 @@ import builtins
 import qiskit.quantum_info
 from qiskit_fermions._lib.operators import fermion_operator
 __all__ = [
-    "jordan_wigner",
+    "fermion_jordan_wigner",
 ]
 
-def jordan_wigner(op: fermion_operator.FermionOperator, num_qubits: builtins.int) -> qiskit.quantum_info.SparseObservable:
+def fermion_jordan_wigner(op: fermion_operator.FermionOperator, num_qubits: builtins.int) -> qiskit.quantum_info.SparseObservable:
     r"""
     Map a :class:`.FermionOperator` to a :class:`~qiskit.quantum_info.SparseObservable` under the
     Jordan-Wigner transformation. [1]_
@@ -59,7 +59,7 @@ def jordan_wigner(op: fermion_operator.FermionOperator, num_qubits: builtins.int
     
     .. doctest::
     
-        >>> from qiskit_fermions.mappers.library import jordan_wigner
+        >>> from qiskit_fermions.mappers.library import fermion_jordan_wigner
         >>> from qiskit_fermions.operators import FermionOperator
         >>> fop = FermionOperator.from_dict(
         ...     {
@@ -68,7 +68,7 @@ def jordan_wigner(op: fermion_operator.FermionOperator, num_qubits: builtins.int
         ...         ((True, 1), (False, 2), (True, 2), (False, 1)): -1.0j,
         ...     }
         ... )
-        >>> qop = jordan_wigner(fop, 4)
+        >>> qop = fermion_jordan_wigner(fop, 4)
         >>> qop.simplify()
         <SparseObservable with 5 terms on 4 qubits: (2.05-0.25j)() + (-0.05+0j)(Z_0) + (0+0.25j)(Z_1) + (0+0.25j)(Z_2 Z_1) + (0-0.25j)(Z_2)>
     

--- a/python/qiskit_fermions/mappers/library/__init__.py
+++ b/python/qiskit_fermions/mappers/library/__init__.py
@@ -25,6 +25,7 @@ routines.
    :toctree: ../stubs/
 
    jordan_wigner
+   fermion_jordan_wigner
    fermion_to_majorana
    majorana_to_fermion
    edge_vertex_to_fermion
@@ -34,11 +35,17 @@ routines.
    transfer_vertex_to_edge_vertex
 """
 
+from __future__ import annotations
+
+from qiskit.quantum_info import SparseObservable
+
 from qiskit_fermions._lib.mappers.mappers_library.edge_vertex import (
     edge_vertex_to_fermion,
     edge_vertex_to_majorana,
 )
-from qiskit_fermions._lib.mappers.mappers_library.jordan_wigner import jordan_wigner
+from qiskit_fermions._lib.mappers.mappers_library.jordan_wigner import (
+    fermion_jordan_wigner,
+)
 from qiskit_fermions._lib.mappers.mappers_library.majorana_fermion import (
     fermion_to_majorana,
     majorana_to_fermion,
@@ -48,10 +55,65 @@ from qiskit_fermions._lib.mappers.mappers_library.transfer_vertex import (
     transfer_vertex_to_fermion,
     transfer_vertex_to_majorana,
 )
+from qiskit_fermions.operators import FermionOperator
+from qiskit_fermions.operators.protocol import OperatorTrait
+
+
+def jordan_wigner(operator: OperatorTrait, num_qubits: int) -> SparseObservable:
+    """Map an operator to a :class:`~qiskit.quantum_info.SparseObservable` under the Jordan-Wigner
+    transformation.
+
+    This is the type-agnostic entry point to the Jordan-Wigner transformation. It dispatches on the
+    concrete type of ``operator`` to the appropriate direct implementation. Today only
+    :class:`.FermionOperator` is supported, delegating to :func:`.fermion_jordan_wigner`; any other
+    operator type raises a :class:`TypeError` until a direct implementation exists for it.
+
+    Args:
+        operator: the operator to map.
+        num_qubits: the number of qubits for the resulting qubit operator. This must be strictly
+            greater than the largest mode index in ``operator`` (any additional qubits are padded
+            with the identity).
+
+    Returns:
+        The mapped qubit operator.
+
+    Raises:
+        TypeError: if ``operator`` is of a type for which no Jordan-Wigner implementation exists.
+        ValueError: if ``num_qubits`` is too small to hold the operator's support.
+
+    .. doctest::
+
+        >>> from qiskit_fermions.mappers.library import jordan_wigner
+        >>> from qiskit_fermions.operators import FermionOperator
+        >>> fop = FermionOperator.from_dict({((True, 0), (False, 0)): 0.1})
+        >>> jordan_wigner(fop, 2).simplify()
+        <SparseObservable with 2 terms on 2 qubits: (0.05+0j)() + (-0.05+0j)(Z_0)>
+
+    An operator type without a direct implementation raises a :class:`TypeError`:
+
+    .. doctest::
+
+        >>> from qiskit_fermions.operators import MajoranaOperator
+        >>> mop = MajoranaOperator.from_dict({(0, 1): 1.0})
+        >>> jordan_wigner(mop, 2)
+        Traceback (most recent call last):
+        ...
+        TypeError: jordan_wigner does not support operator type 'MajoranaOperator'; only FermionOperator is supported today.
+    """
+    match operator:
+        case FermionOperator():
+            return fermion_jordan_wigner(operator, num_qubits)
+        case _:
+            raise TypeError(
+                f"jordan_wigner does not support operator type "
+                f"{type(operator).__name__!r}; only FermionOperator is supported today."
+            )
+
 
 __all__ = [
     "edge_vertex_to_fermion",
     "edge_vertex_to_majorana",
+    "fermion_jordan_wigner",
     "fermion_to_majorana",
     "jordan_wigner",
     "majorana_to_fermion",

--- a/tests/c/test_jordan_wigner.c
+++ b/tests/c/test_jordan_wigner.c
@@ -48,7 +48,7 @@ static int test_mapping(void) {
     }
 
     QkObs *result;
-    if (qf_jordan_wigner(hamil, 4, &result) != QfExitCode_Success) {
+    if (qf_ferm_op_jordan_wigner(hamil, 4, &result) != QfExitCode_Success) {
         qf_ferm_op_free(hamil);
         return RuntimeError;
     }
@@ -103,7 +103,7 @@ static int test_num_qubits_too_small(void) {
 
     // too few qubits must be reported instead of aborting the process
     QkObs *result = NULL;
-    QfExitCode exit = qf_jordan_wigner(op, 3, &result);
+    QfExitCode exit = qf_ferm_op_jordan_wigner(op, 3, &result);
 
     qf_ferm_op_free(op);
 

--- a/tests/python/mappers/library/test_jordan_wigner.py
+++ b/tests/python/mappers/library/test_jordan_wigner.py
@@ -12,11 +12,11 @@
 
 import pytest
 from qiskit.quantum_info import SparseObservable
-from qiskit_fermions.mappers.library import jordan_wigner
-from qiskit_fermions.operators import FermionOperator
+from qiskit_fermions.mappers.library import fermion_jordan_wigner, jordan_wigner
+from qiskit_fermions.operators import FermionOperator, MajoranaOperator
 
 
-def test_jordan_wigner():
+def test_fermion_jordan_wigner():
     num_qubits = 4
     op = FermionOperator.from_dict(
         {
@@ -36,7 +36,7 @@ def test_jordan_wigner():
             ((True, 3), (False, 3)): -0.4718960072811406,
         }
     )
-    qop = jordan_wigner(op, num_qubits)
+    qop = fermion_jordan_wigner(op, num_qubits)
     assert isinstance(qop, SparseObservable)
     expected = SparseObservable.from_sparse_list(
         [
@@ -62,12 +62,28 @@ def test_jordan_wigner():
     assert diff == SparseObservable.zero(num_qubits)
 
 
-def test_jordan_wigner_num_qubits_too_small():
+def test_fermion_jordan_wigner_num_qubits_too_small():
     # an operator acting on mode index 3 requires at least 4 qubits; too few qubits must raise a
     # catchable ValueError instead of aborting the interpreter
     op = FermionOperator.from_dict({((True, 3),): 1.0})
     with pytest.raises(ValueError):
-        jordan_wigner(op, 3)
+        fermion_jordan_wigner(op, 3)
 
     # exactly enough qubits succeeds
-    assert isinstance(jordan_wigner(op, 4), SparseObservable)
+    assert isinstance(fermion_jordan_wigner(op, 4), SparseObservable)
+
+
+def test_jordan_wigner_dispatches_fermion():
+    # the type-agnostic entry point must delegate FermionOperator inputs to fermion_jordan_wigner
+    op = FermionOperator.from_dict({((True, 0), (False, 0)): 0.1, ((True, 1), (False, 1)): -0.2})
+    dispatched = jordan_wigner(op, 3)
+    direct = fermion_jordan_wigner(op, 3)
+    assert isinstance(dispatched, SparseObservable)
+    assert (dispatched - direct).simplify() == SparseObservable.zero(3)
+
+
+def test_jordan_wigner_unsupported_type_raises():
+    # any operator type without a direct implementation must raise TypeError (not silently fail)
+    maj_op = MajoranaOperator.from_dict({(0, 1): 1.0})
+    with pytest.raises(TypeError, match="MajoranaOperator"):
+        jordan_wigner(maj_op, 2)


### PR DESCRIPTION
The `jordan_wigner` mapper was another instance of false security since its name suggests to be more general than it truly was (see also #181). This PR adjusts the public API functions to correctly reflect that today's JW implementation is bound against the `FermionOperator` type.

On Python, we introduce a `jordan_wigner` wrapper which delegates to the correct fast paths depending on the provided operator type and raises `TypeError`s on unsupported types.

:warning: This is definitely a breaking change for the C API!