### PR TITLE
refactor(ucj): parallelize diagonal Coulomb evolution via disjoint-support groups

### DIFF
--- a/python/qiskit_fermions/circuit/library/ucj.py
+++ b/python/qiskit_fermions/circuit/library/ucj.py
@@ -600,8 +600,17 @@ class UCJ(FermionicGate):
         mode convention (mode ``p`` is alpha orbital ``p``, mode ``norb + p`` is beta orbital ``p``).
         The alpha-alpha/alpha-beta/beta-beta blocks are resolved per spin variant. All terms commute,
         so the resulting :class:`.Evolution` is exact.
+
+        Every term is a number-operator product ``n_{i sigma} n_{j tau}`` acting on the (at most two)
+        modes ``{i + sigma*norb, j + tau*norb}``. Each ``(block, i, j)`` triple maps to a distinct
+        term (no coefficient accumulation into a shared key is ever needed), so the terms are built
+        directly with a :attr:`~qiskit_fermions.operators.FermionOperator.groups` index each, such
+        that all same-group terms have mutually disjoint support and :class:`.Evolution` synthesis
+        emits one parallel layer of two-mode gates per group. The group index is a closed-form edge
+        coloring of the interaction graph (see :meth:`_term_group`), assigned on the fly.
         """
         norb = self.norb
+        num_modes = norb if self._spinless else 2 * norb
         mat_aa, mat_ab, mat_bb = self._resolve_diag_coulomb_blocks(diag_coulomb_mat)
 
         # a true spinless system has only the aa block on the norb spinless modes
@@ -610,7 +619,8 @@ class UCJ(FermionicGate):
         else:
             blocks = {(0, 0): mat_aa, (0, 1): mat_ab, (1, 0): mat_ab.T, (1, 1): mat_bb}
 
-        terms: dict[tuple, complex] = {}
+        # each (block, i, j) is a distinct term, so build them directly -- no collision-handling dict.
+        terms_with_groups: list[tuple[tuple, complex, int]] = []
         for (sigma, tau), block in blocks.items():
             offset_i = sigma * norb
             offset_j = tau * norb
@@ -622,9 +632,54 @@ class UCJ(FermionicGate):
                     mode_i = offset_i + i
                     mode_j = offset_j + j
                     term = (cre(mode_i), ann(mode_i), cre(mode_j), ann(mode_j))
-                    terms[term] = terms.get(term, 0.0) + coeff
+                    group = self._term_group(num_modes, mode_i, mode_j)
+                    terms_with_groups.append((term, coeff, group))
 
-        return FermionOperator.from_dict(terms)  # type: ignore[arg-type]
+        return FermionOperator.from_terms_with_groups(terms_with_groups)
+
+    @staticmethod
+    def _term_group(num_modes: int, mode_i: int, mode_j: int) -> int:
+        r"""Returns the disjoint-support group index for the term ``n_{mode_i} n_{mode_j}``.
+
+        The diagonal Coulomb terms form a *doubled* complete graph on the ``num_modes`` modes: every
+        unordered off-diagonal pair ``{p, q}`` carries two terms (the ``(i, j)`` and ``(j, i)``
+        orderings) and every mode carries one on-site number term ``n_p`` (the ``i == j`` case). This
+        assigns each term a color -- one :class:`.Evolution` group -- so that same-color terms share
+        no mode, hence each group synthesizes as a single parallel layer of (at most two-mode) gates.
+
+        The coloring is the closed-form *circle method* (round-robin) edge coloring of the complete
+        graph, doubled to carry both orderings of each pair, so it needs no per-term state and is
+        layer-**optimal**: it uses exactly the maximum mode degree ``2*num_modes - 1`` colors for even
+        ``num_modes`` (always the case for a spinful register), and ``2*num_modes`` for odd
+        ``num_modes`` -- the latter being unavoidable (an odd complete graph cannot be edge-colored in
+        fewer than ``num_modes`` colors, i.e. degree ``+ 1``).
+
+        Args:
+            num_modes: the number of modes the diagonal Coulomb operator acts on.
+            mode_i: the first mode of the term (its outer number operator).
+            mode_j: the second mode of the term (its inner number operator).
+
+        Returns:
+            The group index (color) for this term.
+        """
+        n = num_modes
+        # on-site term n_p (a self-loop at mode p): take the one color the circle method leaves free
+        # at p. For odd n that free pair-color is (2p) mod n (doubled to its lower slot); for even n
+        # every pair-color is occupied at every mode, so on-site terms share one extra top color.
+        if mode_i == mode_j:
+            return 2 * ((2 * mode_i) % n) if n % 2 else 2 * (n - 1)
+
+        # off-diagonal pair {p, q}: circle-method color of the edge, doubled to fit both orderings.
+        # The ordering copy index r (0 for i < j, 1 for i > j) separates the two same-spin terms that
+        # share this support; cross-spin orderings land on different supports and never collide.
+        p, q = (mode_i, mode_j) if mode_i < mode_j else (mode_j, mode_i)
+        copy = 0 if mode_i < mode_j else 1
+        if n % 2:
+            edge_color = (p + q) % n
+        else:
+            m = n - 1
+            edge_color = (2 * p) % m if q == m else (p + q) % m
+        return 2 * edge_color + copy
 
     def _resolve_diag_coulomb_blocks(
         self, diag_coulomb_mat: np.ndarray

--- a/tests/python/circuit/library/test_ucj.py
+++ b/tests/python/circuit/library/test_ucj.py
@@ -273,3 +273,114 @@ def test_orbital_rotation_from_t1_amplitudes_is_unitary():
     assert gate.num_modes == 4
     u = gate.rotation_unitary
     np.testing.assert_allclose(u.conj().T @ u, np.eye(4), atol=1e-12)
+
+
+def _term_supports(operator):
+    """Returns each term's support (its set of modes) in iteration order."""
+    return [{mode for _, mode in term} for term, _ in operator.iter_terms()]
+
+
+def _reference_diag_coulomb_terms(gate, diag_coulomb_mat):
+    """The ungrouped ``{term: coeff}`` reference for one repetition's diagonal Coulomb operator."""
+    norb = gate.norb
+    mat_aa, mat_ab, mat_bb = gate._resolve_diag_coulomb_blocks(diag_coulomb_mat)
+    if gate._spinless:
+        blocks = {(0, 0): mat_aa}
+    else:
+        blocks = {(0, 0): mat_aa, (0, 1): mat_ab, (1, 0): mat_ab.T, (1, 1): mat_bb}
+    terms: dict[tuple, complex] = {}
+    for (sigma, tau), block in blocks.items():
+        for i in range(norb):
+            for j in range(norb):
+                coeff = 0.5 * block[i, j]
+                if coeff == 0.0:
+                    continue
+                mode_i, mode_j = sigma * norb + i, tau * norb + j
+                key = ((True, mode_i), (False, mode_i), (True, mode_j), (False, mode_j))
+                terms[key] = terms.get(key, 0.0) + coeff
+    return terms
+
+
+@pytest.mark.parametrize("norb", [1, 2, 3, 4, 5])
+def test_diag_coulomb_grouping_preserves_operator(norb):
+    """Grouping the diagonal Coulomb terms leaves the operator itself unchanged (balanced variant)."""
+    from qiskit_fermions.operators import FermionOperator
+
+    mats, rotations = _balanced_tensors(norb, 1, seed=100 + norb)
+    gate = UCJ(norb, (1, 1), mats, rotations)
+    operator = gate._diag_coulomb_operator(gate.diag_coulomb_mats[0])
+
+    reference = FermionOperator.from_dict(
+        _reference_diag_coulomb_terms(gate, gate.diag_coulomb_mats[0])
+    )
+    assert operator.equiv(reference, 1e-12)
+
+
+@pytest.mark.parametrize(
+    ("variant", "nelec", "norb"),
+    [
+        ("balanced", (1, 1), 4),
+        ("spinless", 2, 4),  # spinful sector: 2*norb block-spin modes
+        ("spinless", 3, 5),  # true spinless sector: norb modes
+    ],
+)
+def test_diag_coulomb_groups_have_disjoint_support(variant, nelec, norb):
+    """Every diagonal Coulomb group's terms act on mutually disjoint modes (one parallel layer)."""
+    rng = np.random.default_rng(hash((variant, norb)) % (2**32))
+    if variant == "balanced":
+        mats = rng.standard_normal((1, 2, norb, norb))
+        mats = mats + mats.transpose(0, 1, 3, 2)
+    else:
+        mats = rng.standard_normal((1, norb, norb))
+        mats = mats + mats.transpose(0, 2, 1)
+    rotations = np.stack([random_unitary(norb, seed=7)])
+    gate = UCJ(norb, nelec, mats, rotations)
+
+    operator = gate._diag_coulomb_operator(gate.diag_coulomb_mats[0])
+    assert operator.groups is not None
+    for group in operator.split_out_groups():
+        seen: set[int] = set()
+        for support in _term_supports(group):
+            assert not (support & seen), "group has overlapping term supports"
+            seen |= support
+
+
+@pytest.mark.parametrize(
+    ("variant", "nelec", "norb"),
+    [
+        ("balanced", (1, 1), 3),  # spinful sector: even num_modes = 2*norb
+        ("balanced", (1, 1), 4),
+        ("balanced", (1, 1), 5),
+        ("spinless", 3, 3),  # true spinless sector: odd num_modes = norb (odd)
+        ("spinless", 4, 4),  # true spinless sector: even num_modes = norb (even)
+        ("spinless", 5, 5),  # true spinless sector: odd num_modes = norb (odd)
+    ],
+)
+def test_diag_coulomb_group_count_is_optimal(variant, nelec, norb):
+    """The group (layer) count matches the provable optimum of the closed-form circle coloring.
+
+    Every term sharing a mode must land in a distinct group, so the count is bounded below by the
+    maximum mode degree. For an even mode count that lower bound is achievable and hit exactly; for
+    an odd mode count (an odd complete graph) the chromatic index is one higher and unavoidable. The
+    circle-method coloring attains this optimum in both cases.
+    """
+    rng = np.random.default_rng(hash((variant, norb)) % (2**32))
+    if variant == "balanced":
+        mats = rng.standard_normal((1, 2, norb, norb))
+        mats = mats + mats.transpose(0, 1, 3, 2)
+    else:
+        mats = rng.standard_normal((1, norb, norb))
+        mats = mats + mats.transpose(0, 2, 1)
+    rotations = np.stack([random_unitary(norb, seed=7)])
+    gate = UCJ(norb, nelec, mats, rotations)
+    operator = gate._diag_coulomb_operator(gate.diag_coulomb_mats[0])
+
+    degree: dict[int, int] = {}
+    for support in _term_supports(operator):
+        for mode in support:
+            degree[mode] = degree.get(mode, 0) + 1
+    max_degree = max(degree.values())
+
+    # even mode count -> optimum == max degree; odd -> the unavoidable max degree + 1
+    optimum = max_degree if gate.num_modes % 2 == 0 else max_degree + 1
+    assert operator.num_groups() == optimum


### PR DESCRIPTION
### What

The diagonal Coulomb operator built for each UCJ repetition now tags its terms with groups indices so that Evolution synthesis emits parallel layers of two-mode gates instead of one gate per term.

### Why

Two issues in `UCJ._diag_coulomb_operator`:

1. It accumulated terms into a dict keyed by term, guarding against key collisions that can never occur — each `(block, i, j)` triple is a distinct term. The dict (and its `raise KeyError`) was dead defensiveness.
2. The operator carried no group indices, so synthesis serialized every `n_i n_j` term into its own gate with zero parallelism.

### How

- Terms are built directly as a list with a per-term `groups` index — no collision-handling dict.
- Same-group terms are guaranteed mutually disjoint support, so each group synthesizes as a single parallel layer.
- The grouping is a closed-form circle-method (round-robin) edge coloring assigned on the fly (no collected state). The interaction graph is a doubled complete graph on the modes, whose optimal edge coloring is a direct formula of the two mode indices.

### Result

The coloring is layer-optimal:
- Even mode count (always the case for a spinful register): exactly `2·num_modes` − 1 layers = the max mode degree.
- Odd mode count (spinless odd `norb`): `2·num_modes`, one above the degree — unavoidable for an odd complete graph.