### PR TITLE
ci: add cibuildwheel config and wheel-build workflows

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -U pip build
+          python -m pip install -U pip build uv
 
       - name: Compile Qiskit from source
         shell: bash
@@ -81,8 +81,13 @@ jobs:
       - name: Install Python package
         shell: bash
         run: |
-          pip install --group build --group test "qiskit @ file:$(echo build/qiskit/dist/*.whl)"
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e .
+          # `build`/`test` pin `qiskit` to a single minor (see `pyproject.toml`, tied to the
+          # vendored `qiskit-pyo3-ffi` snapshot), which conflicts with the dev wheel built here.
+          # Excluding `qiskit` from `uv`'s resolution means that pin is never checked against the
+          # already-installed dev version.
+          pip install "qiskit @ file:$(echo build/qiskit/dist/*.whl)"
+          uv pip install --system --exclude <(echo qiskit) --group build --group test
+          SETUPTOOLS_RUST_CARGO_PROFILE=release uv pip install --system --exclude <(echo qiskit) -e .
 
       - name: Python tests
         shell: bash
@@ -92,7 +97,7 @@ jobs:
       - name: Optional tests
         shell: bash
         run: |
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e ".[all]"
+          SETUPTOOLS_RUST_CARGO_PROFILE=release uv pip install --system --exclude <(echo qiskit) -e ".[all]"
           make testoptional
 
       - name: Documentation tests

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -U pip
+          python -m pip install -U pip uv
 
       - name: Compile Qiskit C API (minimum version)
         shell: bash
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install Python dependencies (minimum versions)
         run: |
-          pip install --group build --group test qiskit uv
+          pip install --group build --group test qiskit
           uv sync --active --resolution lowest-direct
 
       - name: Install Python package

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -1,0 +1,132 @@
+name: Build release artifacts
+on:
+  workflow_call:
+    inputs:
+      default-action:
+        description: >-
+          The default action for each artifact.
+          Choose from 'build' (default) or 'skip'.
+        type: string
+        default: "build"
+        required: false
+
+      sdist:
+        description: >-
+          The action to take for the sdist.
+          Choose from 'default', 'build' or 'skip'.
+        type: string
+        default: "default"
+        required: false
+
+      wheels-linux:
+        description: >-
+          The action to take for Linux (x86_64, aarch64) wheels.
+          Choose from 'default', 'build' or 'skip'.
+          This builds multiple artifacts, which all match 'wheels-linux-*'.
+        type: string
+        default: "default"
+        required: false
+
+      wheels-macos:
+        description: >-
+          The action to take for macOS arm64 wheels.
+          Choose from 'default', 'build' or 'skip'.
+        type: string
+        default: "default"
+        required: false
+
+      wheels-windows:
+        description: >-
+          The action to take for Windows x64 wheels.
+          Choose from 'default', 'build' or 'skip'.
+        type: string
+        default: "default"
+        required: false
+
+      artifact-prefix:
+        description: "A prefix to give all artifacts uploaded with 'actions/upload-artifact'."
+        type: string
+        default: ""
+        required: false
+
+      python-version:
+        description: "The Python version to use to host the build runner."
+        type: string
+        default: "3.13"
+        required: false
+
+jobs:
+  wheels-linux:
+    name: "Wheels / Linux"
+    if: (inputs.wheels-linux == 'default' && inputs.default-action || inputs.wheels-linux) == 'build'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: pypa/cibuildwheel@v3.4.0
+      - uses: actions/upload-artifact@v7
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ inputs.artifact-prefix }}wheels-linux-${{ matrix.os }}
+
+  wheels-macos:
+    name: "Wheels / macOS arm64"
+    if: (inputs.wheels-macos == 'default' && inputs.default-action || inputs.wheels-macos) == 'build'
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        name: Install Python
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: pypa/cibuildwheel@v3.4.0
+      - uses: actions/upload-artifact@v7
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ inputs.artifact-prefix }}wheels-macos
+
+  wheels-windows:
+    name: "Wheels / Windows x64"
+    if: (inputs.wheels-windows == 'default' && inputs.default-action || inputs.wheels-windows) == 'build'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        name: Install Python
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: pypa/cibuildwheel@v3.4.0
+      - uses: actions/upload-artifact@v7
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ inputs.artifact-prefix }}wheels-windows
+
+  sdist:
+    name: "sdist"
+    if: (inputs.sdist == 'default' && inputs.default-action || inputs.sdist) == 'build'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Build sdist
+        run: |
+          set -e
+          python -m pip install -U build
+          python -m build --sdist .
+      - uses: actions/upload-artifact@v7
+        with:
+          path: ./dist/*.tar.gz
+          name: ${{ inputs.artifact-prefix }}sdist

--- a/.github/workflows/wheels-pr.yml
+++ b/.github/workflows/wheels-pr.yml
@@ -1,0 +1,23 @@
+name: Build wheels
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      # Above are the defaults for the PR trigger, below are our insertions.
+      # Trigger on 'labeled' so we catch the initial manual labelling event.
+      - labeled
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref_name }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  test-wheels:
+    name: Build
+    if: '${{ contains(github.event.pull_request.labels.*.name, ''ci: test wheels'') }}'
+    uses: './.github/workflows/wheels-build.yml'
+    with:
+      default-action: "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
     "setuptools>=77.0.1",
     "setuptools-rust",
-    "qiskit>=2.5",
+    "qiskit~=2.5.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -32,7 +32,10 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = [
-    "qiskit>=2.5.0, <3",
+    # Pinned to a single minor: `crates/qiskit-pyo3-ffi` is a pre-generated FFI snapshot tied to
+    # this Qiskit release, and its stability across Qiskit minors is not yet guaranteed. Widen
+    # this once a new minor has been verified against the vendored FFI.
+    "qiskit~=2.5.0",
     "scipy>=1.10",
     "stevedore>=3.0.0",
     "typing-extensions",
@@ -55,7 +58,7 @@ simulation = [
 build = [
     "setuptools>=77.0.1",
     "setuptools-rust",
-    "qiskit>=2.5",
+    "qiskit~=2.5.0",
 ]
 style = [
     "ruff==0.16.1",
@@ -216,3 +219,36 @@ NDArray = "NDArray"
 
 [tool.typos.files]
 extend-exclude = ["crates/qiskit-pyo3-ffi"]
+
+# `pyext` is built abi3 (see `crates/pyext/Cargo.toml`'s `pyo3` feature `abi3-py310` and
+# `setup.py`'s `py_limited_api="cp310"`), so cibuildwheel collapses each platform down to a
+# single `cp310-abi3` wheel.
+[tool.cibuildwheel]
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+build = ["cp3??-*"]
+skip = ["*-win32", "*_i686", "*_universal2", "*-musllinux_*"]
+# Run straight from the source checkout: passing an explicit path (`{project}/tests/python`) on
+# the command line makes pytest ignore `[tool.pytest.ini_options].testpaths`, so it never walks
+# into `python/qiskit_fermions/` and picks up the Sybil-collected doctests there (those need the
+# `doctest` dependency group and stay owned by `test_latest_versions.yml`; here we only want the
+# plain `tests/python` suite against the installed wheel). Deliberately narrower than the full
+# `test` dependency group for the same reason: doctests aren't run here (`-p no:doctest`).
+# Both the `--group` and the test path are qualified with `{project}` rather than relying on a
+# `cd`, since cibuildwheel runs the test command from its own scratch directory (not the source
+# checkout) and, on Windows, a `cd ... &&`-chained command does not reliably carry its directory
+# change through to the rest of the chain.
+test-command = "pip install --group {project}/pyproject.toml:basetest && python -m pytest -p no:doctest -s {project}/tests/python"
+environment = 'RUSTUP_TOOLCHAIN="stable"'
+
+[tool.cibuildwheel.linux]
+before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="stable"'
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && pipx run abi3audit --strict --report {wheel}"
+
+[tool.cibuildwheel.macos]
+environment = "MACOSX_DEPLOYMENT_TARGET='11.0' RUSTUP_TOOLCHAIN=stable"
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} && pipx run abi3audit --strict --report {wheel}"
+
+[tool.cibuildwheel.windows]
+repair-wheel-command = "cp {wheel} {dest_dir}/. && pipx run abi3audit --strict --report {wheel}"


### PR DESCRIPTION
Prepare for the first PyPI release by building pre-compiled wheels the way Qiskit does, scoped to manylinux x86_64/aarch64, macOS arm64, and Windows x64. Also tighten the `qiskit` dependency to `~=2.5.0`, since the vendored `qiskit-pyo3-ffi` snapshot is tied to that release and its stability across Qiskit minors isn't yet guaranteed.