### PR TITLE
perf(transpiler): remove `QDriftTrotterization`'s `filter_diagonal_terms` flag

### DIFF
--- a/docs/guides/sqdrift.rst
+++ b/docs/guides/sqdrift.rst
@@ -78,6 +78,43 @@ detail in :ref:`this guide <grouping_explanation>`.
        QfExitCode exit = qf_ferm_op_group_terms_by_electronic_structure(normal, num_modes, false);
        QfFermionOperator* canon = qf_ferm_op_canonical_order(normal);
 
+.. hint::
+
+   The full electronic structure Hamiltonian contains certain terms whose
+   inclusion in a time-evolution circuit will have no impact on the perceived
+   bitstrings and, thus, only result in an increased sampling overhead.
+   Therefore, it is recommended that such terms be filtered from the
+   Hamiltonian at this point, before constructing the :class:`.Evolution` gate
+   in the next step.
+
+   The terms that fit this description are exactly those that are *diagonal*
+   in the occupation-number basis, i.e. the products of number operators
+   (:math:`a^\dagger_i a_i`). This includes the constant energy offset, whose
+   time evolution only introduces a global phase into the circuit, the
+   individual number-operators whose time evolution amounts to single-qubit Z
+   rotations, as well as higher-order products such as :math:`n_i n_j`. None
+   of these impact the sampled bitstrings.
+
+   The :func:`~qiskit_fermions.operators.terms.filtering.filter_diagonal_terms`
+   function removes such terms from an operator in place:
+
+   .. tab-set-code::
+
+       .. code-block:: python
+
+          >>> from qiskit_fermions.operators.terms.filtering import filter_diagonal_terms
+          >>>
+          >>> filter_diagonal_terms(canon)
+
+       .. code-block:: c
+
+          qf_ferm_op_filter_diagonal_terms(canon);
+
+   Filtering here, once, is considerably cheaper than filtering repeatedly:
+   :class:`.QDriftTrotterization` runs once per transpiled circuit, so
+   filtering the Hamiltonian beforehand -- rather than on every call -- avoids
+   redoing the same work for every circuit generated from it.
+
 3. Prepare the time evolution circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -133,29 +170,6 @@ each circuit, every time we transpile the circuit. Through this, we can generate
 multiple circuit randomizations as required by the `SqDRIFT`_ algorithm by
 repeatedly running the transpilation pipeline.
 
-.. hint::
-
-   The full electronic structure Hamiltonian contains certain terms whose
-   inclusion in a time-evolution circuit will have no impact on the perceived
-   bitstrings and, thus, only result in an increased sampling overhead.
-   Therefore, it is recommended that such terms be filtered from the Hamiltonian
-   before continuing with the remaining procedure.
-
-   The terms that fit this description are exactly those that are *diagonal* in
-   the occupation-number basis, i.e. the products of number operators
-   (:math:`a^\dagger_i a_i`). This includes the constant energy offset, whose
-   time evolution only introduces a global phase into the circuit, the
-   individual number-operators whose time evolution amounts to single-qubit Z
-   rotations, as well as higher-order products such as :math:`n_i n_j`. None of
-   these impact the sampled bitstrings.
-
-   The :func:`~qiskit_fermions.operators.terms.filtering.filter_diagonal_terms`
-   function can be used to remove such terms from an operator manually (for
-   example before constructing the :class:`.Evolution` gate in the previous
-   step. Alternatively, the :class:`.QDriftTrotterization` pass can apply this
-   filtering automatically via its ``filter_diagonal_terms=True`` flag, so an
-   explicit call is usually not necessary.
-
 This step also introduces the few parameters with which one can tweak the
 ensemble of circuits to generate:
 
@@ -171,7 +185,7 @@ ensemble of circuits to generate:
        >>> from qiskit_fermions.transpiler.passes import QDriftTrotterization
        >>>
        >>> num_groups = 10
-       >>> qdrift = QDriftTrotterization(num_groups, filter_diagonal_terms=True, rng=19)
+       >>> qdrift = QDriftTrotterization(num_groups, rng=19)
        >>>
        >>> pm = generate_preset_jw_pass_manager()
        >>> pm.optimization = FermionicPassManager([qdrift])
@@ -225,11 +239,9 @@ sampled excitations with and without ``filter_trivial=True``:
        >>> hf_circ.append(Evolution(num_modes, canon, time), hf_circ.modes)
        >>>
        >>> num_groups = 5
-       >>> qdrift_unfiltered = QDriftTrotterization(
-       ...     num_groups, filter_diagonal_terms=True, rng=3480
-       ... )
+       >>> qdrift_unfiltered = QDriftTrotterization(num_groups, rng=3480)
        >>> qdrift_trivial = QDriftTrotterization(
-       ...     num_groups, filter_diagonal_terms=True, filter_trivial=True, rng=3480
+       ...     num_groups, filter_trivial=True, rng=3480
        ... )
        >>>
        >>> for instruction in FermionicPassManager(qdrift_unfiltered).run(hf_circ)._inner.data:
@@ -280,15 +292,6 @@ once the first excitation touched them.
    has no occupation information to filter against: it emits a
    :class:`UserWarning` and leaves the sampling unfiltered for that
    :class:`.Evolution` gate.
-
-.. note::
-   ``filter_diagonal_terms=True`` remains worth keeping enabled even alongside
-   ``filter_trivial=True``. The two act at different stages: diagonal-term
-   filtering shrinks the Hamiltonian *before* sampling begins, while
-   ``filter_trivial`` only rejects already-sampled terms one draw at a time.
-   Removing the (always-trivial) diagonal terms up front reduces how often
-   ``filter_trivial`` has to reject and re-draw, lowering the runtime cost of
-   filling all ``num_groups`` slots.
 
 (Optional) Optimize the fermionic mode indexing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import copy
 import warnings
 from typing import Any
 
@@ -28,8 +27,6 @@ from qiskit_fermions.circuit.library import (
     OrbitalRotation,
     PrepareSlaterDeterminant,
 )
-from qiskit_fermions.operators import FermionOperator
-from qiskit_fermions.operators.terms.filtering import filter_diagonal_terms
 
 from ... import FermionicDAGCircuitPass
 
@@ -59,6 +56,15 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
     ``num_terms`` grows. Because the output depends on the random draws, it differs from run to run
     unless a fixed ``rng`` is supplied.
 
+    .. hint::
+       Terms that are diagonal in the occupation-number basis (i.e. products of number operators)
+       have no effect on the sampled bitstrings, so including them only increases the sampling
+       overhead. Filter them out with
+       :func:`~qiskit_fermions.operators.terms.filtering.filter_diagonal_terms` on the Hamiltonian
+       *before* constructing the :class:`.Evolution` gate, rather than on every call to :meth:`run`:
+       this pass runs once per transpiled circuit, so filtering upstream avoids repeating the same
+       filtering work for every circuit generated from the same Hamiltonian.
+
     .. seealso::
        The qDRIFT protocol was introduced in `arXiv:1811.08017 <https://arxiv.org/abs/1811.08017>`_.
     """
@@ -74,7 +80,6 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
         self,
         num_terms: int,
         *,
-        filter_diagonal_terms: bool = False,
         filter_trivial: bool = False,
         rng: np.random.Generator | int | None = None,
     ) -> None:
@@ -84,22 +89,6 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
             num_terms: the number of terms to sample for the qDRIFT Trotterization. This equals the
                 number of :class:`.Evolution` gates emitted per input gate; a larger value reduces
                 the Trotterization error at the cost of a deeper circuit.
-            filter_diagonal_terms: when set to ``True``, terms that are diagonal in the
-                occupation-number basis (i.e. products of number operators) are removed from the
-                Hamiltonian before the qDRIFT sampling. The time evolution of such terms does not
-                affect the sampled bitstrings, so including them would only increase the sampling
-                overhead. This automates the manual filtering otherwise required when preparing a
-                Hamiltonian for SqDRIFT. The Hamiltonian is assumed to be normal-ordered. See also
-                :func:`~qiskit_fermions.operators.terms.filtering.filter_diagonal_terms`. Because
-                diagonal-term filtering is defined in terms of fermionic number operators, it is
-                only supported for :class:`.Evolution` gates whose operator is a
-                :class:`.FermionOperator`; :meth:`run` raises :class:`TypeError` otherwise. This
-                remains worthwhile even in combination with ``filter_trivial=True``: it shrinks the
-                pool of terms being sampled from *before* the sampling starts, whereas
-                ``filter_trivial`` can only reject terms one draw at a time, after they have already
-                been sampled. Removing the (always-trivial) diagonal terms up front therefore lowers
-                the average number of rejected draws that ``filter_trivial`` has to make, reducing
-                the runtime cost of reaching ``num_terms`` accepted samples.
             filter_trivial: when set to ``True``, the sampling loop rejects a sampled term unless it
                 couples a mode known to be occupied with a mode known to be unoccupied. Any term
                 acting only within one of these two sets cannot change the occupation and, thus, has
@@ -125,9 +114,6 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
 
         self.num_terms = num_terms
         """The number of terms to include in the qDRIFT Trotterization."""
-
-        self.filter_diagonal_terms = filter_diagonal_terms
-        """Whether to filter out diagonal terms before the qDRIFT sampling."""
 
         self.filter_trivial = filter_trivial
         """Whether to reject sampled terms that cannot affect the sampled bitstring (see the
@@ -167,9 +153,6 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
             The output circuit which is still acting on a fermionic register.
 
         Raises:
-            TypeError: if ``filter_diagonal_terms`` is ``True`` but an :class:`.Evolution` gate
-                carries an operator that is not a :class:`.FermionOperator` (diagonal-term filtering
-                is only defined for fermionic operators).
             RuntimeError: if ``filter_trivial`` is ``True`` and :attr:`MAX_SAMPLE_RETRIES`
                 consecutive samples are rejected without finding a non-trivial term to emit.
         """
@@ -225,20 +208,6 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
             hamil = node.op.operator
             time = node.op.params[0]
             num_modes = len(node.qargs)
-
-            if self.filter_diagonal_terms:
-                # Diagonal-term filtering is defined in terms of fermionic number operators, so it
-                # only applies to a `FermionOperator`; reject any other operator type up front.
-                if not isinstance(hamil, FermionOperator):
-                    raise TypeError(
-                        "filter_diagonal_terms=True is only supported for Evolution gates whose "
-                        f"operator is a FermionOperator, but got {type(hamil).__name__}."
-                    )
-                # Work on a copy so that the user's original operator (held by the Evolution gate)
-                # is left untouched. Filtering re-indexes any group information to a contiguous
-                # range, keeping the grouped branch below consistent.
-                hamil = copy.deepcopy(hamil)
-                filter_diagonal_terms(hamil)
 
             terms: list[Any]  # can be either a list of operator terms or operator instances
             if hamil.groups is None:

--- a/tests/python/transpiler/passes/test_qdrift_optimization.py
+++ b/tests/python/transpiler/passes/test_qdrift_optimization.py
@@ -25,8 +25,9 @@ from qiskit_fermions.circuit.library import (
     OrbitalRotation,
     PrepareSlaterDeterminant,
 )
-from qiskit_fermions.operators import FermionOperator, MajoranaOperator, gamma
+from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.operators.library import FCIDump
+from qiskit_fermions.operators.terms.filtering import filter_diagonal_terms
 from qiskit_fermions.operators.terms.grouping import group_terms_by_electronic_structure
 from qiskit_fermions.transpiler.passes import QDriftTrotterization
 from qiskit_fermions.transpiler.passmanager import FermionicPassManager
@@ -142,6 +143,8 @@ def _is_diagonal(term):
 
 
 def test_qdrift_optimization_filter_diagonal_terms():
+    """Diagonal-term filtering is expected to happen on the Hamiltonian before it is wrapped in an
+    Evolution gate (see the QDriftTrotterization class docstring), not on every call to run()."""
     file_path = Path(__file__).parent / "../../../h2.fcidump"
     fcidump = FCIDump.from_file(str(file_path))
     num_modes = 2 * fcidump.norb
@@ -152,44 +155,25 @@ def test_qdrift_optimization_filter_diagonal_terms():
     # sanity check: the grouped, normal-ordered Hamiltonian still contains diagonal terms (the
     # constant offset and number operators) which the filtering is expected to remove.
     assert any(_is_diagonal(term) for term, _ in normal.iter_terms())
-    num_groups_before = normal.num_groups()
+
+    filter_diagonal_terms(normal)
+    assert not any(_is_diagonal(term) for term, _ in normal.iter_terms())
 
     time = 1.5
     circ = FermionicCircuit(num_modes)
     circ.append(Evolution(num_modes, normal, time=time), circ.modes)
 
     num_terms = 5
-    qdrift = QDriftTrotterization(num_terms, filter_diagonal_terms=True, rng=42)
+    qdrift = QDriftTrotterization(num_terms, rng=42)
     pm = FermionicPassManager(qdrift)
 
     qdrift_circ = pm.run(circ)
     assert qdrift_circ.count_ops() == {"Evolution": num_terms}
 
-    # the user's original operator must not have been mutated by the pass
-    assert normal.num_groups() == num_groups_before
-    assert any(_is_diagonal(term) for term, _ in normal.iter_terms())
-
     # none of the sampled sub-operators may contain a diagonal term
     for instruction in qdrift_circ._inner.data:
         for term, _ in instruction.operation.operator.iter_terms():
             assert not _is_diagonal(term), "a diagonal term was sampled despite filtering"
-
-
-def test_qdrift_optimization_filter_diagonal_terms_rejects_non_fermion_operator():
-    """Diagonal-term filtering is only defined for fermionic number operators, so requesting it for
-    an Evolution gate carrying a non-FermionOperator must raise TypeError rather than passing the
-    wrong operator type into the fermion-specific filter."""
-    num_modes = 2
-    hamil = MajoranaOperator.from_dict({(gamma(0, False), gamma(1, False)): 1.0})
-
-    circ = FermionicCircuit(num_modes)
-    circ.append(Evolution(num_modes, hamil, time=1.5), circ.modes)
-
-    qdrift = QDriftTrotterization(5, filter_diagonal_terms=True, rng=42)
-    pm = FermionicPassManager(qdrift)
-
-    with pytest.raises(TypeError, match="only supported for Evolution gates"):
-        pm.run(circ)
 
 
 def test_qdrift_optimization_preserves_coefficient_sign():


### PR DESCRIPTION
This is follow-up number 4 from #229. This was an easy and quick change to do, hence it comes first.