### PR TITLE
docs(guides): expand the LUCJ guide

### DIFF
--- a/docs/guides/lucj.rst
+++ b/docs/guides/lucj.rst
@@ -82,43 +82,27 @@ and the constant nuclear-repulsion energy. The electronic-integral constructors
 :meth:`~qiskit_fermions.operators.FermionOperator.from_2body_tril_spin_sym` expect the integrals
 in packed (lower-triangular) `chemist` ordering, which is exactly what PySCF produces.
 
-.. tab-set::
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
 
-   .. tab-item:: Python
-      :sync: python
-
-      .. plot::
-         :context:
-         :nofigs:
-         :include-source:
-
-         >>> from pyscf import ao2mo, lib
-         >>>
-         >>> from qiskit_fermions.operators import FermionOperator
-         >>>
-         >>> # one- and two-body molecular-orbital integrals and the nuclear-repulsion energy
-         >>> h1e = mo_coeff.T @ scf.get_hcore() @ mo_coeff
-         >>> h2e = ao2mo.kernel(mol, mo_coeff)
-         >>> ecore = mol.energy_nuc()
-         >>>
-         >>> # pack into the lower-triangular chemist-ordered layout the constructors expect
-         >>> h1e_tril = lib.pack_tril(h1e)
-         >>> h2e_tril = lib.pack_tril(h2e)
-         >>>
-         >>> hamiltonian = ecore * FermionOperator.one()
-         >>> hamiltonian += FermionOperator.from_1body_tril_spin_sym(h1e_tril, norb)
-         >>> hamiltonian += FermionOperator.from_2body_tril_spin_sym(h2e_tril, norb)
-
-   .. tab-item:: C
-      :sync: c
-
-      .. code-block:: c
-
-         // Given the packed integrals (obtained as above), the C API exposes matching
-         // electronic-integral constructors:
-         //
-         //   QfFermionOperator *h1 = qf_ferm_op_from_1body_tril_spin_sym(h1e_tril, norb);
-         //   QfFermionOperator *h2 = qf_ferm_op_from_2body_tril_spin_sym(h2e_tril, norb);
+   >>> from pyscf import ao2mo, lib
+   >>>
+   >>> from qiskit_fermions.operators import FermionOperator
+   >>>
+   >>> # one- and two-body molecular-orbital integrals and the nuclear-repulsion energy
+   >>> h1e = mo_coeff.T @ scf.get_hcore() @ mo_coeff
+   >>> h2e = ao2mo.kernel(mol, mo_coeff)
+   >>> ecore = mol.energy_nuc()
+   >>>
+   >>> # pack into the lower-triangular chemist-ordered layout the constructors expect
+   >>> h1e_tril = lib.pack_tril(h1e)
+   >>> h2e_tril = lib.pack_tril(h2e)
+   >>>
+   >>> hamiltonian = ecore * FermionOperator.one()
+   >>> hamiltonian += FermionOperator.from_1body_tril_spin_sym(h1e_tril, norb)
+   >>> hamiltonian += FermionOperator.from_2body_tril_spin_sym(h2e_tril, norb)
 
 3. Build the LUCJ circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -135,31 +119,19 @@ factorization. Truncating it with the ``n_reps`` argument trades some accuracy f
 circuit; here we keep the two largest terms, which recovers most of the correlation energy while
 halving the number of layers.
 
-.. tab-set::
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
 
-   .. tab-item:: Python
-      :sync: python
-
-      .. plot::
-         :context:
-         :nofigs:
-         :include-source:
-
-         >>> from qiskit_fermions.circuit import FermionicCircuit
-         >>> from qiskit_fermions.circuit.library import InitializeModes, UCJ
-         >>>
-         >>> ansatz = UCJ.from_t_amplitudes(nelec, t2, t1=t1, n_reps=2)
-         >>>
-         >>> circuit = FermionicCircuit(2 * norb)
-         >>> circuit.append(InitializeModes.from_hartree_fock(norb, nelec), circuit.modes)
-         >>> circuit.append(ansatz, circuit.modes)
-
-   .. tab-item:: C
-      :sync: c
-
-      .. code-block:: c
-
-         // The C API for FermionicCircuit is not available yet.
+   >>> from qiskit_fermions.circuit import FermionicCircuit
+   >>> from qiskit_fermions.circuit.library import InitializeModes, UCJ
+   >>>
+   >>> ansatz = UCJ.from_t_amplitudes(nelec, t2, t1=t1, n_reps=2)
+   >>>
+   >>> circuit = FermionicCircuit(2 * norb)
+   >>> circuit.append(InitializeModes.from_hartree_fock(norb, nelec), circuit.modes)
+   >>> circuit.append(ansatz, circuit.modes)
 
 The :class:`.UCJ` gate is a pure unitary carrying no reference of its own, so we prepend an
 :class:`.InitializeModes` gate (built with
@@ -197,33 +169,21 @@ protocol, so we can obtain a SciPy :class:`~scipy.sparse.linalg.LinearOperator` 
 :func:`ffsim.linear_operator` and evaluate the ansatz energy as the expectation value of the
 molecular Hamiltonian.
 
-.. tab-set::
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
 
-   .. tab-item:: Python
-      :sync: python
-
-      .. plot::
-         :context:
-         :nofigs:
-         :include-source:
-
-         >>> import ffsim
-         >>> import numpy as np
-         >>>
-         >>> reference = ffsim.hartree_fock_state(norb, nelec)
-         >>> state = ffsim.apply_unitary(reference, circuit, norb=norb, nelec=nelec)
-         >>>
-         >>> linop = ffsim.linear_operator(hamiltonian, norb=norb, nelec=nelec)
-         >>> energy = np.vdot(state, linop @ state).real
-         >>> print(f"LUCJ energy: {energy:.8f} Hartree")
-         LUCJ energy: -1.14618323 Hartree
-
-   .. tab-item:: C
-      :sync: c
-
-      .. code-block:: c
-
-         // Circuit simulation is not available via the C API.
+   >>> import ffsim
+   >>> import numpy as np
+   >>>
+   >>> reference = ffsim.hartree_fock_state(norb, nelec)
+   >>> state = ffsim.apply_unitary(reference, circuit, norb=norb, nelec=nelec)
+   >>>
+   >>> linop = ffsim.linear_operator(hamiltonian, norb=norb, nelec=nelec)
+   >>> energy = np.vdot(state, linop @ state).real
+   >>> print(f"LUCJ energy: {energy:.8f} Hartree")
+   LUCJ energy: -1.14618323 Hartree
 
 The LUCJ energy improves substantially on the Hartree-Fock reference and approaches the CCSD
 energy it was initialized from -- the small remaining gap is the price of truncating the ansatz to
@@ -241,13 +201,211 @@ two repetitions:
 
 .. skip: end
 
+5. (Optional) Use ffsim's compressed double factorization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :class:`.UCJ` gate above is initialized from an *exact* double factorization of the :math:`t_2`
+amplitudes: the number of ansatz repetitions :math:`L` is whatever that factorization yields (up to
+the ``n_reps`` truncation), and each layer reproduces one factorized term exactly. `ffsim`_
+additionally offers an optimized ("compressed") double factorization -- its
+``from_t_amplitudes(..., optimize=True)`` -- which *variationally* fits the amplitudes with a chosen,
+typically smaller, number of repetitions. This trades a classical optimization up front for a
+shallower ansatz at a target accuracy, and has no equivalent in this package.
+
+There is no need to re-implement it: an ``ffsim`` UCJ operator exposes the same tensors that
+:class:`.UCJ` is built from, so we can construct the operator with ``optimize=True`` and hand its
+``diag_coulomb_mats`` / ``orbital_rotations`` / ``final_orbital_rotation`` straight to the
+:class:`.UCJ` constructor.
+
+.. skip: start if(not HAS_FFSIM)
+
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
+
+   >>> compressed = ffsim.UCJOpSpinBalanced.from_t_amplitudes(
+   ...     t2, t1=t1, n_reps=2, optimize=True
+   ... )
+   >>>
+   >>> compressed_ansatz = UCJ(
+   ...     norb,
+   ...     nelec,
+   ...     compressed.diag_coulomb_mats,
+   ...     compressed.orbital_rotations,
+   ...     final_orbital_rotation=compressed.final_orbital_rotation,
+   ... )
+   >>>
+   >>> compressed_circuit = FermionicCircuit(2 * norb)
+   >>> compressed_circuit.append(
+   ...     InitializeModes.from_hartree_fock(norb, nelec), compressed_circuit.modes
+   ... )
+   >>> compressed_circuit.append(compressed_ansatz, compressed_circuit.modes)
+
+The resulting circuit is used exactly like the one built from the exact factorization -- the
+:class:`.UCJ` gate does not care how its tensors were obtained -- and evaluating its energy the same
+way recovers the same correlation energy at this (small) system size:
+
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
+
+   >>> state = ffsim.apply_unitary(reference, compressed_circuit, norb=norb, nelec=nelec)
+   >>> energy = np.vdot(state, linop @ state).real
+   >>> print(f"compressed LUCJ energy: {energy:.8f} Hartree")
+   compressed LUCJ energy: -1.14618323 Hartree
+
 .. note::
-   The :class:`.UCJ` gate is initialized here from an *exact* double factorization of the
-   :math:`t_2` amplitudes. ffsim additionally offers an optimized ("compressed") double
-   factorization (its ``from_t_amplitudes(..., optimize=True)``), which has no equivalent in this
-   package. To use it, build an ``ffsim`` UCJ operator with ``optimize=True`` and pass its
-   ``diag_coulomb_mats`` / ``orbital_rotations`` / ``final_orbital_rotation`` into :class:`.UCJ`
-   directly.
+   ``diag_coulomb_mats`` from ``optimize=True`` may carry tiny imaginary round-off; :class:`.UCJ`
+   takes their real part and raises only if the imaginary part is not negligible. For a better fit at
+   a given ``n_reps`` (at increased classical cost) see ffsim's ``multi_stage_start`` /
+   ``multi_stage_step`` options.
+
+.. skip: end
+
+6. Transpile the ansatz to a qubit circuit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To run the ansatz on hardware it must be lowered from fermionic modes to qubits.
+The :func:`~qiskit_fermions.transpiler.presets.generate_preset_jw_pass_manager` preset builds a
+staged pipeline that maps the fermionic circuit through the Jordan-Wigner transformation and
+synthesizes each gate into a qubit-level circuit. The composite :class:`.UCJ` gate must first be
+decomposed into its primitive gates (:class:`.OrbitalRotation`, :class:`.Evolution`, ...) so the
+pipeline's optimization stage can act on them -- so we pass ``circuit.decompose()``.
+
+.. skip: start if(not HAS_FFSIM)
+
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
+
+   >>> from qiskit_fermions.transpiler.presets import generate_preset_jw_pass_manager
+   >>>
+   >>> # ``circuit`` is the exact-factorization ansatz assembled in step 3
+   >>> pm = generate_preset_jw_pass_manager()
+   >>> transpiled = pm.run(circuit.decompose())
+   >>> print(dict(sorted(transpiled.count_ops().items())))
+   {'p': 16, 'rzz': 12, 'x': 2, 'xx_plus_yy': 28}
+
+Without a target device this maps onto ``2 * norb`` qubits with all-to-all connectivity assumed; the
+orbital rotations synthesize into :class:`~qiskit.circuit.library.XXPlusYYGate`\ s and the diagonal
+Coulomb evolutions into :class:`~qiskit.circuit.library.RZZGate`\ s:
+
+.. plot::
+   :alt: The Jordan-Wigner transpiled LUCJ circuit.
+   :context: close-figs
+   :include-source:
+
+   >>> transpiled.draw("mpl", fold=-1)
+   <Figure size ... with 1 Axes>
+
+.. rubric:: Targeting hardware connectivity with ffsim's LUCJ pass manager
+
+A real device has a restricted qubit coupling map, and the LUCJ ansatz is designed to match it: the
+same-spin (``pairs_aa``) interactions form two linear chains and the alpha-beta (``pairs_ab``)
+interactions bridge them. ffsim's :external:func:`~ffsim.qiskit.generate_lucj_pass_manager` builds a
+device-aware qubit pipeline for exactly this structure -- and returns the subset of ``pairs_ab`` the
+hardware can actually accommodate. We can slot that pipeline into the preset's ``qubit`` stage while
+keeping our own fermion-to-qubit synthesis:
+
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
+
+   >>> from ffsim.qiskit import generate_lucj_pass_manager
+   >>> from qiskit.providers.fake_provider import GenericBackendV2
+   >>> from qiskit.transpiler import CouplingMap
+   >>>
+   >>> # a heavy-hex device coupling map (any BackendV2 works, e.g. a real fake_provider backend)
+   >>> coupling_map = CouplingMap.from_heavy_hex(5)
+   >>> backend = GenericBackendV2(
+   ...     num_qubits=coupling_map.size(),
+   ...     basis_gates=["cp", "xx_plus_yy", "p", "x", "swap"],
+   ...     coupling_map=coupling_map,
+   ... )
+   >>>
+   >>> # nearest-neighbor same-spin chain; let the pass manager choose the alpha-beta pairs
+   >>> pairs_aa = [(p, p + 1) for p in range(norb - 1)]
+   >>>
+   >>> pm = generate_preset_jw_pass_manager()
+   >>> pm.qubit, allowed_pairs_ab = generate_lucj_pass_manager(
+   ...     backend, norb, "heavy-hex", (pairs_aa, None), optimization_level=3
+   ... )
+   >>>
+   >>> # the alpha-beta interactions the heavy-hex connectivity can implement
+   >>> print(allowed_pairs_ab)
+   [(0, 0)]
+
+With ``pm.qubit`` now set to the device-aware pipeline, running the pass manager lays the circuit out
+on the backend's qubits and routes it to the coupling map. If we route the *unrestricted* ansatz from
+step 3 -- whose diagonal Coulomb operator still contains alpha-beta terms the hardware cannot reach
+directly -- the router must insert many ``SWAP`` gates to bridge them:
+
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
+
+   >>> naive = pm.run(circuit.decompose())
+   >>> naive.num_qubits  # laid out on the full heavy-hex device register
+   57
+   >>> naive_swaps = naive.count_ops()["swap"]
+   >>> naive_swaps  # many SWAPs to bridge the unreachable alpha-beta interactions
+   33
+
+.. rubric:: Restricting the ansatz to the hardware-implementable interactions
+
+The fix is to feed ``allowed_pairs_ab`` back into the ansatz construction -- via the
+``interaction_pairs`` argument of :meth:`~qiskit_fermions.circuit.library.UCJ.from_t_amplitudes` --
+so the diagonal Coulomb operator only contains alpha-beta terms the coupling map can implement
+directly. The ansatz then matches the device topology and the router barely has to touch it:
+
+.. plot::
+   :context:
+   :nofigs:
+   :include-source:
+
+   >>> restricted = UCJ.from_t_amplitudes(
+   ...     nelec, t2, t1=t1, n_reps=2, interaction_pairs=(pairs_aa, allowed_pairs_ab)
+   ... )
+   >>>
+   >>> circuit = FermionicCircuit(2 * norb)
+   >>> circuit.append(InitializeModes.from_hartree_fock(norb, nelec), circuit.modes)
+   >>> circuit.append(restricted, circuit.modes)
+   >>>
+   >>> transpiled = pm.run(circuit.decompose())
+   >>> restricted_swaps = transpiled.count_ops()["swap"]
+   >>> restricted_swaps  # far fewer routing SWAPs than the unrestricted ansatz
+   4
+
+Drawing only the active qubits (``idle_wires=False``) shows the circuit restricted to the two spin
+chains and the alpha-beta bridge, expressed in the device basis gates. Layout and routing scatter the
+logical modes across the device's physical qubits, so we pass a ``wire_order`` taken from the
+circuit's final layout -- :meth:`~qiskit.transpiler.TranspileLayout.final_index_layout` lists the
+physical qubit each input qubit ended up on, in input-qubit order -- to draw the wires back in the
+original mode order:
+
+.. plot::
+   :alt: The hardware-restricted LUCJ circuit routed onto the heavy-hex device coupling map.
+   :context: close-figs
+   :include-source:
+
+   >>> wire_order = transpiled.layout.final_index_layout(filter_ancillas=False)
+   >>> transpiled.draw("mpl", idle_wires=False, fold=-1, wire_order=wire_order)
+   <Figure size ... with 1 Axes>
+
+.. note::
+   The exact post-layout gate counts and depth depend on the routing/optimization passes and the
+   chosen device, so they are not reproduced here. The key point is the co-design: expressing the
+   ansatz with a nearest-neighbor ``pairs_aa`` chain and hardware-filtered ``pairs_ab`` bridges keeps
+   the synthesized circuit close to the device topology, minimizing the routing overhead (inserted
+   ``SWAP`` gates). See :class:`.GivensDecompositionSlaterDeterminantSynthesis` for a related
+   synthesis choice (``minimize_2q_gate_count``) trading two-qubit gate count against routed depth.
+
+.. skip: end
 
 Next steps
 ^^^^^^^^^^
@@ -260,3 +418,4 @@ Next steps
   :ref:`transpilation guide <transpilation_explanation>`.
 
 .. _LUCJ: https://pubs.rsc.org/en/content/articlelanding/2023/sc/d3sc02516k
+.. _ffsim: https://qiskit-community.github.io/ffsim/


### PR DESCRIPTION
This is the guide which motivated so many of the previous PRs concerned with circuit synthesis and transpilation (#197 as prerequisite for #200 which was desirable for #205, #204 was a low-hanging fruit and #198 was anticipated as necessary knowing that pattern arises in simulated circuits after #205 gets applied to a circuit. The whole optimizations from #203, #206, #207, #211, and #212 were all motivated to achieve equally good transpilation results as ffsim).

So finally, we are able to update the LUCJ user guide with a section on transpilation. With all these optimizations baked into the preset JW passmanager, it is actually fairly straight forward. However, we also add two details on how we can leverage aspects of `ffsim`:

- using its compressed double-factorization of t2 amplitudes (Closes #191)
- using its LUCJ-tailored Qiskit pass-manager (`qiskit-fermions` doesn't (yet?) ship its own variant of this, but can leverage ffsim's pass-manager natively)