### PR TITLE
Clean up URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -32,14 +32,14 @@ body:
   - type: textarea
     attributes:
       label: How can we reproduce the issue?
-      description: Give some steps that show the bug.  A [minimal working example](https://stackoverflow.com/help/minimal-reproducible-example) of code with output is best.  If you are copying in code, please remember to enclose it in triple backticks (` ``` [multiline code goes here] ``` `) so that it [displays correctly](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+      description: Give some steps that show the bug.  A [minimal working example](https://stackoverflow.com/help/minimal-reproducible-example) of code with output is best.  If you are copying in code, please remember to enclose it in triple backticks (` ``` [multiline code goes here] ``` `) so that it [displays correctly](https://docs.github.com/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
     validations:
       required: true
 
   - type: textarea
     attributes:
       label: Traceback
-      description: If your code provided an error traceback, please paste it below, enclosed in triple backticks (` ``` [multiline code goes here] ``` `) so that it [displays correctly](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+      description: If your code provided an error traceback, please paste it below, enclosed in triple backticks (` ``` [multiline code goes here] ``` `) so that it [displays correctly](https://docs.github.com/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
     validations:
       required: false
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,4 +17,4 @@ Please do **not** open a public issue about a potential security vulnerability.
 You can find more details on the security vulnerability feature in the GitHub
 documentation here:
 
-https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
+https://docs.github.com/code-security/how-tos/report-and-fix-vulnerabilities/report-privately

--- a/docs/guides/skqd.rst
+++ b/docs/guides/skqd.rst
@@ -538,7 +538,7 @@ handful of configurations dominate, led by the reference determinant.
 
 The sampled bitstrings are the input to the classical half of SKQD: the Hamiltonian is projected onto
 the subspace the sampled configurations span and diagonalized there. We hand this off to the
-`qiskit-addon-sqd <https://quantum.cloud.ibm.com/docs/en/addons/qiskit-addon-sqd>`_ package, whose
+`qiskit-addon-sqd <https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd>`_ package, whose
 :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` runs the full sample-based
 quantum diagonalization loop: it builds a subspace from batches of the sampled configurations,
 diagonalizes the Hamiltonian in it, and iteratively refines the subspace via *configuration
@@ -632,7 +632,7 @@ transpiled ``circuits`` would be executed and measured in place of the statevect
 6, with the resulting counts feeding the same step-7 diagonalization unchanged. Refer to the `Qiskit
 documentation <https://quantum.cloud.ibm.com/docs/guides/intro-to-patterns>`_ for running circuits,
 and to the `SQD addon tutorials
-<https://quantum.cloud.ibm.com/docs/en/addons/qiskit-addon-sqd/guides/overview>`_ for more on the
+<https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd/guides/overview>`_ for more on the
 subspace-diagonalization post-processing -- including its behavior on noisy samples, where
 configuration recovery does the most work.
 

--- a/docs/guides/sqdrift.rst
+++ b/docs/guides/sqdrift.rst
@@ -356,7 +356,7 @@ for detailed instructions.
 
 Once the bitstring samples have been obtained, these can be used in combination
 with the Hamiltonian coefficients to perform SQD post-processing, as explained in the `SQD addon
-tutorials <https://quantum.cloud.ibm.com/docs/en/addons/qiskit-addon-sqd/guides/overview>`_.
+tutorials <https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd/guides/overview>`_.
 
 
 .. _qDRIFT: https://arxiv.org/abs/1811.08017

--- a/tests/python/transpiler/passes/test_custom_layout.py
+++ b/tests/python/transpiler/passes/test_custom_layout.py
@@ -111,7 +111,7 @@ def derby_klassen(
 
     .. [1] C. Derby, J. Klassen, J. Bausch, and T. Cubitt, Compact fermion to qubit mappings,
            Phys. Rev. B 104, 035118 (2021),
-           `doi:10.1103/PhysRevB.104.035118 <http://dx.doi.org/10.1103/PhysRevB.104.035118>`_.
+           `doi:10.1103/PhysRevB.104.035118 <https://doi.org/10.1103/PhysRevB.104.035118>`_.
     """
     assert op.is_even()
 
@@ -169,7 +169,7 @@ def test_derby_klassen():
 
     .. [1] C. Derby, J. Klassen, J. Bausch, and T. Cubitt, Compact fermion to qubit mappings,
            Phys. Rev. B 104, 035118 (2021),
-           `doi:10.1103/PhysRevB.104.035118 <http://dx.doi.org/10.1103/PhysRevB.104.035118>`_.
+           `doi:10.1103/PhysRevB.104.035118 <https://doi.org/10.1103/PhysRevB.104.035118>`_.
     """
     num_qubits = 20
     hamil = build_fermi_hubbard_square_lattice(4, 4, 5.0, 5.0)
@@ -300,7 +300,7 @@ def test_custom_layout():
 
     .. [1] C. Derby, J. Klassen, J. Bausch, and T. Cubitt, Compact fermion to qubit mappings,
            Phys. Rev. B 104, 035118 (2021),
-           `doi:10.1103/PhysRevB.104.035118 <http://dx.doi.org/10.1103/PhysRevB.104.035118>`_.
+           `doi:10.1103/PhysRevB.104.035118 <https://doi.org/10.1103/PhysRevB.104.035118>`_.
     """
     num_modes = 16
     num_qubits = 20


### PR DESCRIPTION
This PR includes some URL cleanup that will make migrating documentation to the IBM Platform easier

- Remove language-specific URL sub-strings when possible (e.g. "/en/")
- Use secure HTTP when possible
- Update links that are redirecting to more modern URLS to the new URL