### PR TITLE
refactor(transpiler): default Slater-prep synthesis to minimal two-qubit depth

### DIFF
--- a/python/qiskit_fermions/transpiler/passes/synthesis/prepare_slater_determinant.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/prepare_slater_determinant.py
@@ -193,12 +193,13 @@ class GivensDecompositionSlaterDeterminantSynthesis:
        or not.
 
     .. note::
-       Occupied orbitals that are basis vectors on a mode disjoint from every other occupied orbital
-       are *peeled off* before the decomposition: their ``XGate`` is placed directly on the target
-       mode and they are excluded from the Givens sweep. This avoids the chain of bare ``SWAP``\ s
-       (``XXPlusYYGate`` with ``c = 0``) that the leading-reference sweep would otherwise emit to
-       transport such an orbital out to its mode. Only the genuinely-mixing remainder is decomposed.
-       When the whole occupied space is a signed permutation every orbital peels and no
+       *Optionally* (when :attr:`minimize_2q_gate_count` is set; it is **off** by default -- see the
+       caution below) occupied orbitals that are basis vectors on a mode disjoint from every other
+       occupied orbital are *peeled off* before the decomposition: their ``XGate`` is placed directly
+       on the target mode and they are excluded from the Givens sweep. This avoids the chain of bare
+       ``SWAP``\ s (``XXPlusYYGate`` with ``c = 0``) that the leading-reference sweep would otherwise
+       emit to transport such an orbital out to its mode. Only the genuinely-mixing remainder is then
+       decomposed; when the whole occupied space is a signed permutation every orbital peels and no
        ``XXPlusYYGate`` is emitted at all.
 
        A peeled mode may sit *between* the physical endpoints of a sweep rotation, making that
@@ -209,13 +210,29 @@ class GivensDecompositionSlaterDeterminantSynthesis:
        the mixing space.
 
     .. note::
-       The genuinely-mixing remainder that survives peeling is further partitioned into
-       disjoint-support **blocks**, each synthesized on its own contiguous mode window. When the
-       occupied space splits into several mixing clusters
-       separated by empty (or peeled) modes, this drops the bare ``SWAP``\ s (``XXPlusYYGate`` with
-       ``c = 0``) the single leading-reference sweep would otherwise emit to transport occupation
-       across the gaps between clusters. A single mixing cluster spanning all kept modes is one block
-       and reproduces the plain leading-reference sweep exactly.
+       The occupied space (the genuinely-mixing remainder that survives peeling, when
+       :attr:`minimize_2q_gate_count` is set; the full occupied space otherwise) is further
+       partitioned into disjoint-support **blocks**, each synthesized on its own contiguous mode
+       window. When it splits into several mixing clusters separated by empty (or peeled) modes, this
+       drops the bare ``SWAP``\ s (``XXPlusYYGate`` with ``c = 0``) the single leading-reference sweep
+       would otherwise emit to transport occupation across the gaps between clusters. A single mixing
+       cluster spanning all kept modes is one block and reproduces the plain leading-reference sweep
+       exactly. This block splitting runs regardless of :attr:`minimize_2q_gate_count`.
+
+    .. caution::
+       The unit-orbital peeling above trades circuit metrics: it minimizes the emitted two-qubit gate
+       *count* (replacing a swept orbital by a direct ``XGate``), but only under free (all-to-all)
+       connectivity. On a constrained coupling map it can *increase* the two-qubit gate *depth* after
+       routing -- peeling occupied modes that the leading-reference sweep would have used as
+       nearest-neighbor stepping-stones can strand the residual mixing orbital across a wide,
+       physically non-adjacent window (a single long-range ``XXPlusYYGate`` that routing must then
+       bridge with many ``SWAP``\ s). The full leading-reference sweep instead keeps every emitted
+       rotation nearest-neighbor along the mode order -- more two-qubit gates, but no routing overhead.
+       The two are a genuine, non-dominated trade-off (neither ever beats the other on both metrics),
+       so which is preferable depends on the target: minimizing two-qubit *depth* generally matters
+       more than raw gate *count*, both on hardware and in simulation, so peeling is **off** by
+       default. Enable it via :attr:`minimize_2q_gate_count` when raw gate count is the bottleneck
+       (e.g. richly-connected hardware). Both settings prepare the same state (up to a global phase).
 
     .. warning::
        This transpilation pass plugin makes the following assumptions:
@@ -224,6 +241,27 @@ class GivensDecompositionSlaterDeterminantSynthesis:
        - a trivial fermion-to-qubit layout (i.e. no change in their register lengths)
        - a 1-to-1 mapping of fermionic mode indices to qubit indices
     """
+
+    def __init__(self, *, minimize_2q_gate_count: bool = False) -> None:
+        """Initializing this plugin can be done with the arguments listed below.
+
+        Args:
+            minimize_2q_gate_count: which of two equivalent syntheses to emit, selected by the circuit
+                metric to optimize. When ``False`` (the default), the full leading-reference Givens
+                sweep is used: every emitted two-qubit rotation is nearest-neighbor along the mode
+                order, minimizing the post-routing two-qubit *depth* on a constrained coupling map at
+                the cost of more two-qubit gates. When ``True``, disjoint unit-orbitals (occupied
+                orbitals that are basis vectors on a mode disjoint from all other occupied orbitals)
+                are peeled out of the decomposition and realized with a direct ``XGate``, minimizing
+                the two-qubit gate *count* but potentially emitting long-range rotations that inflate
+                the routed depth (see the caution in the class docstring). Both settings prepare the
+                same state (up to a global phase); the default favors depth because it generally
+                matters more than gate count, both on hardware and in simulation.
+        """
+        self.minimize_2q_gate_count = minimize_2q_gate_count
+        """Whether to peel disjoint unit-orbitals to minimize the two-qubit gate count (see
+        ``__init__``). When ``False`` (default), the nearest-neighbor leading-reference sweep is used
+        instead, minimizing the routed two-qubit depth."""
 
     def run(self, in_node: DAGOpNode, out_dag: DAGCircuit, *, f2q_layout: F2QLayout) -> None:
         """Runs this transpilation plugin.
@@ -254,10 +292,22 @@ class GivensDecompositionSlaterDeterminantSynthesis:
         occupied = np.nonzero(occupation)[0]
         orbital_coeffs = rotation_unitary[:, occupied].T
 
-        # peel off occupied orbitals that are disjoint unit-orbitals: seed their XGate directly on the
-        # target mode and hand only the genuinely-mixing remainder to the decomposition. ``kept_modes``
-        # maps the reduced decomposition's local indices back to physical mode indices.
-        peel_modes, kept_modes, reduced = _peel_disjoint_unit_orbitals(orbital_coeffs)
+        # to minimize the two-qubit gate count (see ``minimize_2q_gate_count``), peel off occupied
+        # orbitals that are disjoint unit-orbitals: seed their XGate directly on the target mode and
+        # hand only the genuinely-mixing remainder to the decomposition. ``kept_modes`` maps the
+        # reduced decomposition's local indices back to physical mode indices. Otherwise (the default),
+        # keep the entire occupied space in the sweep so the block splitting below reduces to the full
+        # leading-reference sweep -- every emitted rotation then stays nearest-neighbor along the mode
+        # order (at the cost of more two-qubit gates), which routes far cheaper on a constrained
+        # coupling map.
+        if self.minimize_2q_gate_count:
+            peel_modes, kept_modes, reduced = _peel_disjoint_unit_orbitals(orbital_coeffs)
+        else:
+            peel_modes, kept_modes, reduced = (
+                [],
+                list(range(orbital_coeffs.shape[1])),
+                orbital_coeffs,
+            )
 
         for mode in peel_modes:
             out_dag.apply_operation_back(XGate(), (qreg[freg_indices[mode]],))

--- a/tests/python/transpiler/passes/test_prepare_slater_determinant_synthesis.py
+++ b/tests/python/transpiler/passes/test_prepare_slater_determinant_synthesis.py
@@ -54,8 +54,12 @@ def _synthesize(circ: FermionicCircuit, synth: F2QSynthesis):
 
 
 def _slater_synth() -> F2QSynthesis:
+    # most tests below assert the peeling (minimize-2q-gate-count) behavior, which is *not* the
+    # default; request it explicitly. The peel-free default path is covered by its own tests.
     synth = F2QSynthesis()
-    synth.methods["PrepareSlaterDeterminant"] = GivensDecompositionSlaterDeterminantSynthesis()
+    synth.methods["PrepareSlaterDeterminant"] = GivensDecompositionSlaterDeterminantSynthesis(
+        minimize_2q_gate_count=True
+    )
     return synth
 
 
@@ -693,3 +697,105 @@ def test_prepare_slater_determinant_synthesis_negative_control_no_z_string():
 
     qc_wrong = _synthesize_without_z_string(num_modes, occupation, rotation)
     assert not np.isclose(_overlap(qc_wrong, num_modes, occupation, rotation), 1.0, atol=1e-8)
+
+
+# --- minimize_2q_gate_count toggle -----------------------------------------------------------------
+#
+# The default synthesis uses the full leading-reference sweep (block splitting retained): every
+# emitted rotation is nearest-neighbor along the mode order, minimizing the routed two-qubit *depth*.
+# Setting ``minimize_2q_gate_count=True`` peels disjoint unit-orbitals instead, minimizing the
+# two-qubit gate *count* but potentially stranding a residual mixing orbital across a wide window (a
+# long-range gate that inflates the routed depth). The two are a non-dominated trade-off; both prepare
+# the same state (up to a global phase). ``_slater_synth`` above requests the peeling (count-min) path
+# explicitly; the plain default plugin below exercises the depth-min path.
+
+
+def _slater_synth_default() -> F2QSynthesis:
+    synth = F2QSynthesis()
+    synth.methods["PrepareSlaterDeterminant"] = GivensDecompositionSlaterDeterminantSynthesis()
+    return synth
+
+
+def test_prepare_slater_determinant_minimize_2q_gate_count_keyword_only():
+    """``minimize_2q_gate_count`` is keyword-only and defaults to ``False`` (peeling off)."""
+    assert GivensDecompositionSlaterDeterminantSynthesis().minimize_2q_gate_count is False
+    assert (
+        GivensDecompositionSlaterDeterminantSynthesis(
+            minimize_2q_gate_count=True
+        ).minimize_2q_gate_count
+        is True
+    )
+    with pytest.raises(TypeError):
+        GivensDecompositionSlaterDeterminantSynthesis(True)  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "label,num_modes,occupied_columns,build_rotation",
+    _STRUCTURE_CASES,
+    ids=[case[0] for case in _STRUCTURE_CASES],
+)
+def test_prepare_slater_determinant_default_matches_reference(
+    label, num_modes, occupied_columns, build_rotation
+):
+    """The default (peel-free) synthesis prepares the correct state for every occupied-space structure.
+
+    Runs the same structural cases as the peeling path against the faithful ``InitializeModes +
+    OrbitalRotation`` reference. The ``minimize_2q_gate_count`` setting only changes *how* the state is
+    synthesized (full leading-reference sweep vs peel + direct X gates), never *which* state -- so the
+    reference comparison must hold for both settings.
+    """
+    rotation = build_rotation()
+    occupation = [i in occupied_columns for i in range(num_modes)]
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+    qc_default = _synthesize(slater, _slater_synth_default())
+    _assert_equal_up_to_global_phase(
+        qc_default, _reference_circuit(num_modes, occupation, rotation)
+    )
+
+
+def _xx_plus_yy_spans(qc) -> list[int]:
+    """The physical qubit-index spans ``|i - j|`` of every emitted ``XXPlusYYGate``."""
+    spans = []
+    for instruction in qc.data:
+        if instruction.operation.name != "xx_plus_yy":
+            continue
+        i, j = (qc.find_bit(qubit).index for qubit in instruction.qubits)
+        spans.append(abs(i - j))
+    return spans
+
+
+def test_prepare_slater_determinant_default_avoids_long_range_gate():
+    """The default (depth-minimizing) synthesis emits a nearest-neighbor chain where peeling strands.
+
+    This is the routing motivation for the default: a dense occupation with one disjoint mixing orbital
+    spanning the whole window peels its interior modes to X gates and strands the residual as a single
+    long-range ``XXPlusYYGate`` on the block extremes (``minimize_2q_gate_count=True``). The default
+    instead emits the Clements brickwork -- every rotation mode-adjacent (``|i - j| == 1``) -- while
+    preparing the identical state.
+
+    The rotation mixes only the block *extremes* (modes 0 and ``num_modes - 1``) and is the identity on
+    the interior; occupying columns ``0 .. num_modes - 2`` (all but the last mode) makes the interior
+    modes 1..num_modes-2 disjoint unit-orbitals that peel, leaving one mixing orbital on ``{0,
+    num_modes - 1}``. This is exactly the N2 LUCJ HF state-prep shape (all-but-one mode occupied) that
+    motivated the toggle.
+    """
+    num_modes = 6
+    rotation = _givens_2mode(0.6, 0, num_modes - 1, num_modes)
+    occupation = [i < num_modes - 1 for i in range(num_modes)]
+
+    slater = FermionicCircuit(num_modes)
+    slater.append(PrepareSlaterDeterminant(occupation, rotation), slater.modes)
+
+    qc_count_min = _synthesize(slater, _slater_synth())  # minimize_2q_gate_count=True
+    qc_default = _synthesize(slater, _slater_synth_default())
+
+    # peeling (count-min) strands a single long-range gate on the block extremes; the default keeps
+    # every rotation nearest-neighbor
+    assert max(_xx_plus_yy_spans(qc_count_min)) == num_modes - 1
+    default_spans = _xx_plus_yy_spans(qc_default)
+    assert default_spans and max(default_spans) == 1
+
+    # ... and both prepare the same state (up to a global phase)
+    _assert_equal_up_to_global_phase(qc_count_min, qc_default)


### PR DESCRIPTION
### Summary

Adds a keyword-only `minimize_2q_gate_count` flag to `GivensDecompositionSlaterDeterminantSynthesis` and flips the default behavior of the Slater-determinant synthesis from minimizing two-qubit gate count to minimizing routed two-qubit depth.

### Motivation

The disjoint-unit-orbital peeling optimization (#203) realizes an occupied unit-orbital with a direct `XGate` instead of transporting it out through the Givens sweep. That minimizes the emitted two-qubit gate count — but only under free (all-to-all) connectivity. On a constrained coupling map it can inflate the two-qubit depth after routing: peeling an occupied interior mode that the full leading-reference sweep would have used as a nearest-neighbor stepping-stone strands the residual mixing orbital across a wide, physically non-adjacent window — a single long-range `XXPlusYYGate` the router must then bridge with a chain of `SWAP`s.

Concretely, for an LUCJ Hartree-Fock state prep on a near-full active space (N₂, 5 of 6 modes occupied per spin sector, transpiled onto heavy-hex) peeling inflates the routed SWAP count ~9× (≈18–21 vs 2) versus the peel-free synthesis, which stays a nearest-neighbor chain.

### Why a flag rather than just removing peeling

A randomized sweep over thousands of structured occupations shows the two strategies are a genuine, non-dominated trade-off:

- the full leading-reference sweep is always nearest-neighbor → never routes worse than peeling;
- peeling always emits no more two-qubit gates → never a higher count.

Neither dominates. Since minimizing two-qubit depth generally matters more than raw gate count — both on hardware and in simulation — the default is `minimize_2q_gate_count=False` (peeling off, depth-minimizing). Set it to `True` to recover the count-minimizing peeling when raw gate count is the bottleneck (e.g. richly-connected hardware).