### PR TITLE
feat(transpiler): add `filter_trivial` to `QDriftTrotterization`

### DIFF
--- a/docs/guides/sqdrift.rst
+++ b/docs/guides/sqdrift.rst
@@ -192,6 +192,104 @@ ensemble of circuits to generate:
    generator used inside of the :class:`.QDriftTrotterization` transpilation
    pass.
 
+5. Filter out trivial excitations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Beyond the diagonal terms filtered out in the previous step, a sampled
+excitation can *still* fail to affect the sampled bitstrings: whenever it acts
+entirely within a set of modes whose occupation is already fixed (all occupied
+or all unoccupied), it cannot move a particle from one to the other, so it
+leaves the state -- and thus the eventual measurement outcome -- unchanged.
+Setting ``filter_trivial=True`` on the :class:`.QDriftTrotterization` pass
+rejects such terms as they are sampled and re-draws a replacement, so that
+every one of the ``num_groups`` slots of the resulting circuit contributes a
+non-trivial excitation.
+
+This filtering needs to know which modes start out occupied. It therefore
+requires an :class:`.InitializeModes` gate preceding the :class:`.Evolution`
+gate(s) in the circuit; :meth:`.InitializeModes.from_hartree_fock` is a
+convenient way to construct one. We add one here for the N2 Hartree-Fock
+reference (7 alpha and 7 beta electrons in 14 spatial orbitals) and compare the
+sampled excitations with and without ``filter_trivial=True``:
+
+.. tab-set-code::
+
+    .. code-block:: python
+
+       >>> from qiskit_fermions.circuit.library import InitializeModes
+       >>>
+       >>> init = InitializeModes.from_hartree_fock(fcidump.norb, (7, 7))
+       >>>
+       >>> hf_circ = FermionicCircuit(num_modes)
+       >>> hf_circ.append(init, hf_circ.modes)
+       >>> hf_circ.append(Evolution(num_modes, canon, time), hf_circ.modes)
+       >>>
+       >>> num_groups = 5
+       >>> qdrift_unfiltered = QDriftTrotterization(
+       ...     num_groups, filter_diagonal_terms=True, rng=3480
+       ... )
+       >>> qdrift_trivial = QDriftTrotterization(
+       ...     num_groups, filter_diagonal_terms=True, filter_trivial=True, rng=3480
+       ... )
+       >>>
+       >>> for instruction in FermionicPassManager(qdrift_unfiltered).run(hf_circ)._inner.data:
+       ...     if instruction.operation.name == "Evolution":
+       ...         print(sorted(instruction.operation.operator.get_support()))
+       [2, 4]
+       [41, 45, 52]
+       [15, 45, 55]
+       [41, 52, 53]
+       [10, 16, 37, 38]
+       >>>
+       >>> for instruction in FermionicPassManager(qdrift_trivial).run(hf_circ)._inner.data:
+       ...     if instruction.operation.name == "Evolution":
+       ...         print(sorted(instruction.operation.operator.get_support()))
+       [0, 1, 6, 7]
+       [0, 1, 28, 29]
+       [4, 13, 55]
+       [13, 20, 40, 41]
+       [0, 1, 28, 29]
+
+    .. code-block:: c
+
+       // WARNING: Qiskit's C API does not yet allow us to implement circuits
+       // with custom gate definitions, which we therefore also cannot transpile
+       // via this API.
+
+None of the excitations sampled without filtering touch the occupied set
+(``0-6`` and ``28-34``) at all, so none of them can move a particle between an
+occupied and an unoccupied mode -- every single one is trivial and would have
+no effect on the sampled bitstrings. With ``filter_trivial=True``, all five are
+rejected and replaced by excitations that do couple an occupied mode with an
+unoccupied one, e.g. the first accepted excitation ``[0, 1, 6, 7]`` moves a
+particle between occupied modes ``0``, ``1``, and ``6`` and unoccupied mode
+``7``.
+
+Once an excitation is accepted, every mode in its support becomes
+"uncertain" and, thus, eligible to play either role for later samples --
+so the occupied and unoccupied mode sets keep growing as more excitations
+get accepted. This is what makes the second accepted excitation,
+``[0, 1, 28, 29]``, acceptable at all: all four of its modes are among the
+*originally* occupied ones, so it does not couple to any originally
+unoccupied mode. It is only accepted because modes ``0`` and ``1`` became
+uncertain -- and thus eligible as the "unoccupied" side of the coupling --
+once the first excitation touched them.
+
+.. note::
+   Without a preceding :class:`.InitializeModes` gate, ``filter_trivial=True``
+   has no occupation information to filter against: it emits a
+   :class:`UserWarning` and leaves the sampling unfiltered for that
+   :class:`.Evolution` gate.
+
+.. note::
+   ``filter_diagonal_terms=True`` remains worth keeping enabled even alongside
+   ``filter_trivial=True``. The two act at different stages: diagonal-term
+   filtering shrinks the Hamiltonian *before* sampling begins, while
+   ``filter_trivial`` only rejects already-sampled terms one draw at a time.
+   Removing the (always-trivial) diagonal terms up front reduces how often
+   ``filter_trivial`` has to reject and re-draw, lowering the runtime cost of
+   filling all ``num_groups`` slots.
+
 (Optional) Optimize the fermionic mode indexing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -22,7 +22,12 @@ import numpy as np
 from qiskit.dagcircuit import DAGOpNode
 
 from qiskit_fermions.circuit import FermionicDAGCircuit
-from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
+from qiskit_fermions.circuit.library import (
+    Evolution,
+    InitializeModes,
+    OrbitalRotation,
+    PrepareSlaterDeterminant,
+)
 from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.operators.terms.filtering import filter_diagonal_terms
 
@@ -99,15 +104,20 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
                 couples a mode known to be occupied with a mode known to be unoccupied. Any term
                 acting only within one of these two sets cannot change the occupation and, thus, has
                 no effect on a sampled bitstring, so re-drawing avoids wasting one of the
-                ``num_terms`` slots on it. This requires an :class:`.InitializeModes` gate to precede
-                the :class:`.Evolution` gates being Trotterized (to seed the initial occupied and
-                unoccupied mode sets); if none is found, or if the mode sets it seeds turn out to be
-                entirely occupied or entirely unoccupied, filtering is skipped for that gate and a
-                :class:`UserWarning` is emitted instead. Any :class:`.OrbitalRotation` gate
-                encountered before or between the :class:`.Evolution` gates also updates these sets:
-                every mode it acts on becomes "uncertain" (since the rotation may mix it with any
-                other mode it touches), just like a mode touched by an accepted qDRIFT term. See the
-                :meth:`run` docstring for the precise acceptance rule.
+                ``num_terms`` slots on it. This requires an :class:`.InitializeModes` or
+                :class:`.PrepareSlaterDeterminant` gate to precede the :class:`.Evolution` gates
+                being Trotterized (to seed the initial occupied and unoccupied mode sets); if none is
+                found, or if the mode sets it seeds turn out to be entirely occupied or entirely
+                unoccupied, filtering is skipped for that gate and a :class:`UserWarning` is emitted
+                instead. Any :class:`.OrbitalRotation` gate encountered before or between the
+                :class:`.Evolution` gates also updates these sets: every mode it acts on becomes
+                "uncertain" (since the rotation may mix it with any other mode it touches), just like
+                a mode touched by an accepted qDRIFT term. A :class:`.PrepareSlaterDeterminant` gate
+                updates these sets the same way its :class:`.InitializeModes` and
+                :class:`.OrbitalRotation` components would if applied in sequence: it seeds the
+                occupied/unoccupied sets from its ``occupation``, then immediately marks every mode
+                it acts on as "uncertain" because of its rotation. See the :meth:`run` docstring for
+                the precise acceptance rule.
             rng: the random number generator (rng) to be used. When this is an ``int``, the internal
                 rng will be initialized with ``np.random.default_rng(seed=rng)``.
         """
@@ -143,7 +153,10 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
         making it eligible to participate in either role for subsequent samples. Any
         :class:`.OrbitalRotation` gate found in the circuit updates these sets the same way: every
         mode it acts on becomes "uncertain" too, since the rotation may mix it with any other mode
-        in its support.
+        in its support. A :class:`.PrepareSlaterDeterminant` gate is treated as its
+        :class:`.InitializeModes` and :class:`.OrbitalRotation` components applied back-to-back: its
+        ``occupation`` first seeds the occupied/unoccupied sets, and then every mode it acts on is
+        immediately marked "uncertain", since it also carries a rotation.
 
         Args:
             dag: the input circuit with fermion-based instructions. Only
@@ -190,6 +203,20 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
                 modes = set(_global_modes(dag, node).tolist())
                 occupied |= modes
                 unoccupied |= modes
+
+            elif isinstance(node.op, PrepareSlaterDeterminant):
+                # This gate is the composition of an `InitializeModes` reference occupation
+                # followed by an `OrbitalRotation` (see its class docstring), so it updates the
+                # tracked sets the same way those two gates would back-to-back: first seed from
+                # `occupation`, then immediately promote every mode it touches to "uncertain"
+                # because of the rotation it also carries.
+                modes = _global_modes(dag, node)
+                occupation = node.op.occupation
+                occupied |= set(modes[occupation].tolist())
+                unoccupied |= set(modes[~occupation].tolist())
+                all_modes = set(modes.tolist())
+                occupied |= all_modes
+                unoccupied |= all_modes
 
             if not isinstance(node.op, Evolution):
                 out_dag.apply_operation_back(node.op, qargs=node.qargs)

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -15,16 +15,23 @@
 from __future__ import annotations
 
 import copy
+import warnings
 from typing import Any
 
 import numpy as np
+from qiskit.dagcircuit import DAGOpNode
 
 from qiskit_fermions.circuit import FermionicDAGCircuit
-from qiskit_fermions.circuit.library import Evolution
+from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
 from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.operators.terms.filtering import filter_diagonal_terms
 
 from ... import FermionicDAGCircuitPass
+
+
+def _global_modes(dag: FermionicDAGCircuit, node: DAGOpNode) -> np.ndarray:
+    """Returns the global mode indices that ``node`` acts on, in the order of its ``qargs``."""
+    return np.array([dag.find_bit(qubit).index for qubit in node.qargs])
 
 
 class QDriftTrotterization(FermionicDAGCircuitPass):
@@ -51,11 +58,19 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
        The qDRIFT protocol was introduced in `arXiv:1811.08017 <https://arxiv.org/abs/1811.08017>`_.
     """
 
+    MAX_SAMPLE_RETRIES = 1_000_000
+    """The maximum number of consecutive rejected samples tolerated by ``filter_trivial`` before
+    :meth:`run` gives up and raises :class:`RuntimeError`. This guards against an infinite loop when
+    the Hamiltonian's remaining terms cannot bridge the tracked occupied/unoccupied mode sets — for
+    example, when both sets remain small and disjoint (few modes have been marked occupied or
+    unoccupied, and none have yet become "uncertain") and no remaining term's support touches both."""
+
     def __init__(
         self,
         num_terms: int,
         *,
         filter_diagonal_terms: bool = False,
+        filter_trivial: bool = False,
         rng: np.random.Generator | int | None = None,
     ) -> None:
         """Initializing this transpiler pass can be done with the arguments listed below.
@@ -73,7 +88,26 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
                 :func:`~qiskit_fermions.operators.terms.filtering.filter_diagonal_terms`. Because
                 diagonal-term filtering is defined in terms of fermionic number operators, it is
                 only supported for :class:`.Evolution` gates whose operator is a
-                :class:`.FermionOperator`; :meth:`run` raises :class:`TypeError` otherwise.
+                :class:`.FermionOperator`; :meth:`run` raises :class:`TypeError` otherwise. This
+                remains worthwhile even in combination with ``filter_trivial=True``: it shrinks the
+                pool of terms being sampled from *before* the sampling starts, whereas
+                ``filter_trivial`` can only reject terms one draw at a time, after they have already
+                been sampled. Removing the (always-trivial) diagonal terms up front therefore lowers
+                the average number of rejected draws that ``filter_trivial`` has to make, reducing
+                the runtime cost of reaching ``num_terms`` accepted samples.
+            filter_trivial: when set to ``True``, the sampling loop rejects a sampled term unless it
+                couples a mode known to be occupied with a mode known to be unoccupied. Any term
+                acting only within one of these two sets cannot change the occupation and, thus, has
+                no effect on a sampled bitstring, so re-drawing avoids wasting one of the
+                ``num_terms`` slots on it. This requires an :class:`.InitializeModes` gate to precede
+                the :class:`.Evolution` gates being Trotterized (to seed the initial occupied and
+                unoccupied mode sets); if none is found, or if the mode sets it seeds turn out to be
+                entirely occupied or entirely unoccupied, filtering is skipped for that gate and a
+                :class:`UserWarning` is emitted instead. Any :class:`.OrbitalRotation` gate
+                encountered before or between the :class:`.Evolution` gates also updates these sets:
+                every mode it acts on becomes "uncertain" (since the rotation may mix it with any
+                other mode it touches), just like a mode touched by an accepted qDRIFT term. See the
+                :meth:`run` docstring for the precise acceptance rule.
             rng: the random number generator (rng) to be used. When this is an ``int``, the internal
                 rng will be initialized with ``np.random.default_rng(seed=rng)``.
         """
@@ -85,6 +119,10 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
         self.filter_diagonal_terms = filter_diagonal_terms
         """Whether to filter out diagonal terms before the qDRIFT sampling."""
 
+        self.filter_trivial = filter_trivial
+        """Whether to reject sampled terms that cannot affect the sampled bitstring (see the
+        class docstring for the ``filter_trivial`` argument)."""
+
         self._rng = rng if isinstance(rng, np.random.Generator) else np.random.default_rng(rng)
 
     def run(self, dag: FermionicDAGCircuit) -> FermionicDAGCircuit:
@@ -94,6 +132,18 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
         :class:`.Evolution` gates (see the class docstring). Nodes that are not :class:`.Evolution`
         gates are copied to the output unchanged. Since the sampling is random, the output varies
         between runs unless the ``rng`` was seeded.
+
+        When :attr:`filter_trivial` is set, this method tracks the sets of modes that are known to
+        be occupied or unoccupied, seeded from any :class:`.InitializeModes` gate(s) preceding the
+        :class:`.Evolution` gates in the circuit (several such gates placed in parallel, e.g. one per
+        spin sector, are accumulated together). A sampled term is only accepted if its support
+        intersects *both* sets, i.e. it couples a known-occupied mode with a known-unoccupied one;
+        otherwise it is discarded and re-sampled, since it cannot affect the sampled bitstring. Once a
+        term is accepted, every mode in its support becomes "uncertain" and is added to *both* sets,
+        making it eligible to participate in either role for subsequent samples. Any
+        :class:`.OrbitalRotation` gate found in the circuit updates these sets the same way: every
+        mode it acts on becomes "uncertain" too, since the rotation may mix it with any other mode
+        in its support.
 
         Args:
             dag: the input circuit with fermion-based instructions. Only
@@ -107,10 +157,40 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
             TypeError: if ``filter_diagonal_terms`` is ``True`` but an :class:`.Evolution` gate
                 carries an operator that is not a :class:`.FermionOperator` (diagonal-term filtering
                 is only defined for fermionic operators).
+            RuntimeError: if ``filter_trivial`` is ``True`` and :attr:`MAX_SAMPLE_RETRIES`
+                consecutive samples are rejected without finding a non-trivial term to emit.
         """
         out_dag = dag.copy_empty_like()
 
+        # The sets of modes that are currently known to be occupied/unoccupied, respectively. Seeded
+        # by any preceding `InitializeModes` gate(s); both remain empty until the first one is
+        # encountered, which is how we distinguish "no InitializeModes seen yet" from "seeded, but
+        # every mode landed in the same set" (see the two warnings below). `filter_trivial` uses these
+        # sets to reject sampled terms that cannot change the occupation. Once a term is accepted, the
+        # modes it touches move into "uncertain" (see below), so they end up in *both* sets going
+        # forward.
+        occupied: set[int] = set()
+        unoccupied: set[int] = set()
+
         for node in dag.op_nodes():
+            if isinstance(node.op, InitializeModes):
+                modes = _global_modes(dag, node)
+                occupation = node.op.occupation
+                # Several `InitializeModes` gates may be placed in parallel (e.g. one per spin
+                # sector), so accumulate rather than overwrite.
+                occupied |= set(modes[occupation].tolist())
+                unoccupied |= set(modes[~occupation].tolist())
+
+            elif isinstance(node.op, OrbitalRotation):
+                # An `OrbitalRotation` mixes creation operators across all of the modes it acts
+                # on (its `rotation_unitary` carries no per-mode sparsity information we could use
+                # to do better - see the `OrbitalRotation` docstring), so every mode it touches
+                # becomes "uncertain" just like an accepted qDRIFT term below: no longer known to
+                # be occupied or unoccupied, and thus eligible for both roles going forward.
+                modes = set(_global_modes(dag, node).tolist())
+                occupied |= modes
+                unoccupied |= modes
+
             if not isinstance(node.op, Evolution):
                 out_dag.apply_operation_back(node.op, qargs=node.qargs)
                 continue
@@ -154,30 +234,98 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
                 # term actually gets sampled.
                 terms = hamil.split_out_groups()
 
+            def _unit_terms(term):
+                if isinstance(term, tuple):
+                    # in this case, we have already normalized the coefficient to its sign
+                    return [term]
+
+                # NOTE: as per the comment earlier, we have not yet normalized the coefficients
+                # of grouped operator terms. Keep each term's sign (dropping only its magnitude)
+                # so that the sampled rotation points in the correct direction.
+                return [(actions, np.sign(coeff)) for actions, coeff in term.iter_terms()]
+
             lambd = np.sum(weights)
             delta = (lambd * time) / self.num_terms
+            probabilities = weights / lambd
 
-            sampled_indices = self._rng.choice(
-                np.arange(len(weights)),
-                size=self.num_terms,
-                p=weights / lambd,
-            )
+            filter_trivial = self.filter_trivial and (bool(occupied) and bool(unoccupied))
+            if self.filter_trivial and not filter_trivial:
+                match (bool(occupied), bool(unoccupied)):
+                    case (True, False):
+                        reason = (
+                            "the preceding InitializeModes gate(s) marked every mode as occupied, "
+                            "so no unoccupied mode is available to filter against"
+                        )
+                    case (False, True):
+                        reason = (
+                            "the preceding InitializeModes gate(s) marked every mode as "
+                            "unoccupied, so no occupied mode is available to filter against"
+                        )
+                    case _:
+                        reason = (
+                            "it is not preceded by an InitializeModes gate, so no occupation "
+                            "information is available to filter against"
+                        )
+                warnings.warn(
+                    f"filter_trivial=True has no effect on this Evolution gate because {reason}.",
+                    category=UserWarning,
+                    stacklevel=2,
+                )
 
-            for ind in sampled_indices:
-                sampled_term = terms[ind]
-                if isinstance(sampled_term, tuple):
-                    # in this case, we have already normalized the coefficient to its sign
-                    unit_terms = [sampled_term]
-                else:
-                    # NOTE: as per the comment earlier, we have not yet normalized the coefficients
-                    # of grouped operator terms. Keep each term's sign (dropping only its magnitude)
-                    # so that the sampled rotation points in the correct direction.
-                    unit_terms = [
-                        (actions, np.sign(coeff)) for actions, coeff in sampled_term.iter_terms()
-                    ]
+            if not filter_trivial:
+                # No rejection sampling is needed, so we can draw every index for this gate in a
+                # single batched call instead of `num_terms` separate scalar draws, which is
+                # considerably faster (each scalar `choice()` call rebuilds the cumulative-
+                # probability structure from scratch, whereas a batched call builds it once).
+                sampled_indices = self._rng.choice(
+                    np.arange(len(weights)), size=self.num_terms, p=probabilities
+                )
+                for sampled_idx in sampled_indices:
+                    unit_terms = _unit_terms(terms[sampled_idx])
+                    op = hamil.__class__.from_terms(unit_terms)
+                    evo = Evolution(num_modes, op, time=delta)
+                    out_dag.apply_operation_back(evo, qargs=out_dag.qubits)
+                continue
 
+            # Precomputed once here (only reached once rejection sampling is actually needed) so
+            # the loop below can draw against it directly via `searchsorted` instead of calling
+            # `rng.choice(..., p=probabilities)`, which would rebuild this same cumulative sum from
+            # scratch on every single draw.
+            cdf = np.cumsum(probabilities)
+            cdf /= cdf[-1]  # guards against float-sum drift from 1.0, matching numpy's own choice()
+
+            added_terms = 0
+            failed_attempts = 0
+            while added_terms < self.num_terms:
+                # Equivalent to `self._rng.choice(np.arange(len(weights)), p=probabilities)`:
+                # this is numpy's own implementation of weighted sampling (see `Generator.choice`),
+                # just reusing the `cdf` precomputed above instead of rebuilding it on every draw.
+                sampled_idx = cdf.searchsorted(self._rng.random(), side="right")
+                unit_terms = _unit_terms(terms[sampled_idx])
                 op = hamil.__class__.from_terms(unit_terms)
+
+                term_support = op.get_support()
+                # The term is non-trivial exactly when it couples a known-occupied mode with a
+                # known-unoccupied one; otherwise it cannot change which bitstring gets sampled.
+                if not (term_support & occupied and term_support & unoccupied):
+                    failed_attempts += 1
+                    if failed_attempts > self.MAX_SAMPLE_RETRIES:
+                        raise RuntimeError(
+                            f"Failed to sample a non-trivial term after "
+                            f"{self.MAX_SAMPLE_RETRIES} consecutive attempts. The remaining "
+                            "Hamiltonian terms may no longer be able to couple the tracked "
+                            "occupied and unoccupied mode sets."
+                        )
+                    continue
+                failed_attempts = 0
+                # The modes touched by an accepted term become "uncertain": we no longer know
+                # whether they end up occupied or not, so they must be considered eligible for
+                # both roles by subsequent samples.
+                occupied |= term_support
+                unoccupied |= term_support
+
                 evo = Evolution(num_modes, op, time=delta)
                 out_dag.apply_operation_back(evo, qargs=out_dag.qubits)
+                added_terms += 1
 
         return out_dag

--- a/tests/python/transpiler/passes/test_qdrift_optimization.py
+++ b/tests/python/transpiler/passes/test_qdrift_optimization.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from qiskit_fermions.circuit import FermionicCircuit
-from qiskit_fermions.circuit.library import Evolution, InitializeModes
+from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
 from qiskit_fermions.operators import FermionOperator, MajoranaOperator, gamma
 from qiskit_fermions.operators.library import FCIDump
 from qiskit_fermions.operators.terms.grouping import group_terms_by_electronic_structure
@@ -239,3 +239,200 @@ def test_qdrift_preserves_non_evolution_gates():
 
     qdrift_circ = pm.run(circ)
     assert qdrift_circ.count_ops() == {"InitializeModes": 1, "Evolution": num_terms}
+
+
+def test_qdrift_filter_trivial_only_emits_coupling_terms():
+    """Every sampled term must have support intersecting both, the (dynamically growing) occupied
+    and unoccupied mode sets -- a term entirely confined to one side cannot change the sampled
+    bitstring and must never survive the filtering."""
+    num_modes = 4
+    init = InitializeModes([True, True, False, False])
+    hamil = FermionOperator.from_terms(
+        [
+            (((True, 0), (False, 0)), 1.0),  # n_0: trivial (within occupied)
+            (((True, 0), (True, 1), (False, 1), (False, 0)), 1.0),  # n_0 n_1: trivial
+            (((True, 2), (False, 0)), 1.0),  # 0 -> 2: couples occupied/unoccupied
+            (((True, 3), (False, 1)), 1.0),  # 1 -> 3: couples occupied/unoccupied
+            (((True, 3), (False, 2)), 1.0),  # 2 -> 3: trivial (within unoccupied)
+        ]
+    )
+    hamil.groups = None
+
+    circ = FermionicCircuit(num_modes)
+    circ.append(init, circ.modes)
+    circ.append(Evolution(num_modes, hamil, time=1.0), circ.modes)
+
+    num_terms = 30
+    qdrift = QDriftTrotterization(num_terms, filter_trivial=True, rng=42)
+    pm = FermionicPassManager(qdrift)
+
+    qdrift_circ = pm.run(circ)
+    assert qdrift_circ.count_ops() == {"InitializeModes": 1, "Evolution": num_terms}
+
+    occupied = {0, 1}
+    unoccupied = {2, 3}
+    for instruction in qdrift_circ._inner.data:
+        if instruction.operation.name != "Evolution":
+            continue
+        support = instruction.operation.operator.get_support()
+        assert support & occupied and support & unoccupied, (
+            f"sampled a trivial term with support {support}"
+        )
+        occupied |= support
+        unoccupied |= support
+
+
+def test_qdrift_filter_trivial_orbital_rotation_marks_modes_uncertain():
+    """An OrbitalRotation between InitializeModes and Evolution mixes creation operators across the
+    modes it acts on, so every one of those modes must become "uncertain" (added to both the
+    occupied and unoccupied sets) exactly like a mode touched by an accepted qDRIFT term -- a term
+    that would otherwise be trivially confined to one side must be accepted once one of its modes
+    has been marked uncertain this way."""
+    num_modes = 4
+    init = InitializeModes([True, True, False, False])  # occupied={0,1}, unoccupied={2,3}
+    # mixes mode 0 (occupied) with mode 2 (unoccupied), marking both "uncertain"
+    rotation = OrbitalRotation(np.array([[0.0, 1.0], [1.0, 0.0]], dtype=complex))
+
+    # entirely confined to the original occupied set {0, 1} -- trivial unless mode 0 is uncertain
+    hamil = FermionOperator.from_terms([(((True, 1), (False, 0)), 1.0)])
+    hamil.groups = None
+
+    circ = FermionicCircuit(num_modes)
+    circ.append(init, circ.modes)
+    circ.append(rotation, [circ.modes[0], circ.modes[2]])
+    circ.append(Evolution(num_modes, hamil, time=1.0), circ.modes)
+
+    num_terms = 5
+    qdrift = QDriftTrotterization(num_terms, filter_trivial=True, rng=42)
+    pm = FermionicPassManager(qdrift)
+
+    qdrift_circ = pm.run(circ)
+    assert qdrift_circ.count_ops() == {
+        "InitializeModes": 1,
+        "OrbitalRotation": 1,
+        "Evolution": num_terms,
+    }
+
+    for instruction in qdrift_circ._inner.data:
+        if instruction.operation.name == "Evolution":
+            assert instruction.operation.operator.get_support() == {0, 1}
+
+
+def test_qdrift_filter_trivial_rejects_purely_diagonal_hamiltonian():
+    """When every term is diagonal (i.e. never couples the occupied/unoccupied sets), filtering can
+    never find a non-trivial term, so sampling must exhaust its retry budget and raise."""
+    num_modes = 2
+    init = InitializeModes([True, False])
+    hamil = FermionOperator.from_terms([(((True, 0), (False, 0)), 1.0)])
+    hamil.groups = None
+
+    circ = FermionicCircuit(num_modes)
+    circ.append(init, circ.modes)
+    circ.append(Evolution(num_modes, hamil, time=1.0), circ.modes)
+
+    qdrift = QDriftTrotterization(3, filter_trivial=True, rng=1)
+    qdrift.MAX_SAMPLE_RETRIES = 100
+    pm = FermionicPassManager(qdrift)
+
+    with pytest.raises(RuntimeError, match="non-trivial term"):
+        pm.run(circ)
+
+
+def test_qdrift_filter_trivial_warns_without_initialize_modes():
+    """filter_trivial requires occupation information from a preceding InitializeModes gate; without
+    one, filtering cannot be applied and a UserWarning must be emitted instead of silently ignoring
+    the flag or raising."""
+    num_modes = 2
+    hamil = FermionOperator.from_terms([(((True, 0), (False, 1)), 1.0)])
+    hamil.groups = None
+
+    circ = FermionicCircuit(num_modes)
+    circ.append(Evolution(num_modes, hamil, time=1.0), circ.modes)
+
+    num_terms = 3
+    qdrift = QDriftTrotterization(num_terms, filter_trivial=True, rng=1)
+    pm = FermionicPassManager(qdrift)
+
+    with pytest.warns(UserWarning, match="not preceded by an InitializeModes gate"):
+        qdrift_circ = pm.run(circ)
+
+    assert qdrift_circ.count_ops() == {"Evolution": num_terms}
+
+
+def test_qdrift_filter_trivial_warns_when_all_modes_occupied():
+    """When the preceding InitializeModes gate(s) mark every mode as occupied, there is no
+    unoccupied mode left to couple against, so filtering cannot be applied and a UserWarning must
+    be emitted instead of silently ignoring the flag or raising."""
+    num_modes = 2
+    circ = FermionicCircuit(num_modes)
+    circ.append(InitializeModes([True, True]), circ.modes)
+
+    hamil = FermionOperator.from_terms([(((True, 0), (False, 1)), 1.0)])
+    hamil.groups = None
+    circ.append(Evolution(num_modes, hamil, time=1.0), circ.modes)
+
+    num_terms = 3
+    qdrift = QDriftTrotterization(num_terms, filter_trivial=True, rng=1)
+    pm = FermionicPassManager(qdrift)
+
+    with pytest.warns(UserWarning, match="marked every mode as occupied"):
+        qdrift_circ = pm.run(circ)
+
+    assert qdrift_circ.count_ops() == {"InitializeModes": 1, "Evolution": num_terms}
+
+
+def test_qdrift_filter_trivial_warns_when_all_modes_unoccupied():
+    """When the preceding InitializeModes gate(s) mark every mode as unoccupied, there is no
+    occupied mode left to couple against, so filtering cannot be applied and a UserWarning must be
+    emitted instead of silently ignoring the flag or raising."""
+    num_modes = 2
+    circ = FermionicCircuit(num_modes)
+    circ.append(InitializeModes([False, False]), circ.modes)
+
+    hamil = FermionOperator.from_terms([(((True, 0), (False, 1)), 1.0)])
+    hamil.groups = None
+    circ.append(Evolution(num_modes, hamil, time=1.0), circ.modes)
+
+    num_terms = 3
+    qdrift = QDriftTrotterization(num_terms, filter_trivial=True, rng=1)
+    pm = FermionicPassManager(qdrift)
+
+    with pytest.warns(UserWarning, match="marked every mode as unoccupied"):
+        qdrift_circ = pm.run(circ)
+
+    assert qdrift_circ.count_ops() == {"InitializeModes": 1, "Evolution": num_terms}
+
+
+def test_qdrift_filter_trivial_accumulates_parallel_initialize_modes():
+    """Several InitializeModes gates placed in parallel (e.g. one per spin sector) must have their
+    occupation information accumulated together, correctly mapped onto *global* mode indices rather
+    than assumed to start at index 0."""
+    num_modes = 4
+    circ = FermionicCircuit(num_modes)
+    # alpha sector (modes 0, 1): mode 0 occupied, mode 1 unoccupied
+    circ.append(InitializeModes([True, False]), [circ.modes[0], circ.modes[1]])
+    # beta sector (modes 2, 3): mode 2 unoccupied, mode 3 occupied
+    circ.append(InitializeModes([False, True]), [circ.modes[2], circ.modes[3]])
+
+    hamil = FermionOperator.from_terms(
+        [
+            (((True, 1), (False, 0)), 1.0),  # 0 -> 1: occupied -> unoccupied (non-trivial)
+            (((True, 2), (False, 3)), 1.0),  # 3 -> 2: occupied -> unoccupied (non-trivial)
+        ]
+    )
+    hamil.groups = None
+    circ.append(Evolution(num_modes, hamil, time=1.0), circ.modes)
+
+    num_terms = 10
+    qdrift = QDriftTrotterization(num_terms, filter_trivial=True, rng=7)
+    pm = FermionicPassManager(qdrift)
+
+    qdrift_circ = pm.run(circ)
+    assert qdrift_circ.count_ops() == {"InitializeModes": 2, "Evolution": num_terms}
+
+    # both terms already couple occupied with unoccupied modes from the start, so every sample must
+    # be accepted immediately -- exercising this confirms the occupation was read from the correct
+    # (global) mode indices rather than e.g. both gates being wrongly assumed to start at 0.
+    for instruction in qdrift_circ._inner.data:
+        if instruction.operation.name == "Evolution":
+            assert instruction.operation.operator.get_support() in ({0, 1}, {2, 3})

--- a/tests/python/transpiler/passes/test_qdrift_optimization.py
+++ b/tests/python/transpiler/passes/test_qdrift_optimization.py
@@ -19,7 +19,12 @@ from pathlib import Path
 import numpy as np
 import pytest
 from qiskit_fermions.circuit import FermionicCircuit
-from qiskit_fermions.circuit.library import Evolution, InitializeModes, OrbitalRotation
+from qiskit_fermions.circuit.library import (
+    Evolution,
+    InitializeModes,
+    OrbitalRotation,
+    PrepareSlaterDeterminant,
+)
 from qiskit_fermions.operators import FermionOperator, MajoranaOperator, gamma
 from qiskit_fermions.operators.library import FCIDump
 from qiskit_fermions.operators.terms.grouping import group_terms_by_electronic_structure
@@ -310,6 +315,42 @@ def test_qdrift_filter_trivial_orbital_rotation_marks_modes_uncertain():
     assert qdrift_circ.count_ops() == {
         "InitializeModes": 1,
         "OrbitalRotation": 1,
+        "Evolution": num_terms,
+    }
+
+    for instruction in qdrift_circ._inner.data:
+        if instruction.operation.name == "Evolution":
+            assert instruction.operation.operator.get_support() == {0, 1}
+
+
+def test_qdrift_filter_trivial_prepare_slater_determinant_seeds_and_marks_uncertain():
+    """PrepareSlaterDeterminant is the composition of an InitializeModes reference occupation and an
+    OrbitalRotation (see its class docstring), so filter_trivial must treat it as both applied
+    back-to-back: seed the occupied/unoccupied sets from its occupation, then immediately mark every
+    mode it acts on as "uncertain" because of the rotation it also carries."""
+    num_modes = 4
+    # occupation seeds occupied={0,1}, unoccupied={2,3}; the rotation swaps modes 0 and 2 (leaving 1
+    # and 3 unchanged), so all four end up "uncertain" right away, just like the OrbitalRotation-only
+    # test above (whose rotation is embedded here, extended to the identity on modes 1 and 3).
+    rotation_unitary = np.eye(4, dtype=complex)
+    rotation_unitary[[0, 2]] = rotation_unitary[[2, 0]]
+    prep = PrepareSlaterDeterminant([True, True, False, False], rotation_unitary)
+
+    # entirely confined to the original occupied set {0, 1} -- trivial unless mode 0 is uncertain
+    hamil = FermionOperator.from_terms([(((True, 1), (False, 0)), 1.0)])
+    hamil.groups = None
+
+    circ = FermionicCircuit(num_modes)
+    circ.append(prep, circ.modes)
+    circ.append(Evolution(num_modes, hamil, time=1.0), circ.modes)
+
+    num_terms = 5
+    qdrift = QDriftTrotterization(num_terms, filter_trivial=True, rng=42)
+    pm = FermionicPassManager(qdrift)
+
+    qdrift_circ = pm.run(circ)
+    assert qdrift_circ.count_ops() == {
+        "PrepareSlaterDeterminant": 1,
         "Evolution": num_terms,
     }
 


### PR DESCRIPTION
Excitations sampled by qDRIFT that act entirely within the known-occupied or known-unoccupied mode set cannot change the sampled bitstrings, so including them only wastes one of the num_terms slots. `filter_trivial` rejects and re-draws such terms, tracking the occupied/unoccupied mode sets from any preceding `InitializeModes` gate(s).

Closes #194