### PR TITLE
docs: add citation information

### DIFF
--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -1,0 +1,72 @@
+name: Citation preview
+
+on:
+  push:
+    branches:
+      - main
+      - 'stable/**'
+    paths: ['CITATION.bib', '.github/workflows/citation.yml']
+  pull_request:
+    branches:
+      - main
+      - 'stable/**'
+    paths: ['CITATION.bib', '.github/workflows/citation.yml']
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check for non-ASCII characters
+        run: |
+          # Fail immediately if there are any non-ASCII characters in
+          # the BibTeX source.  We prefer "escaped codes" rather than
+          # UTF-8 characters in order to ensure the bibliography will
+          # display correctly even in documents that do not contain
+          # \usepackage[utf8]{inputenc}.
+          if [ -f "CITATION.bib" ]; then
+          python3 -c 'open("CITATION.bib", encoding="ascii").read()'
+          fi
+      - name: Install LaTeX
+        run: |
+          if [ -f "CITATION.bib" ]; then
+          sudo apt-get update
+          sudo apt-get install -y texlive-latex-base texlive-publishers
+          fi
+      - name: Run LaTeX
+        run: |
+          if [ -f "CITATION.bib" ]; then
+          arr=(${GITHUB_REPOSITORY//\// })
+          export REPO=${arr[1]}
+          cat <<- EOF > citation-preview.tex
+          \documentclass[preprint,aps,physrev,notitlepage]{revtex4-2}
+          \usepackage{hyperref}
+          \begin{document}
+          \title{\texttt{$REPO} BibTeX test}
+          \maketitle
+          \noindent
+          \texttt{$REPO}
+          \cite{$REPO}
+          \bibliography{CITATION}
+          \end{document}
+          EOF
+          pdflatex citation-preview
+          fi
+      - name: Run BibTeX
+        run: |
+          if [ -f "CITATION.bib" ]; then
+          bibtex citation-preview
+          fi
+      - name: Re-run LaTeX
+        run: |
+          if [ -f "CITATION.bib" ]; then
+          pdflatex citation-preview
+          pdflatex citation-preview
+          fi
+      - name: Upload PDF
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: citation-preview.pdf
+          path: citation-preview.pdf

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,8 @@
+@software{qiskit-fermions,
+    author = {
+        Rossmannek, Max
+    },
+    title = {{Qiskit Fermions}},
+    howpublished = {\url{https://github.com/Qiskit/qiskit-fermions}},
+    year = {2026}
+}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Each substantial improvement, breaking change, or deprecation will be documented
 
 ----------------------------------------------------------------------------------------------------
 
+### Citing this package
+
+If you use this package in your research, use the [CITATION.bib](CITATION.bib) file in this
+project’s repository to cite the appropriate reference(s).
+
+----------------------------------------------------------------------------------------------------
+
 ### Contributing
 
 The source code is available [on GitHub](https://github.com/Qiskit/qiskit-fermions).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,14 @@ By participating, you are expected to uphold Qiskit's `code of conduct <https://
 We use `GitHub issues <https://github.com/Qiskit/qiskit-fermions/issues/new/choose>`_ for tracking requests and bugs.
 
 
+Citing this package
+-------------------
+
+If you use this package in your research, use the `CITATION.bib
+<https://github.com/Qiskit/qiskit-fermions/blob/main/CITATION.bib>`_ file in
+this project's repository to cite the appropriate reference(s).
+
+
 License
 -------
 


### PR DESCRIPTION
Closes #202

For now, we will have this simple `CITATION.bib` file. Once we have the first release, we can publish the package to Zenodo and obtain a DOI.