### PR TITLE
feat(transpiler): let MapperFnEvolutionSynthesis choose the product formula

### DIFF
--- a/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
+++ b/python/qiskit_fermions/transpiler/passes/synthesis/evolution.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode
@@ -24,6 +25,9 @@ from qiskit_fermions.operators.protocol import OperatorTrait
 
 from ... import F2QLayout
 from ..utils import map_node_single_register
+
+if TYPE_CHECKING:
+    from qiskit.synthesis.evolution import EvolutionSynthesis
 
 MapperFunction = Callable[[OperatorTrait, int], SparseObservable]
 """The function signature for :attr:`mapper_fn`."""
@@ -37,13 +41,28 @@ class MapperFnEvolutionSynthesis:
     :class:`~qiskit.circuit.library.PauliEvolutionGate`. It thereby preserves the
     :math:`e^{-i t H}` convention of the :class:`.Evolution` gate, with the same evolution time
     :math:`t`.
+
+    How that :class:`~qiskit.circuit.library.PauliEvolutionGate` is subsequently decomposed into
+    basis gates is governed by the product formula passed as :attr:`product_formula`. Leaving it at
+    its default (``None``) defers to the :class:`~qiskit.circuit.library.PauliEvolutionGate`'s own
+    default synthesis (a first-order :class:`~qiskit.synthesis.LieTrotter` decomposition with a
+    single repetition). Supplying an explicit
+    :class:`~qiskit.synthesis.EvolutionSynthesis` -- for example a higher-order
+    :class:`~qiskit.synthesis.SuzukiTrotter` or one with several repetitions -- selects a different
+    Trotter-Suzuki product formula, trading circuit depth for a smaller Trotter error.
     """
 
-    def __init__(self, mapper_fn: MapperFunction) -> None:
+    def __init__(
+        self, mapper_fn: MapperFunction, product_formula: EvolutionSynthesis | None = None
+    ) -> None:
         """Initializing this transpiler pass plugin can be done with the arguments listed below.
 
         Args:
             mapper_fn: the fermion-to-qubit operator mapping function.
+            product_formula: the product formula with which to synthesize the emitted
+                :class:`~qiskit.circuit.library.PauliEvolutionGate`. If ``None`` (the default), the
+                gate's own default synthesis is used (a first-order
+                :class:`~qiskit.synthesis.LieTrotter` decomposition with a single repetition).
         """
         super().__init__()
 
@@ -60,13 +79,18 @@ class MapperFnEvolutionSynthesis:
            transpilation :class:`~qiskit_fermions.transpiler.F2QLayout` setting.
         """
 
+        self.product_formula: EvolutionSynthesis | None = product_formula
+        """The product formula used to synthesize the emitted
+        :class:`~qiskit.circuit.library.PauliEvolutionGate`, or ``None`` to defer to that gate's own
+        default synthesis."""
+
     def run(self, in_node: DAGOpNode, out_dag: DAGCircuit, *, f2q_layout: F2QLayout) -> None:
         r"""Runs this transpilation plugin.
 
         The fermionic Hamiltonian of the incoming :class:`.Evolution` gate is mapped to a qubit
         operator via :attr:`mapper_fn`, simplified, and appended to ``out_dag`` as a
         :class:`~qiskit.circuit.library.PauliEvolutionGate` implementing :math:`e^{-i t H}` with the
-        original evolution time :math:`t`.
+        original evolution time :math:`t` and the :attr:`product_formula` synthesis.
 
         Args:
             in_node: the input fermion-based circuit instruction. When this plugin gets called, the
@@ -87,4 +111,7 @@ class MapperFnEvolutionSynthesis:
         local_op = in_node.op.operator
         global_op = local_op.relabel_modes(freg_indices)
         pauli_op = self.mapper_fn(global_op, len(qreg)).simplify()
-        out_dag.apply_operation_back(PauliEvolutionGate(pauli_op, time=in_node.op.params[0]), qreg)
+        out_dag.apply_operation_back(
+            PauliEvolutionGate(pauli_op, time=in_node.op.params[0], synthesis=self.product_formula),
+            qreg,
+        )

--- a/tests/python/transpiler/passes/test_evolution_synthesis.py
+++ b/tests/python/transpiler/passes/test_evolution_synthesis.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.passmanager import MultiStagePassManager
+from qiskit.synthesis import LieTrotter, SuzukiTrotter
 from qiskit_fermions.circuit import FermionicCircuit
 from qiskit_fermions.circuit.library import Evolution
 from qiskit_fermions.mappers.library import jordan_wigner
@@ -102,3 +103,79 @@ def test_custom_qubit_ordering():
 
     qu_circ_decomp = qu_circ.decompose(reps=2)
     assert qu_circ_decomp.depth(lambda instr: len(instr.qubits) == 2) == 4
+
+
+def _single_evolution_circuit(time: float = 1.5) -> FermionicCircuit:
+    hamil = FermionOperator.from_dict(
+        {
+            ((True, 0), (False, 2)): 2.0,
+            ((True, 2), (False, 0)): 2.0,
+            ((True, 1), (False, 3)): -2.0,
+            ((True, 3), (False, 1)): -2.0,
+        }
+    )
+    num_modes = 4
+    circ = FermionicCircuit(num_modes)
+    circ.append(Evolution(num_modes, hamil, time=time), circ.modes)
+    return circ
+
+
+def _run_with_product_formula(product_formula) -> object:
+    synth = F2QSynthesis()
+    synth.methods["Evolution"] = MapperFnEvolutionSynthesis(jordan_wigner, product_formula)
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
+    return pm.run(_single_evolution_circuit())
+
+
+def test_default_product_formula_is_none():
+    """Omitting ``product_formula`` leaves the emitted gate on its default synthesis."""
+    plugin = MapperFnEvolutionSynthesis(jordan_wigner)
+    assert plugin.product_formula is None
+
+    qu_circ = _run_with_product_formula(None)
+    (instruction,) = qu_circ.data
+    assert isinstance(instruction.operation, PauliEvolutionGate)
+    # a PauliEvolutionGate with no explicit synthesis falls back to a single-rep LieTrotter
+    assert isinstance(instruction.operation.synthesis, LieTrotter)
+    assert instruction.operation.synthesis.reps == 1
+
+
+def test_product_formula_is_forwarded_to_pauli_evolution_gate():
+    """An explicit product formula is attached to the emitted PauliEvolutionGate verbatim."""
+    product_formula = SuzukiTrotter(order=2, reps=3)
+    qu_circ = _run_with_product_formula(product_formula)
+    (instruction,) = qu_circ.data
+    assert isinstance(instruction.operation, PauliEvolutionGate)
+    assert instruction.operation.synthesis is product_formula
+
+
+def test_higher_order_product_formula_deepens_synthesis():
+    """A higher-order / repeated product formula yields a deeper decomposition."""
+    default_circ = _run_with_product_formula(None).decompose(reps=2)
+    suzuki_circ = _run_with_product_formula(SuzukiTrotter(order=2, reps=3)).decompose(reps=2)
+
+    two_qubit = lambda instr: len(instr.qubits) == 2  # noqa: E731
+    assert suzuki_circ.depth(two_qubit) > default_circ.depth(two_qubit)
+
+
+def test_product_formula_via_config_kwargs():
+    """The product formula flows through the ``F2QSynthesisConfig`` keyword-argument form."""
+    product_formula = SuzukiTrotter(order=2, reps=2)
+    config = {"Evolution": ("MapperFn", (jordan_wigner,), {"product_formula": product_formula})}
+    synth = F2QSynthesis(config)
+    assert synth.methods["Evolution"].product_formula is product_formula
+
+    pm = MultiStagePassManager(
+        input=FermionicCircuitToDAG(),
+        layout=TrivialF2QLayout(),
+        synthesis=synth,
+        output=QuantumDAGToCircuit(),
+    )
+    qu_circ = pm.run(_single_evolution_circuit())
+    (instruction,) = qu_circ.data
+    assert instruction.operation.synthesis is product_formula


### PR DESCRIPTION
The plugin previously emitted the PauliEvolutionGate without a `synthesis` argument, so every mapped `Evolution` was forced onto the gate's default first-order LieTrotter with a single repetition. Callers had no way to select a higher-order Suzuki formula or additional repetitions, which are exactly what Trotter-error-sensitive workloads (e.g. Krylov time evolution) want to trade depth for accuracy.

Add an optional `product_formula` parameter, forwarded verbatim to `PauliEvolutionGate(synthesis=...)`. It composes with the existing F2QSynthesisConfig plumbing unchanged, e.g.
`("MapperFn", (jordan_wigner,), {"product_formula": SuzukiTrotter(2)})`. Leaving it `None` preserves the previous default behavior.