### PR TITLE
fix: ensure `FermionicCircuit` intances can be serialized

### DIFF
--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -1043,6 +1043,29 @@ impl PyEdgeVertexOperator {
             .map(Into::into)
             .map_err(crate::value_err)
     }
+
+    /// Returns the constructor arguments needed to pickle this operator.
+    ///
+    /// Together with :meth:`__getstate__`/:meth:`__setstate__` (which round-trip
+    /// :attr:`groups`), this makes instances of this class picklable.
+    fn __getnewargs__(&self) -> (Vec<Complex64>, Vec<u32>, Vec<u32>, Vec<usize>) {
+        (
+            self.inner.coeffs.clone(),
+            self.inner.left_indices.clone(),
+            self.inner.right_indices.clone(),
+            self.inner.boundaries.clone(),
+        )
+    }
+
+    /// Returns the pickled state of this operator (its :attr:`groups`).
+    fn __getstate__(&self) -> Option<Vec<u32>> {
+        self.inner.groups.clone()
+    }
+
+    /// Restores this operator's :attr:`groups` from its pickled state.
+    fn __setstate__(&mut self, state: Option<Vec<u32>>) {
+        self.inner.groups = state;
+    }
 }
 
 #[pymodule]

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -1147,6 +1147,29 @@ impl PyFermionOperator {
     ///     TypeError: if ``nelec`` is neither an ``int`` nor a ``(int, int)`` tuple.
     ///     ValueError: if ``norb`` exceeds the maximum number of orbitals the bitmask
     ///         representation supports (64).
+    /// Returns the constructor arguments needed to pickle this operator.
+    ///
+    /// Together with :meth:`__getstate__`/:meth:`__setstate__` (which round-trip
+    /// :attr:`groups`), this makes instances of this class picklable.
+    fn __getnewargs__(&self) -> (Vec<Complex64>, Vec<bool>, Vec<u32>, Vec<usize>) {
+        (
+            self.inner.coeffs.clone(),
+            self.inner.actions.clone(),
+            self.inner.modes.clone(),
+            self.inner.boundaries.clone(),
+        )
+    }
+
+    /// Returns the pickled state of this operator (its :attr:`groups`).
+    fn __getstate__(&self) -> Option<Vec<u32>> {
+        self.inner.groups.clone()
+    }
+
+    /// Restores this operator's :attr:`groups` from its pickled state.
+    fn __setstate__(&mut self, state: Option<Vec<u32>>) {
+        self.inner.groups = state;
+    }
+
     fn _fci_linear_operator_(
         &self,
         norb: u32,

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -1011,6 +1011,28 @@ impl PyMajoranaOperator {
             .map(Into::into)
             .map_err(crate::value_err)
     }
+
+    /// Returns the constructor arguments needed to pickle this operator.
+    ///
+    /// Together with :meth:`__getstate__`/:meth:`__setstate__` (which round-trip
+    /// :attr:`groups`), this makes instances of this class picklable.
+    fn __getnewargs__(&self) -> (Vec<Complex64>, Vec<u32>, Vec<usize>) {
+        (
+            self.inner.coeffs.clone(),
+            self.inner.modes.clone(),
+            self.inner.boundaries.clone(),
+        )
+    }
+
+    /// Returns the pickled state of this operator (its :attr:`groups`).
+    fn __getstate__(&self) -> Option<Vec<u32>> {
+        self.inner.groups.clone()
+    }
+
+    /// Restores this operator's :attr:`groups` from its pickled state.
+    fn __setstate__(&mut self, state: Option<Vec<u32>>) {
+        self.inner.groups = state;
+    }
 }
 
 #[pymodule]

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -1050,6 +1050,29 @@ impl PyTransferVertexOperator {
             .map(Into::into)
             .map_err(crate::value_err)
     }
+
+    /// Returns the constructor arguments needed to pickle this operator.
+    ///
+    /// Together with :meth:`__getstate__`/:meth:`__setstate__` (which round-trip
+    /// :attr:`groups`), this makes instances of this class picklable.
+    fn __getnewargs__(&self) -> (Vec<Complex64>, Vec<u32>, Vec<u32>, Vec<usize>) {
+        (
+            self.inner.coeffs.clone(),
+            self.inner.left_indices.clone(),
+            self.inner.right_indices.clone(),
+            self.inner.boundaries.clone(),
+        )
+    }
+
+    /// Returns the pickled state of this operator (its :attr:`groups`).
+    fn __getstate__(&self) -> Option<Vec<u32>> {
+        self.inner.groups.clone()
+    }
+
+    /// Restores this operator's :attr:`groups` from its pickled state.
+    fn __setstate__(&mut self, state: Option<Vec<u32>>) {
+        self.inner.groups = state;
+    }
 }
 
 #[pymodule]

--- a/python/qiskit_fermions/__init__.py
+++ b/python/qiskit_fermions/__init__.py
@@ -17,7 +17,7 @@
 """
 
 import sys
-from inspect import ismodule
+from inspect import isclass, ismodule
 
 from . import _lib
 from .version import __version__  # noqa: F401
@@ -32,4 +32,14 @@ while len(__modules):
             if ismodule(__submodule):
                 __modules[__submodule] = __submodule_path
                 sys.modules[__submodule_path] = __submodule
+            elif isclass(__submodule) and __submodule.__module__ != __path:
+                # Native pyclasses declare their public, logical dotted path (e.g.
+                # ``qiskit_fermions.operators.fermion_operator``) as ``__module__`` for a
+                # user-facing ``repr``/error messages, which does not match the physical
+                # ``_lib``-rooted path under which they are actually importable. That
+                # logical path is never itself a real module, so ``pickle`` cannot resolve
+                # it via ``importlib.import_module`` when serializing a reference to the
+                # class. Aliasing it to the real (private, underscore-prefixed) module here
+                # fixes that without touching the public-facing ``__module__``.
+                sys.modules[__submodule.__module__] = __module
         del __modules[__module]

--- a/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
@@ -860,6 +860,21 @@ class EdgeVertexOperator:
             ValueError: if ``permutation`` contains duplicate entries, or is too short to relabel
                 some mode the operator acts upon.
         """
+    def __getnewargs__(self) -> tuple[builtins.list[builtins.complex], builtins.list[builtins.int], builtins.list[builtins.int], builtins.list[builtins.int]]:
+        r"""
+        Returns the constructor arguments needed to pickle this operator.
+        
+        Together with :meth:`__getstate__`/:meth:`__setstate__` (which round-trip
+        :attr:`groups`), this makes instances of this class picklable.
+        """
+    def __getstate__(self) -> typing.Optional[builtins.list[builtins.int]]:
+        r"""
+        Returns the pickled state of this operator (its :attr:`groups`).
+        """
+    def __setstate__(self, state: typing.Optional[typing.Sequence[builtins.int]]) -> None:
+        r"""
+        Restores this operator's :attr:`groups` from its pickled state.
+        """
     @staticmethod
     def _commutator_(op_a: EdgeVertexOperator, op_b: EdgeVertexOperator) -> EdgeVertexOperator: ...
     @staticmethod

--- a/python/qiskit_fermions/_lib/operators/fermion_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/fermion_operator/__init__.pyi
@@ -927,7 +927,7 @@ class FermionOperator:
             ValueError: if ``permutation`` contains duplicate entries, or is too short to relabel
                 some mode the operator acts upon.
         """
-    def _fci_linear_operator_(self, norb: builtins.int, nelec: typing.Any) -> fci.FciLinearOperator:
+    def __getnewargs__(self) -> tuple[builtins.list[builtins.complex], builtins.list[builtins.bool], builtins.list[builtins.int], builtins.list[builtins.int]]:
         r"""
         Returns a native FCI matrix-vector view of this operator on a fixed sector.
         
@@ -960,7 +960,20 @@ class FermionOperator:
             TypeError: if ``nelec`` is neither an ``int`` nor a ``(int, int)`` tuple.
             ValueError: if ``norb`` exceeds the maximum number of orbitals the bitmask
                 representation supports (64).
+        Returns the constructor arguments needed to pickle this operator.
+        
+        Together with :meth:`__getstate__`/:meth:`__setstate__` (which round-trip
+        :attr:`groups`), this makes instances of this class picklable.
         """
+    def __getstate__(self) -> typing.Optional[builtins.list[builtins.int]]:
+        r"""
+        Returns the pickled state of this operator (its :attr:`groups`).
+        """
+    def __setstate__(self, state: typing.Optional[typing.Sequence[builtins.int]]) -> None:
+        r"""
+        Restores this operator's :attr:`groups` from its pickled state.
+        """
+    def _fci_linear_operator_(self, norb: builtins.int, nelec: typing.Any) -> fci.FciLinearOperator: ...
     @staticmethod
     def _commutator_(op_a: FermionOperator, op_b: FermionOperator) -> FermionOperator: ...
     @staticmethod

--- a/python/qiskit_fermions/_lib/operators/majorana_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/majorana_operator/__init__.pyi
@@ -847,6 +847,21 @@ class MajoranaOperator:
             ValueError: if ``permutation`` contains duplicate entries, or is too short to relabel
                 some mode the operator acts upon.
         """
+    def __getnewargs__(self) -> tuple[builtins.list[builtins.complex], builtins.list[builtins.int], builtins.list[builtins.int]]:
+        r"""
+        Returns the constructor arguments needed to pickle this operator.
+        
+        Together with :meth:`__getstate__`/:meth:`__setstate__` (which round-trip
+        :attr:`groups`), this makes instances of this class picklable.
+        """
+    def __getstate__(self) -> typing.Optional[builtins.list[builtins.int]]:
+        r"""
+        Returns the pickled state of this operator (its :attr:`groups`).
+        """
+    def __setstate__(self, state: typing.Optional[typing.Sequence[builtins.int]]) -> None:
+        r"""
+        Restores this operator's :attr:`groups` from its pickled state.
+        """
 
 @typing.final
 class MajoranaOperatorDataGroupIter:

--- a/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
@@ -872,6 +872,21 @@ class TransferVertexOperator:
             ValueError: if ``permutation`` contains duplicate entries, or is too short to relabel
                 some mode the operator acts upon.
         """
+    def __getnewargs__(self) -> tuple[builtins.list[builtins.complex], builtins.list[builtins.int], builtins.list[builtins.int], builtins.list[builtins.int]]:
+        r"""
+        Returns the constructor arguments needed to pickle this operator.
+        
+        Together with :meth:`__getstate__`/:meth:`__setstate__` (which round-trip
+        :attr:`groups`), this makes instances of this class picklable.
+        """
+    def __getstate__(self) -> typing.Optional[builtins.list[builtins.int]]:
+        r"""
+        Returns the pickled state of this operator (its :attr:`groups`).
+        """
+    def __setstate__(self, state: typing.Optional[typing.Sequence[builtins.int]]) -> None:
+        r"""
+        Restores this operator's :attr:`groups` from its pickled state.
+        """
 
 @typing.final
 class TransferVertexOperatorDataGroupIter:

--- a/tests/python/circuit/test_fermionic_circuit.py
+++ b/tests/python/circuit/test_fermionic_circuit.py
@@ -14,12 +14,56 @@
 
 from __future__ import annotations
 
+import pickle
+
 import pytest
 from qiskit.circuit.library import XGate
 from qiskit_fermions.circuit import FermionicCircuit
+from qiskit_fermions.circuit.library import Evolution
+from qiskit_fermions.operators import FermionOperator, ann, cre
+from qiskit_fermions.transpiler import FermionicCircuitToDAG
 
 
 def test_invalid_gate():
     circ = FermionicCircuit(1)
     with pytest.raises(ValueError):
         circ.append(XGate(), circ.modes)
+
+
+def _evolution_circuit() -> FermionicCircuit:
+    """Builds a small circuit holding an ``Evolution`` gate over a ``FermionOperator``."""
+    num_modes = 4
+    hamil = FermionOperator.from_dict(
+        {(cre(0), ann(2)): 2.0, (cre(2), ann(0)): 2.0, (cre(1), ann(3)): -2.0}
+    )
+    circ = FermionicCircuit(num_modes)
+    circ.append(Evolution(num_modes, hamil, time=1.5), circ.modes)
+    return circ
+
+
+def test_pickle():
+    """Regression test for https://github.com/Qiskit/qiskit-fermions/issues/225.
+
+    A ``FermionicCircuit`` holding an ``Evolution`` gate failed to pickle because the native
+    operator it wraps carried no pickle protocol, and separately because its ``__module__``
+    was not resolvable via ``importlib`` (see :mod:`qiskit_fermions`'s ``sys.modules`` aliasing).
+    """
+    circ = _evolution_circuit()
+    reconstructed = pickle.loads(pickle.dumps(circ))
+
+    assert reconstructed.modes == circ.modes
+    assert reconstructed.count_ops() == circ.count_ops() == {"Evolution": 1}
+
+
+def test_pickle_dag():
+    """Same as :func:`test_pickle`, but for the ``FermionicDAGCircuit`` conversion."""
+    dag = FermionicCircuitToDAG().run(_evolution_circuit())
+    reconstructed = pickle.loads(pickle.dumps(dag))
+
+    original_nodes = list(dag.op_nodes())
+    reconstructed_nodes = list(reconstructed.op_nodes())
+    assert len(original_nodes) == len(reconstructed_nodes) == 1
+
+    original_op = original_nodes[0].op.operator
+    reconstructed_op = reconstructed_nodes[0].op.operator
+    assert original_op.equiv(reconstructed_op)

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+import pickle
+
 import numpy as np
 import pytest
 from qiskit_fermions.operators import EdgeVertexOperator
@@ -154,6 +156,21 @@ class TestEdgeVertexOperator:
             assert op.groups == reconstructed.groups
         with subtests.test("list"):
             reconstructed = cls.from_terms_with_groups(list(op.iter_terms_with_groups()))
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+
+    def test_pickle(self, subtests):
+        cls = self.get_class()
+        op = cls.from_dict({((0, 1),): 1.0, ((3, 4),): -1.0})
+
+        with subtests.test("without groups"):
+            reconstructed = pickle.loads(pickle.dumps(op))
+            assert op.equiv(reconstructed)
+            assert reconstructed.groups is None
+
+        with subtests.test("with groups"):
+            op.groups = [0, 1]
+            reconstructed = pickle.loads(pickle.dumps(op))
             assert op.equiv(reconstructed)
             assert op.groups == reconstructed.groups
 

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+import pickle
+
 import numpy as np
 import pytest
 from qiskit_fermions.operators import FermionOperator, ann, cre
@@ -156,6 +158,21 @@ class TestFermionOperator:
             assert op.groups == reconstructed.groups
         with subtests.test("list"):
             reconstructed = cls.from_terms_with_groups(list(op.iter_terms_with_groups()))
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+
+    def test_pickle(self, subtests):
+        cls = self.get_class()
+        op = cls.from_dict({(cre(0), ann(2)): 2.0, (cre(2), ann(0)): 2.0})
+
+        with subtests.test("without groups"):
+            reconstructed = pickle.loads(pickle.dumps(op))
+            assert op.equiv(reconstructed)
+            assert reconstructed.groups is None
+
+        with subtests.test("with groups"):
+            op.groups = [0, 1]
+            reconstructed = pickle.loads(pickle.dumps(op))
             assert op.equiv(reconstructed)
             assert op.groups == reconstructed.groups
 

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+import pickle
+
 import numpy as np
 import pytest
 from qiskit_fermions.operators import MajoranaOperator, gamma
@@ -149,6 +151,21 @@ class TestMajoranaOperator:
             assert op.groups == reconstructed.groups
         with subtests.test("list"):
             reconstructed = cls.from_terms_with_groups(list(op.iter_terms_with_groups()))
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+
+    def test_pickle(self, subtests):
+        cls = self.get_class()
+        op = cls.from_dict({(0, 1): 1.0, (2, 3): -1.0})
+
+        with subtests.test("without groups"):
+            reconstructed = pickle.loads(pickle.dumps(op))
+            assert op.equiv(reconstructed)
+            assert reconstructed.groups is None
+
+        with subtests.test("with groups"):
+            op.groups = [0, 1]
+            reconstructed = pickle.loads(pickle.dumps(op))
             assert op.equiv(reconstructed)
             assert op.groups == reconstructed.groups
 

--- a/tests/python/operators/test_transfer_vertex_operator.py
+++ b/tests/python/operators/test_transfer_vertex_operator.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+import pickle
+
 import numpy as np
 import pytest
 from qiskit_fermions.operators import TransferVertexOperator
@@ -154,6 +156,21 @@ class TestTransferVertexOperator:
             assert op.groups == reconstructed.groups
         with subtests.test("list"):
             reconstructed = cls.from_terms_with_groups(list(op.iter_terms_with_groups()))
+            assert op.equiv(reconstructed)
+            assert op.groups == reconstructed.groups
+
+    def test_pickle(self, subtests):
+        cls = self.get_class()
+        op = cls.from_dict({((0, 1),): 1.0, ((3, 4),): -1.0})
+
+        with subtests.test("without groups"):
+            reconstructed = pickle.loads(pickle.dumps(op))
+            assert op.equiv(reconstructed)
+            assert reconstructed.groups is None
+
+        with subtests.test("with groups"):
+            op.groups = [0, 1]
+            reconstructed = pickle.loads(pickle.dumps(op))
             assert op.equiv(reconstructed)
             assert op.groups == reconstructed.groups
 

--- a/tests/python/transpiler/passes/test_relabel_modes.py
+++ b/tests/python/transpiler/passes/test_relabel_modes.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import pickle
+
 import pytest
 from qiskit import QuantumRegister
 from qiskit.circuit.library import PauliEvolutionGate
@@ -161,6 +163,32 @@ def test_relabel_modes_pyomo_optimization():
 
     qu_circ_decomp = qu_circ.decompose(reps=2)
     assert qu_circ_decomp.depth(lambda instr: len(instr.qubits) == 2) == 4
+
+
+@pytest.mark.skipif(not HAS_PYOMO, reason="Pyomo is required")
+def test_relabel_modes_pyomo_metadata_pickle():
+    """Regression test for https://github.com/Qiskit/qiskit-fermions/issues/225.
+
+    The issue speculated that the pyomo ``SolverResults`` object stashed in
+    ``dag.metadata["permutation.opt_result"]`` might not be picklable. That turned out not to be
+    the actual root cause of the reported failure, but the issue explicitly asked for a test
+    ensuring circuits carrying this metadata are -- and remain -- serializable.
+    """
+    hamil = FermionOperator.from_dict({((True, 0), (False, 2)): 2.0, ((True, 2), (False, 0)): 2.0})
+    dag = _single_evolution_dag(hamil)
+
+    solver = SolverFactory("appsi_highs")
+    solver.options["time_limit"] = 60
+    relabel = RelabelModes(solver=solver)
+
+    out_dag = relabel.run(dag)
+    assert "permutation" in out_dag.metadata
+    assert "permutation.opt_result" in out_dag.metadata
+
+    reconstructed = pickle.loads(pickle.dumps(out_dag))
+    assert reconstructed.metadata["permutation"] == out_dag.metadata["permutation"]
+    opt_result_type = type(out_dag.metadata["permutation.opt_result"])
+    assert isinstance(reconstructed.metadata["permutation.opt_result"], opt_result_type)
 
 
 def _single_evolution_dag(operator, num_modes=4, time=1.5):


### PR DESCRIPTION
## Summary

`FermionicCircuit`/`FermionicDAGCircuit` instances holding an `Evolution` gate failed to pickle, which broke parallel transpilation (e.g. of multiple SqDRIFT randomizations) via `concurrent.futures.ProcessPoolExecutor`, since that relies on stdlib `pickle` to ship circuits across process boundaries.

Two independent bugs were involved:

1. `FermionOperator`, `MajoranaOperator`, `EdgeVertexOperator`, and `TransferVertexOperator` carried no pickle protocol, so pickling fell back to `__reduce_ex__`'s default handling and silently dropped the `groups` field. Each now implements `__getnewargs__`/`__getstate__`/`__setstate__` to round-trip through their constructor plus `groups`.
2. Fixing (1) surfaced a second, independent bug: these classes (and `FciLinearOperator`, `FCIDump`) declare a public, logical `__module__` via `#[pyclass(module = "...")]` for user-facing `repr()`/error messages (per #186), but that path was never registered in `sys.modules` — only the physical `_lib`-rooted path was. Pickle needs to resolve a class's `__module__` via `importlib` to serialize a reference to it, so this broke regardless of (1). `qiskit_fermions/__init__.py`'s existing `sys.modules` registration loop now also aliases each pyclass's declared module to its real module object, leaving the public-facing `repr()`/`__module__`/error text untouched.

Closes #225