### PR TITLE
perf: support lazy, index-based group lookup in `split_out_groups`

### DIFF
--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -550,10 +550,23 @@ pub unsafe extern "C" fn qf_ferm_op_del_groups(op: *mut FermionOperator) {
 /// @brief Splits this operator into a list of new operators based on its ``groups`` attribute.
 ///
 /// @param op A pointer to the fermionic operator whose ``groups`` to split out.
+/// @param group_indices A pointer to the array of group indices for which to build operators, in
+///     the desired output order. May be ``NULL``, in which case every group is built, in index
+///     order (equivalent to passing every index from ``0`` to
+///     :c:func:`qf_ferm_op_num_groups` ``- 1``).
+/// @param num_indices The number of indices in the ``group_indices`` array. Ignored if
+///     ``group_indices`` is ``NULL``.
 /// @param group_ops_out A pointer to the array of :c:struct:`QfFermionOperator` into which to
-///     write the operators for each group.
+///     write the operators for each requested group. Must be sized to ``num_indices`` when
+///     ``group_indices`` is non-``NULL``, or to :c:func:`qf_ferm_op_num_groups` when it is
+///     ``NULL``.
 ///
 /// @rst
+///
+/// A duplicate index in ``group_indices`` is written once per occurrence in ``group_ops_out``.
+/// Requesting only a small number of groups out of a much larger total is significantly cheaper
+/// than requesting all of them, since terms belonging to a group that is not requested are
+/// skipped rather than appended anywhere.
 ///
 /// .. seealso::
 ///    The explanation on :ref:`grouping_explanation`.
@@ -576,17 +589,30 @@ pub unsafe extern "C" fn qf_ferm_op_del_groups(op: *mut FermionOperator) {
 ///     uint32_t groups_in[4] = {0, 1, 0, 1};
 ///     qf_ferm_op_set_groups(op, groups_in, num_terms);
 ///
+///     // build every group, in index order
 ///     QfFermionOperator *group_ops[2];
-///     qf_ferm_op_split_out_groups(op, group_ops);
+///     qf_ferm_op_split_out_groups(op, NULL, 0, group_ops);
+///
+///     // build only group 1
+///     uint32_t group_indices[1] = {1};
+///     QfFermionOperator *group_op[1];
+///     qf_ferm_op_split_out_groups(op, group_indices, 1, group_op);
 ///
 /// @endrst
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qf_ferm_op_split_out_groups(
     op: *const FermionOperator,
+    group_indices: *const u32,
+    num_indices: u64,
     group_ops_out: *mut *mut FermionOperator,
 ) {
     let op = unsafe { const_ptr_as_ref(op) };
-    let groups = op.split_out_groups().expect(
+    let group_indices = if group_indices.is_null() {
+        None
+    } else {
+        Some(unsafe { slice_from_ptr(group_indices, num_indices as usize) })
+    };
+    let groups = op.split_out_groups(group_indices).expect(
         "Expected groups to be present. It is the user's responsibility to check this via \
         qf_ferm_op_has_groups before calling this function.",
     );

--- a/crates/cext/src/operators/majorana_operator.rs
+++ b/crates/cext/src/operators/majorana_operator.rs
@@ -489,10 +489,23 @@ pub unsafe extern "C" fn qf_maj_op_del_groups(op: *mut MajoranaOperator) {
 /// @brief Splits this operator into a list of new operators based on its ``groups`` attribute.
 ///
 /// @param op A pointer to the majorana operator whose ``groups`` to split out.
+/// @param group_indices A pointer to the array of group indices for which to build operators, in
+///     the desired output order. May be ``NULL``, in which case every group is built, in index
+///     order (equivalent to passing every index from ``0`` to
+///     :c:func:`qf_maj_op_num_groups` ``- 1``).
+/// @param num_indices The number of indices in the ``group_indices`` array. Ignored if
+///     ``group_indices`` is ``NULL``.
 /// @param group_ops_out A pointer to the array of :c:struct:`QfMajoranaOperator` into which to
-///     write the operators for each group.
+///     write the operators for each requested group. Must be sized to ``num_indices`` when
+///     ``group_indices`` is non-``NULL``, or to :c:func:`qf_maj_op_num_groups` when it is
+///     ``NULL``.
 ///
 /// @rst
+///
+/// A duplicate index in ``group_indices`` is written once per occurrence in ``group_ops_out``.
+/// Requesting only a small number of groups out of a much larger total is significantly cheaper
+/// than requesting all of them, since terms belonging to a group that is not requested are
+/// skipped rather than appended anywhere.
 ///
 /// .. seealso::
 ///    The explanation on :ref:`grouping_explanation`.
@@ -513,17 +526,30 @@ pub unsafe extern "C" fn qf_maj_op_del_groups(op: *mut MajoranaOperator) {
 ///     uint32_t groups_in[4] = {0, 1, 0, 1};
 ///     qf_maj_op_set_groups(op, groups_in, num_terms);
 ///
+///     // build every group, in index order
 ///     QfMajoranaOperator *group_ops[2];
-///     qf_maj_op_split_out_groups(op, group_ops);
+///     qf_maj_op_split_out_groups(op, NULL, 0, group_ops);
+///
+///     // build only group 1
+///     uint32_t group_indices[1] = {1};
+///     QfMajoranaOperator *group_op[1];
+///     qf_maj_op_split_out_groups(op, group_indices, 1, group_op);
 ///
 /// @endrst
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qf_maj_op_split_out_groups(
     op: *const MajoranaOperator,
+    group_indices: *const u32,
+    num_indices: u64,
     group_ops_out: *mut *mut MajoranaOperator,
 ) {
     let op = unsafe { const_ptr_as_ref(op) };
-    let groups = op.split_out_groups().expect(
+    let group_indices = if group_indices.is_null() {
+        None
+    } else {
+        Some(unsafe { slice_from_ptr(group_indices, num_indices as usize) })
+    };
+    let groups = op.split_out_groups(group_indices).expect(
         "Expected groups to be present. It is the user's responsibility to check this via \
         qf_maj_op_has_groups before calling this function.",
     );

--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -136,16 +136,54 @@ impl EdgeVertexOperator {
         }
     }
 
-    pub fn split_out_groups(&self) -> Option<Vec<Self>> {
-        let mut groups = vec![Self::zero(); self.num_groups()? as usize];
-        for term in self.iter_with_groups() {
-            groups[term.group as usize]._append_term(
-                term.coeff,
-                term.left_indices,
-                term.right_indices,
-            );
+    /// Splits this operator into new operators based on its [`groups`](Self::groups).
+    ///
+    /// If `group_indices` is `None`, every group is materialized once, in index order (`0` to
+    /// [`num_groups`](Self::num_groups) `- 1`). If `group_indices` is `Some`, only the requested
+    /// indices are materialized, in the given order; a duplicate index is materialized once
+    /// internally and cloned once per occurrence in the output. This is significantly cheaper than
+    /// requesting all indices when only a small number of groups out of a much larger total are
+    /// needed, e.g. when subsampling groups for a randomized product formula, since terms
+    /// belonging to a group that is not requested are skipped rather than appended anywhere.
+    ///
+    /// Returns `None` if `self.groups` is `None`, regardless of `group_indices`.
+    pub fn split_out_groups(&self, group_indices: Option<&[u32]>) -> Option<Vec<Self>> {
+        match group_indices {
+            None => {
+                let mut groups = vec![Self::zero(); self.num_groups()? as usize];
+                for term in self.iter_with_groups() {
+                    groups[term.group as usize]._append_term(
+                        term.coeff,
+                        term.left_indices,
+                        term.right_indices,
+                    );
+                }
+                Some(groups)
+            }
+            Some(group_indices) => {
+                self.groups.as_ref()?;
+                let mut wanted: HashMap<u32, Self> = group_indices
+                    .iter()
+                    .map(|&idx| (idx, Self::zero()))
+                    .collect();
+                for term in self.iter_with_groups() {
+                    if let Some(acc) = wanted.get_mut(&term.group) {
+                        acc._append_term(term.coeff, term.left_indices, term.right_indices);
+                    }
+                }
+                Some(
+                    group_indices
+                        .iter()
+                        .map(|idx| {
+                            wanted
+                                .get(idx)
+                                .expect("every requested index was inserted above")
+                                .clone()
+                        })
+                        .collect(),
+                )
+            }
         }
-        Some(groups)
     }
 
     // TODO: expose an optional mode to also unify E_{jk} operators into a fixed order of j,k
@@ -1195,8 +1233,26 @@ mod tests {
             },
         ];
 
-        let groups = op.split_out_groups();
-        assert_eq!(groups, Some(expected));
+        let groups = op.split_out_groups(None);
+        assert_eq!(groups, Some(expected.clone()));
+
+        // reversed and non-exhaustive: asserts order-preservation and partial selection.
+        let selected = op.split_out_groups(Some(&[1, 0]));
+        assert_eq!(
+            selected,
+            Some(vec![expected[1].clone(), expected[0].clone()])
+        );
+
+        // a duplicate index must be returned once per occurrence, not deduplicated.
+        let duplicated = op.split_out_groups(Some(&[0, 0]));
+        assert_eq!(
+            duplicated,
+            Some(vec![expected[0].clone(), expected[0].clone()])
+        );
+
+        // an empty request returns an empty (not `None`) result, since `groups` is present.
+        let empty = op.split_out_groups(Some(&[]));
+        assert_eq!(empty, Some(vec![]));
     }
 
     #[test]
@@ -1213,8 +1269,8 @@ mod tests {
             groups: None,
         };
 
-        let groups = op.split_out_groups();
-        assert!(groups.is_none());
+        assert!(op.split_out_groups(None).is_none());
+        assert!(op.split_out_groups(Some(&[0])).is_none());
     }
 
     #[test]

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -137,12 +137,50 @@ impl FermionOperator {
         }
     }
 
-    pub fn split_out_groups(&self) -> Option<Vec<Self>> {
-        let mut groups = vec![Self::zero(); self.num_groups()? as usize];
-        for term in self.iter_with_groups() {
-            groups[term.group as usize]._append_term(term.coeff, term.actions, term.modes);
+    /// Splits this operator into new operators based on its [`groups`](Self::groups).
+    ///
+    /// If `group_indices` is `None`, every group is materialized once, in index order (`0` to
+    /// [`num_groups`](Self::num_groups) `- 1`). If `group_indices` is `Some`, only the requested
+    /// indices are materialized, in the given order; a duplicate index is materialized once
+    /// internally and cloned once per occurrence in the output. This is significantly cheaper than
+    /// requesting all indices when only a small number of groups out of a much larger total are
+    /// needed, e.g. when subsampling groups for a randomized product formula, since terms
+    /// belonging to a group that is not requested are skipped rather than appended anywhere.
+    ///
+    /// Returns `None` if `self.groups` is `None`, regardless of `group_indices`.
+    pub fn split_out_groups(&self, group_indices: Option<&[u32]>) -> Option<Vec<Self>> {
+        match group_indices {
+            None => {
+                let mut groups = vec![Self::zero(); self.num_groups()? as usize];
+                for term in self.iter_with_groups() {
+                    groups[term.group as usize]._append_term(term.coeff, term.actions, term.modes);
+                }
+                Some(groups)
+            }
+            Some(group_indices) => {
+                self.groups.as_ref()?;
+                let mut wanted: HashMap<u32, Self> = group_indices
+                    .iter()
+                    .map(|&idx| (idx, Self::zero()))
+                    .collect();
+                for term in self.iter_with_groups() {
+                    if let Some(acc) = wanted.get_mut(&term.group) {
+                        acc._append_term(term.coeff, term.actions, term.modes);
+                    }
+                }
+                Some(
+                    group_indices
+                        .iter()
+                        .map(|idx| {
+                            wanted
+                                .get(idx)
+                                .expect("every requested index was inserted above")
+                                .clone()
+                        })
+                        .collect(),
+                )
+            }
         }
-        Some(groups)
     }
 
     pub fn normal_ordered(&self, sandwich: Option<bool>) -> Self {
@@ -1386,8 +1424,26 @@ mod tests {
             },
         ];
 
-        let groups = op.split_out_groups();
-        assert_eq!(groups, Some(expected));
+        let groups = op.split_out_groups(None);
+        assert_eq!(groups, Some(expected.clone()));
+
+        // reversed and non-exhaustive: asserts order-preservation and partial selection.
+        let selected = op.split_out_groups(Some(&[1, 0]));
+        assert_eq!(
+            selected,
+            Some(vec![expected[1].clone(), expected[0].clone()])
+        );
+
+        // a duplicate index must be returned once per occurrence, not deduplicated.
+        let duplicated = op.split_out_groups(Some(&[0, 0]));
+        assert_eq!(
+            duplicated,
+            Some(vec![expected[0].clone(), expected[0].clone()])
+        );
+
+        // an empty request returns an empty (not `None`) result, since `groups` is present.
+        let empty = op.split_out_groups(Some(&[]));
+        assert_eq!(empty, Some(vec![]));
     }
 
     #[test]
@@ -1404,8 +1460,8 @@ mod tests {
             groups: None,
         };
 
-        let groups = op.split_out_groups();
-        assert!(groups.is_none());
+        assert!(op.split_out_groups(None).is_none());
+        assert!(op.split_out_groups(Some(&[0])).is_none());
     }
 
     #[test]

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -126,12 +126,50 @@ impl MajoranaOperator {
         }
     }
 
-    pub fn split_out_groups(&self) -> Option<Vec<Self>> {
-        let mut groups = vec![Self::zero(); self.num_groups()? as usize];
-        for term in self.iter_with_groups() {
-            groups[term.group as usize]._append_term(term.coeff, term.modes);
+    /// Splits this operator into new operators based on its [`groups`](Self::groups).
+    ///
+    /// If `group_indices` is `None`, every group is materialized once, in index order (`0` to
+    /// [`num_groups`](Self::num_groups) `- 1`). If `group_indices` is `Some`, only the requested
+    /// indices are materialized, in the given order; a duplicate index is materialized once
+    /// internally and cloned once per occurrence in the output. This is significantly cheaper than
+    /// requesting all indices when only a small number of groups out of a much larger total are
+    /// needed, e.g. when subsampling groups for a randomized product formula, since terms
+    /// belonging to a group that is not requested are skipped rather than appended anywhere.
+    ///
+    /// Returns `None` if `self.groups` is `None`, regardless of `group_indices`.
+    pub fn split_out_groups(&self, group_indices: Option<&[u32]>) -> Option<Vec<Self>> {
+        match group_indices {
+            None => {
+                let mut groups = vec![Self::zero(); self.num_groups()? as usize];
+                for term in self.iter_with_groups() {
+                    groups[term.group as usize]._append_term(term.coeff, term.modes);
+                }
+                Some(groups)
+            }
+            Some(group_indices) => {
+                self.groups.as_ref()?;
+                let mut wanted: HashMap<u32, Self> = group_indices
+                    .iter()
+                    .map(|&idx| (idx, Self::zero()))
+                    .collect();
+                for term in self.iter_with_groups() {
+                    if let Some(acc) = wanted.get_mut(&term.group) {
+                        acc._append_term(term.coeff, term.modes);
+                    }
+                }
+                Some(
+                    group_indices
+                        .iter()
+                        .map(|idx| {
+                            wanted
+                                .get(idx)
+                                .expect("every requested index was inserted above")
+                                .clone()
+                        })
+                        .collect(),
+                )
+            }
         }
-        Some(groups)
     }
 
     pub fn normal_ordered(&self, ascending: bool, reduce: bool) -> Self {
@@ -1149,8 +1187,26 @@ mod tests {
             },
         ];
 
-        let groups = op.split_out_groups();
-        assert_eq!(groups, Some(expected));
+        let groups = op.split_out_groups(None);
+        assert_eq!(groups, Some(expected.clone()));
+
+        // reversed and non-exhaustive: asserts order-preservation and partial selection.
+        let selected = op.split_out_groups(Some(&[1, 0]));
+        assert_eq!(
+            selected,
+            Some(vec![expected[1].clone(), expected[0].clone()])
+        );
+
+        // a duplicate index must be returned once per occurrence, not deduplicated.
+        let duplicated = op.split_out_groups(Some(&[0, 0]));
+        assert_eq!(
+            duplicated,
+            Some(vec![expected[0].clone(), expected[0].clone()])
+        );
+
+        // an empty request returns an empty (not `None`) result, since `groups` is present.
+        let empty = op.split_out_groups(Some(&[]));
+        assert_eq!(empty, Some(vec![]));
     }
 
     #[test]
@@ -1166,8 +1222,8 @@ mod tests {
             groups: None,
         };
 
-        let groups = op.split_out_groups();
-        assert!(groups.is_none());
+        assert!(op.split_out_groups(None).is_none());
+        assert!(op.split_out_groups(Some(&[0])).is_none());
     }
 
     #[test]

--- a/crates/core/src/operators/terms/grouping/electronic_structure.rs
+++ b/crates/core/src/operators/terms/grouping/electronic_structure.rs
@@ -246,7 +246,7 @@ mod tests {
             "The number of groups we expect is 14, meaning the highest group index should be 13!",
         );
 
-        let groups = normal.split_out_groups().unwrap();
+        let groups = normal.split_out_groups(None).unwrap();
         assert!(
             groups.len() == 14,
             "Expected 14 individual operators, one for each group."
@@ -301,7 +301,7 @@ mod tests {
             "The number of groups we expect is 14, meaning the highest group index should be 13!",
         );
 
-        let groups = normal.split_out_groups().unwrap();
+        let groups = normal.split_out_groups(None).unwrap();
         assert!(
             groups.len() == 14,
             "Expected 14 individual operators, one for each group."

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -136,16 +136,54 @@ impl TransferVertexOperator {
         }
     }
 
-    pub fn split_out_groups(&self) -> Option<Vec<Self>> {
-        let mut groups = vec![Self::zero(); self.num_groups()? as usize];
-        for term in self.iter_with_groups() {
-            groups[term.group as usize]._append_term(
-                term.coeff,
-                term.left_indices,
-                term.right_indices,
-            );
+    /// Splits this operator into new operators based on its [`groups`](Self::groups).
+    ///
+    /// If `group_indices` is `None`, every group is materialized once, in index order (`0` to
+    /// [`num_groups`](Self::num_groups) `- 1`). If `group_indices` is `Some`, only the requested
+    /// indices are materialized, in the given order; a duplicate index is materialized once
+    /// internally and cloned once per occurrence in the output. This is significantly cheaper than
+    /// requesting all indices when only a small number of groups out of a much larger total are
+    /// needed, e.g. when subsampling groups for a randomized product formula, since terms
+    /// belonging to a group that is not requested are skipped rather than appended anywhere.
+    ///
+    /// Returns `None` if `self.groups` is `None`, regardless of `group_indices`.
+    pub fn split_out_groups(&self, group_indices: Option<&[u32]>) -> Option<Vec<Self>> {
+        match group_indices {
+            None => {
+                let mut groups = vec![Self::zero(); self.num_groups()? as usize];
+                for term in self.iter_with_groups() {
+                    groups[term.group as usize]._append_term(
+                        term.coeff,
+                        term.left_indices,
+                        term.right_indices,
+                    );
+                }
+                Some(groups)
+            }
+            Some(group_indices) => {
+                self.groups.as_ref()?;
+                let mut wanted: HashMap<u32, Self> = group_indices
+                    .iter()
+                    .map(|&idx| (idx, Self::zero()))
+                    .collect();
+                for term in self.iter_with_groups() {
+                    if let Some(acc) = wanted.get_mut(&term.group) {
+                        acc._append_term(term.coeff, term.left_indices, term.right_indices);
+                    }
+                }
+                Some(
+                    group_indices
+                        .iter()
+                        .map(|idx| {
+                            wanted
+                                .get(idx)
+                                .expect("every requested index was inserted above")
+                                .clone()
+                        })
+                        .collect(),
+                )
+            }
         }
-        Some(groups)
     }
 
     pub fn normal_ordered(&self) -> Self {
@@ -1238,8 +1276,26 @@ mod tests {
             },
         ];
 
-        let groups = op.split_out_groups();
-        assert_eq!(groups, Some(expected));
+        let groups = op.split_out_groups(None);
+        assert_eq!(groups, Some(expected.clone()));
+
+        // reversed and non-exhaustive: asserts order-preservation and partial selection.
+        let selected = op.split_out_groups(Some(&[1, 0]));
+        assert_eq!(
+            selected,
+            Some(vec![expected[1].clone(), expected[0].clone()])
+        );
+
+        // a duplicate index must be returned once per occurrence, not deduplicated.
+        let duplicated = op.split_out_groups(Some(&[0, 0]));
+        assert_eq!(
+            duplicated,
+            Some(vec![expected[0].clone(), expected[0].clone()])
+        );
+
+        // an empty request returns an empty (not `None`) result, since `groups` is present.
+        let empty = op.split_out_groups(Some(&[]));
+        assert_eq!(empty, Some(vec![]));
     }
 
     #[test]
@@ -1256,8 +1312,8 @@ mod tests {
             groups: None,
         };
 
-        let groups = op.split_out_groups();
-        assert!(groups.is_none());
+        assert!(op.split_out_groups(None).is_none());
+        assert!(op.split_out_groups(Some(&[0])).is_none());
     }
 
     #[test]

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -874,9 +874,14 @@ impl PyEdgeVertexOperator {
 
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
-    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
-    /// return a list of new operators that contain those terms of this operator with the
-    /// corresponding `group` index.
+    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if
+    /// ``group_indices`` is ``None`` (the default), it returns a list of one new operator for
+    /// every group index in :attr:`groups`, in index order. If ``group_indices`` is given, only
+    /// the requested indices are built, in the given order: this avoids the cost of constructing
+    /// operators for groups that are never used, which is especially beneficial when only a small
+    /// number of groups out of a much larger total are needed, e.g. when subsampling groups for a
+    /// randomized product formula. A duplicate index in ``group_indices`` is returned once per
+    /// occurrence.
     ///
     /// .. doctest::
     ///
@@ -895,11 +900,23 @@ impl PyEdgeVertexOperator {
     ///     ...     print(list(sorted(g.iter_terms())))
     ///     [([(0, 1)], (1+0j)), ([(3, 2)], (-1+0j))]
     ///     [([(1, 0), (2, 3)], (2+0j))]
+    ///     >>> groups = op.split_out_groups(group_indices=[1])
+    ///     >>> for g in groups:
+    ///     ...     print(list(sorted(g.iter_terms())))
+    ///     [([(1, 0), (2, 3)], (2+0j))]
+    ///
+    /// Args:
+    ///     group_indices: the group indices for which to build operators, in the desired output
+    ///         order. When omitted, every group is built, in index order.
     ///
     /// Returns:
-    ///     An optional vector of one new operator for each group index in :attr:`groups`.
-    fn split_out_groups(slf: PyRef<'_, Self>) -> Option<Vec<Self>> {
-        let groups = slf.inner.split_out_groups();
+    ///     An optional vector of one new operator for each requested group index.
+    #[pyo3(signature = (group_indices=None))]
+    fn split_out_groups(
+        slf: PyRef<'_, Self>,
+        group_indices: Option<Vec<u32>>,
+    ) -> Option<Vec<Self>> {
+        let groups = slf.inner.split_out_groups(group_indices.as_deref());
         match groups {
             None => None,
             Some(g) => {

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -841,9 +841,14 @@ impl PyFermionOperator {
 
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
-    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
-    /// return a list of new operators that contain those terms of this operator with the
-    /// corresponding `group` index.
+    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if
+    /// ``group_indices`` is ``None`` (the default), it returns a list of one new operator for
+    /// every group index in :attr:`groups`, in index order. If ``group_indices`` is given, only
+    /// the requested indices are built, in the given order: this avoids the cost of constructing
+    /// operators for groups that are never used, which is especially beneficial when only a small
+    /// number of groups out of a much larger total are needed, e.g. when subsampling groups for a
+    /// randomized product formula. A duplicate index in ``group_indices`` is returned once per
+    /// occurrence.
     ///
     /// .. doctest::
     ///
@@ -862,11 +867,23 @@ impl PyFermionOperator {
     ///     ...     print(list(sorted(g.iter_terms())))
     ///     [([(True, 0), (False, 1)], (1+0j)), ([(True, 1), (False, 0)], (-1+0j))]
     ///     [([(True, 2), (False, 3)], (2+0j)), ([(True, 3), (False, 2)], (-2+0j))]
+    ///     >>> groups = op.split_out_groups(group_indices=[1])
+    ///     >>> for g in groups:
+    ///     ...     print(list(sorted(g.iter_terms())))
+    ///     [([(True, 2), (False, 3)], (2+0j)), ([(True, 3), (False, 2)], (-2+0j))]
+    ///
+    /// Args:
+    ///     group_indices: the group indices for which to build operators, in the desired output
+    ///         order. When omitted, every group is built, in index order.
     ///
     /// Returns:
-    ///     An optional vector of one new operator for each group index in :attr:`groups`.
-    fn split_out_groups(slf: PyRef<'_, Self>) -> Option<Vec<Self>> {
-        let groups = slf.inner.split_out_groups();
+    ///     An optional vector of one new operator for each requested group index.
+    #[pyo3(signature = (group_indices=None))]
+    fn split_out_groups(
+        slf: PyRef<'_, Self>,
+        group_indices: Option<Vec<u32>>,
+    ) -> Option<Vec<Self>> {
+        let groups = slf.inner.split_out_groups(group_indices.as_deref());
         match groups {
             None => None,
             Some(g) => {

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -787,9 +787,14 @@ impl PyMajoranaOperator {
 
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
-    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
-    /// return a list of new operators that contain those terms of this operator with the
-    /// corresponding `group` index.
+    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if
+    /// ``group_indices`` is ``None`` (the default), it returns a list of one new operator for
+    /// every group index in :attr:`groups`, in index order. If ``group_indices`` is given, only
+    /// the requested indices are built, in the given order: this avoids the cost of constructing
+    /// operators for groups that are never used, which is especially beneficial when only a small
+    /// number of groups out of a much larger total are needed, e.g. when subsampling groups for a
+    /// randomized product formula. A duplicate index in ``group_indices`` is returned once per
+    /// occurrence.
     ///
     /// .. doctest::
     ///
@@ -807,11 +812,23 @@ impl PyMajoranaOperator {
     ///     ...     print(list(sorted(g.iter_terms())))
     ///     [([0, 1], (1+0j)), ([1, 0], (-1+0j))]
     ///     [([2, 3], (2+0j)), ([3, 2], (-2+0j))]
+    ///     >>> groups = op.split_out_groups(group_indices=[1])
+    ///     >>> for g in groups:
+    ///     ...     print(list(sorted(g.iter_terms())))
+    ///     [([2, 3], (2+0j)), ([3, 2], (-2+0j))]
+    ///
+    /// Args:
+    ///     group_indices: the group indices for which to build operators, in the desired output
+    ///         order. When omitted, every group is built, in index order.
     ///
     /// Returns:
-    ///     An optional vector of one new operator for each group index in :attr:`groups`.
-    fn split_out_groups(slf: PyRef<'_, Self>) -> Option<Vec<Self>> {
-        let groups = slf.inner.split_out_groups();
+    ///     An optional vector of one new operator for each requested group index.
+    #[pyo3(signature = (group_indices=None))]
+    fn split_out_groups(
+        slf: PyRef<'_, Self>,
+        group_indices: Option<Vec<u32>>,
+    ) -> Option<Vec<Self>> {
+        let groups = slf.inner.split_out_groups(group_indices.as_deref());
         match groups {
             None => None,
             Some(g) => {

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -880,9 +880,14 @@ impl PyTransferVertexOperator {
 
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
-    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
-    /// return a list of new operators that contain those terms of this operator with the
-    /// corresponding `group` index.
+    /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if
+    /// ``group_indices`` is ``None`` (the default), it returns a list of one new operator for
+    /// every group index in :attr:`groups`, in index order. If ``group_indices`` is given, only
+    /// the requested indices are built, in the given order: this avoids the cost of constructing
+    /// operators for groups that are never used, which is especially beneficial when only a small
+    /// number of groups out of a much larger total are needed, e.g. when subsampling groups for a
+    /// randomized product formula. A duplicate index in ``group_indices`` is returned once per
+    /// occurrence.
     ///
     /// .. doctest::
     ///
@@ -901,11 +906,23 @@ impl PyTransferVertexOperator {
     ///     ...     print(list(sorted(g.iter_terms())))
     ///     [([(0, 1)], (1+0j)), ([(3, 2)], (-1+0j))]
     ///     [([(1, 0), (2, 3)], (2+0j))]
+    ///     >>> groups = op.split_out_groups(group_indices=[1])
+    ///     >>> for g in groups:
+    ///     ...     print(list(sorted(g.iter_terms())))
+    ///     [([(1, 0), (2, 3)], (2+0j))]
+    ///
+    /// Args:
+    ///     group_indices: the group indices for which to build operators, in the desired output
+    ///         order. When omitted, every group is built, in index order.
     ///
     /// Returns:
-    ///     An optional vector of one new operator for each group index in :attr:`groups`.
-    fn split_out_groups(slf: PyRef<'_, Self>) -> Option<Vec<Self>> {
-        let groups = slf.inner.split_out_groups();
+    ///     An optional vector of one new operator for each requested group index.
+    #[pyo3(signature = (group_indices=None))]
+    fn split_out_groups(
+        slf: PyRef<'_, Self>,
+        group_indices: Option<Vec<u32>>,
+    ) -> Option<Vec<Self>> {
+        let groups = slf.inner.split_out_groups(group_indices.as_deref());
         match groups {
             None => None,
             Some(g) => {

--- a/docs/guides/grouping.rst
+++ b/docs/guides/grouping.rst
@@ -114,7 +114,7 @@ the same group. The following code shows how that can be done:
        qf_maj_op_set_groups(op, groups, num_terms);
 
        QfMajoranaOperator *group_ops[4];
-       qf_maj_op_split_out_groups(op, group_ops);
+       qf_maj_op_split_out_groups(op, NULL, 0, group_ops);
 
 
 .. [1] A. Gandon et al., Stabilizer-based quantum simulation of fermion dynamics

--- a/docs/guides/operators.rst
+++ b/docs/guides/operators.rst
@@ -306,7 +306,8 @@ the :ref:`grouping <grouping_explanation>` guide.
        qf_maj_op_set_groups(op, groups, 3);
 
        // Partition operator by groups
-       QfMajoranaOperator **grouped_ops = qf_maj_op_split_out_groups(op, &num_groups);
+       QfMajoranaOperator *grouped_ops[2];
+       qf_maj_op_split_out_groups(op, NULL, 0, grouped_ops);
 
 
 .. |arithmetic_and_mathematical_operations| replace:: **Arithmetic and mathematical operations**

--- a/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
@@ -707,13 +707,18 @@ class EdgeVertexOperator:
         Returns:
             The largest group index in :attr:`groups` plus 1.
         """
-    def split_out_groups(self) -> typing.Optional[builtins.list[EdgeVertexOperator]]:
+    def split_out_groups(self, group_indices: typing.Optional[typing.Sequence[builtins.int]] = None) -> typing.Optional[builtins.list[EdgeVertexOperator]]:
         r"""
         Splits this operator into an optional list of new operators based on :attr:`groups`.
         
-        If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
-        return a list of new operators that contain those terms of this operator with the
-        corresponding `group` index.
+        If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if
+        ``group_indices`` is ``None`` (the default), it returns a list of one new operator for
+        every group index in :attr:`groups`, in index order. If ``group_indices`` is given, only
+        the requested indices are built, in the given order: this avoids the cost of constructing
+        operators for groups that are never used, which is especially beneficial when only a small
+        number of groups out of a much larger total are needed, e.g. when subsampling groups for a
+        randomized product formula. A duplicate index in ``group_indices`` is returned once per
+        occurrence.
         
         .. doctest::
         
@@ -732,9 +737,17 @@ class EdgeVertexOperator:
             ...     print(list(sorted(g.iter_terms())))
             [([(0, 1)], (1+0j)), ([(3, 2)], (-1+0j))]
             [([(1, 0), (2, 3)], (2+0j))]
+            >>> groups = op.split_out_groups(group_indices=[1])
+            >>> for g in groups:
+            ...     print(list(sorted(g.iter_terms())))
+            [([(1, 0), (2, 3)], (2+0j))]
+        
+        Args:
+            group_indices: the group indices for which to build operators, in the desired output
+                order. When omitted, every group is built, in index order.
         
         Returns:
-            An optional vector of one new operator for each group index in :attr:`groups`.
+            An optional vector of one new operator for each requested group index.
         """
     def adjoint(self) -> EdgeVertexOperator:
         r"""

--- a/python/qiskit_fermions/_lib/operators/fermion_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/fermion_operator/__init__.pyi
@@ -673,13 +673,18 @@ class FermionOperator:
         Returns:
             The largest group index in :attr:`groups` plus 1.
         """
-    def split_out_groups(self) -> typing.Optional[builtins.list[FermionOperator]]:
+    def split_out_groups(self, group_indices: typing.Optional[typing.Sequence[builtins.int]] = None) -> typing.Optional[builtins.list[FermionOperator]]:
         r"""
         Splits this operator into an optional list of new operators based on :attr:`groups`.
         
-        If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
-        return a list of new operators that contain those terms of this operator with the
-        corresponding `group` index.
+        If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if
+        ``group_indices`` is ``None`` (the default), it returns a list of one new operator for
+        every group index in :attr:`groups`, in index order. If ``group_indices`` is given, only
+        the requested indices are built, in the given order: this avoids the cost of constructing
+        operators for groups that are never used, which is especially beneficial when only a small
+        number of groups out of a much larger total are needed, e.g. when subsampling groups for a
+        randomized product formula. A duplicate index in ``group_indices`` is returned once per
+        occurrence.
         
         .. doctest::
         
@@ -698,9 +703,17 @@ class FermionOperator:
             ...     print(list(sorted(g.iter_terms())))
             [([(True, 0), (False, 1)], (1+0j)), ([(True, 1), (False, 0)], (-1+0j))]
             [([(True, 2), (False, 3)], (2+0j)), ([(True, 3), (False, 2)], (-2+0j))]
+            >>> groups = op.split_out_groups(group_indices=[1])
+            >>> for g in groups:
+            ...     print(list(sorted(g.iter_terms())))
+            [([(True, 2), (False, 3)], (2+0j)), ([(True, 3), (False, 2)], (-2+0j))]
+        
+        Args:
+            group_indices: the group indices for which to build operators, in the desired output
+                order. When omitted, every group is built, in index order.
         
         Returns:
-            An optional vector of one new operator for each group index in :attr:`groups`.
+            An optional vector of one new operator for each requested group index.
         """
     def adjoint(self) -> FermionOperator:
         r"""

--- a/python/qiskit_fermions/_lib/operators/majorana_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/majorana_operator/__init__.pyi
@@ -642,13 +642,18 @@ class MajoranaOperator:
         Returns:
             The largest group index in :attr:`groups` plus 1.
         """
-    def split_out_groups(self) -> typing.Optional[builtins.list[MajoranaOperator]]:
+    def split_out_groups(self, group_indices: typing.Optional[typing.Sequence[builtins.int]] = None) -> typing.Optional[builtins.list[MajoranaOperator]]:
         r"""
         Splits this operator into an optional list of new operators based on :attr:`groups`.
         
-        If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
-        return a list of new operators that contain those terms of this operator with the
-        corresponding `group` index.
+        If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if
+        ``group_indices`` is ``None`` (the default), it returns a list of one new operator for
+        every group index in :attr:`groups`, in index order. If ``group_indices`` is given, only
+        the requested indices are built, in the given order: this avoids the cost of constructing
+        operators for groups that are never used, which is especially beneficial when only a small
+        number of groups out of a much larger total are needed, e.g. when subsampling groups for a
+        randomized product formula. A duplicate index in ``group_indices`` is returned once per
+        occurrence.
         
         .. doctest::
         
@@ -666,9 +671,17 @@ class MajoranaOperator:
             ...     print(list(sorted(g.iter_terms())))
             [([0, 1], (1+0j)), ([1, 0], (-1+0j))]
             [([2, 3], (2+0j)), ([3, 2], (-2+0j))]
+            >>> groups = op.split_out_groups(group_indices=[1])
+            >>> for g in groups:
+            ...     print(list(sorted(g.iter_terms())))
+            [([2, 3], (2+0j)), ([3, 2], (-2+0j))]
+        
+        Args:
+            group_indices: the group indices for which to build operators, in the desired output
+                order. When omitted, every group is built, in index order.
         
         Returns:
-            An optional vector of one new operator for each group index in :attr:`groups`.
+            An optional vector of one new operator for each requested group index.
         """
     def adjoint(self) -> MajoranaOperator:
         r"""

--- a/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
@@ -718,13 +718,18 @@ class TransferVertexOperator:
         Returns:
             The largest group index in :attr:`groups` plus 1.
         """
-    def split_out_groups(self) -> typing.Optional[builtins.list[TransferVertexOperator]]:
+    def split_out_groups(self, group_indices: typing.Optional[typing.Sequence[builtins.int]] = None) -> typing.Optional[builtins.list[TransferVertexOperator]]:
         r"""
         Splits this operator into an optional list of new operators based on :attr:`groups`.
         
-        If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will
-        return a list of new operators that contain those terms of this operator with the
-        corresponding `group` index.
+        If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if
+        ``group_indices`` is ``None`` (the default), it returns a list of one new operator for
+        every group index in :attr:`groups`, in index order. If ``group_indices`` is given, only
+        the requested indices are built, in the given order: this avoids the cost of constructing
+        operators for groups that are never used, which is especially beneficial when only a small
+        number of groups out of a much larger total are needed, e.g. when subsampling groups for a
+        randomized product formula. A duplicate index in ``group_indices`` is returned once per
+        occurrence.
         
         .. doctest::
         
@@ -743,9 +748,17 @@ class TransferVertexOperator:
             ...     print(list(sorted(g.iter_terms())))
             [([(0, 1)], (1+0j)), ([(3, 2)], (-1+0j))]
             [([(1, 0), (2, 3)], (2+0j))]
+            >>> groups = op.split_out_groups(group_indices=[1])
+            >>> for g in groups:
+            ...     print(list(sorted(g.iter_terms())))
+            [([(1, 0), (2, 3)], (2+0j))]
+        
+        Args:
+            group_indices: the group indices for which to build operators, in the desired output
+                order. When omitted, every group is built, in index order.
         
         Returns:
-            An optional vector of one new operator for each group index in :attr:`groups`.
+            An optional vector of one new operator for each requested group index.
         """
     def adjoint(self) -> TransferVertexOperator:
         r"""

--- a/python/qiskit_fermions/operators/operator_trait.py
+++ b/python/qiskit_fermions/operators/operator_trait.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from typing import Protocol
 
 if sys.version_info >= (3, 11):
@@ -133,5 +133,10 @@ class OperatorTrait(Protocol):
     def num_groups(self) -> int | None:
         """Returns the number of groups."""
 
-    def split_out_groups(self) -> list[Self]:
-        """Splits this operator into an optional list of new operators based on its :attr:`.groups`."""
+    def split_out_groups(self, group_indices: Sequence[int] | None = None) -> list[Self]:
+        """Splits this operator into an optional list of new operators based on its :attr:`.groups`.
+
+        .. note::
+           If ``group_indices`` is omitted, every group is built, in index order. Otherwise, only
+           the requested indices are built, in the given order.
+        """

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -209,7 +209,7 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
             time = node.op.params[0]
             num_modes = len(node.qargs)
 
-            terms: list[Any]  # can be either a list of operator terms or operator instances
+            terms: list[Any] | None  # a list of operator terms, or None when `hamil.groups` is set
             if hamil.groups is None:
                 # NOTE: the qDRIFT protocol normalizes each term to unit magnitude because the
                 # evolution time is entirely dictated by `delta` (computed below). Only the
@@ -224,11 +224,11 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
                 weights = np.zeros((hamil.num_groups(),))
                 np.add.at(weights, groups, np.abs(all_coeffs))
                 weights /= np.unique(groups, return_counts=True)[1]
-                # NOTE: we do not pre-process the coefficients of these different group terms here,
-                # because we would unnecessarily need to loop over all terms in all groups. Instead,
-                # we replace the coefficients by identity values only once that particular group
-                # term actually gets sampled.
-                terms = hamil.split_out_groups()
+                # NOTE: we do not materialize the group operators here. Since only a small
+                # fraction of the (potentially much larger) set of groups ends up being sampled,
+                # we look up each sampled group's operator lazily via `split_out_groups`, once we
+                # know which indices were actually drawn.
+                terms = None
 
             def _unit_terms(term):
                 if isinstance(term, tuple):
@@ -276,8 +276,17 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
                 sampled_indices = self._rng.choice(
                     np.arange(len(weights)), size=self.num_terms, p=probabilities
                 )
-                for sampled_idx in sampled_indices:
-                    unit_terms = _unit_terms(terms[sampled_idx])
+                if terms is None:
+                    # Only look up the (typically much smaller) set of distinct sampled groups,
+                    # rather than materializing every group in the Hamiltonian, then map each
+                    # draw back to its (possibly repeated) fetched operator.
+                    unique_indices, inverse = np.unique(sampled_indices, return_inverse=True)
+                    sampled_terms = hamil.split_out_groups(group_indices=unique_indices.tolist())
+                    draws = [sampled_terms[i] for i in inverse]
+                else:
+                    draws = [terms[sampled_idx] for sampled_idx in sampled_indices]
+                for term in draws:
+                    unit_terms = _unit_terms(term)
                     op = hamil.__class__.from_terms(unit_terms)
                     evo = Evolution(num_modes, op, time=delta)
                     out_dag.apply_operation_back(evo, qargs=out_dag.qubits)
@@ -297,7 +306,11 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
                 # this is numpy's own implementation of weighted sampling (see `Generator.choice`),
                 # just reusing the `cdf` precomputed above instead of rebuilding it on every draw.
                 sampled_idx = cdf.searchsorted(self._rng.random(), side="right")
-                unit_terms = _unit_terms(terms[sampled_idx])
+                if terms is None:
+                    term = hamil.split_out_groups(group_indices=[int(sampled_idx)])[0]
+                else:
+                    term = terms[sampled_idx]
+                unit_terms = _unit_terms(term)
                 op = hamil.__class__.from_terms(unit_terms)
 
                 term_support = op.get_support()

--- a/tests/c/test_fermion_operator.c
+++ b/tests/c/test_fermion_operator.c
@@ -621,7 +621,7 @@ static int test_groups(void) {
 
     QfFermionOperator *group_ops[2];
 
-    qf_ferm_op_split_out_groups(op, group_ops);
+    qf_ferm_op_split_out_groups(op, NULL, 0, group_ops);
 
     uint32_t boundaries_group[3] = {0, 2, 4};
     QkComplex64 coeffs_group[2] = {{1.0, 0.0}, {1.0, 0.0}};
@@ -635,6 +635,16 @@ static int test_groups(void) {
 
     bool correct_group0 = qf_ferm_op_equiv(group_ops[0], group0, 1e-10);
     bool correct_group1 = qf_ferm_op_equiv(group_ops[1], group1, 1e-10);
+
+    uint32_t group_indices[2] = {1, 1};
+    QfFermionOperator *group_ops_indexed[2];
+    qf_ferm_op_split_out_groups(op, group_indices, 2, group_ops_indexed);
+
+    bool correct_indexed0 = qf_ferm_op_equiv(group_ops_indexed[0], group1, 1e-10);
+    bool correct_indexed1 = qf_ferm_op_equiv(group_ops_indexed[1], group1, 1e-10);
+
+    qf_ferm_op_free(group_ops_indexed[0]);
+    qf_ferm_op_free(group_ops_indexed[1]);
 
     uint32_t *groups_out;
     uint64_t groups_len;
@@ -652,9 +662,9 @@ static int test_groups(void) {
     bool deleted_groups = !qf_ferm_op_has_groups(op);
 
     bool passed_all = has_no_groups && has_some_groups && correct_num_groups && correct_group0 &&
-                      correct_group1 && correct_groups_len && correct_groups_out0 &&
-                      correct_groups_out1 && correct_groups_out2 && correct_groups_out3 &&
-                      deleted_groups;
+                      correct_group1 && correct_indexed0 && correct_indexed1 &&
+                      correct_groups_len && correct_groups_out0 && correct_groups_out1 &&
+                      correct_groups_out2 && correct_groups_out3 && deleted_groups;
 
     qf_ferm_op_free(op);
     qf_ferm_op_free(group0);

--- a/tests/c/test_majorana_operator.c
+++ b/tests/c/test_majorana_operator.c
@@ -528,7 +528,7 @@ static int test_groups(void) {
 
     QfMajoranaOperator *group_ops[2];
 
-    qf_maj_op_split_out_groups(op, group_ops);
+    qf_maj_op_split_out_groups(op, NULL, 0, group_ops);
 
     uint32_t boundaries_group[3] = {0, 2, 4};
     QkComplex64 coeffs_group[2] = {{1.0, 0.0}, {1.0, 0.0}};
@@ -539,6 +539,16 @@ static int test_groups(void) {
 
     bool correct_group0 = qf_maj_op_equiv(group_ops[0], group0, 1e-10);
     bool correct_group1 = qf_maj_op_equiv(group_ops[1], group1, 1e-10);
+
+    uint32_t group_indices[2] = {1, 1};
+    QfMajoranaOperator *group_ops_indexed[2];
+    qf_maj_op_split_out_groups(op, group_indices, 2, group_ops_indexed);
+
+    bool correct_indexed0 = qf_maj_op_equiv(group_ops_indexed[0], group1, 1e-10);
+    bool correct_indexed1 = qf_maj_op_equiv(group_ops_indexed[1], group1, 1e-10);
+
+    qf_maj_op_free(group_ops_indexed[0]);
+    qf_maj_op_free(group_ops_indexed[1]);
 
     uint32_t *groups_out;
     uint64_t groups_len;
@@ -556,9 +566,9 @@ static int test_groups(void) {
     bool deleted_groups = !qf_maj_op_has_groups(op);
 
     bool passed_all = has_no_groups && has_some_groups && correct_num_groups && correct_group0 &&
-                      correct_group1 && correct_groups_len && correct_groups_out0 &&
-                      correct_groups_out1 && correct_groups_out2 && correct_groups_out3 &&
-                      deleted_groups;
+                      correct_group1 && correct_indexed0 && correct_indexed1 &&
+                      correct_groups_len && correct_groups_out0 && correct_groups_out1 &&
+                      correct_groups_out2 && correct_groups_out3 && deleted_groups;
 
     qf_maj_op_free(op);
     qf_maj_op_free(group0);

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -434,8 +434,25 @@ class TestEdgeVertexOperator:
         with subtests.test("split groups"):
             assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
 
+        with subtests.test("split groups reversed"):
+            reversed_groups = op.split_out_groups(group_indices=[1, 0])
+            assert all(
+                a.equiv(b) for a, b in zip(reversed_groups, list(reversed(expected)), strict=True)
+            )
+
+        with subtests.test("split groups duplicate"):
+            duplicate_groups = op.split_out_groups(group_indices=[0, 0])
+            assert all(
+                a.equiv(b)
+                for a, b in zip(duplicate_groups, [expected[0], expected[0]], strict=True)
+            )
+
+        with subtests.test("split groups empty"):
+            assert op.split_out_groups(group_indices=[]) == []
+
     def test_split_out_groups_err(self):
         cls = self.get_class()
 
         op = cls.from_dict({((0, 1),): 1, ((2, 3),): 1, ((1, 0), (2, 3)): 2})
         assert op.split_out_groups() is None
+        assert op.split_out_groups(group_indices=[0]) is None

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -529,6 +529,22 @@ class TestFermionOperator:
         with subtests.test("split groups"):
             assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
 
+        with subtests.test("split groups reversed"):
+            reversed_groups = op.split_out_groups(group_indices=[1, 0])
+            assert all(
+                a.equiv(b) for a, b in zip(reversed_groups, list(reversed(expected)), strict=True)
+            )
+
+        with subtests.test("split groups duplicate"):
+            duplicate_groups = op.split_out_groups(group_indices=[0, 0])
+            assert all(
+                a.equiv(b)
+                for a, b in zip(duplicate_groups, [expected[0], expected[0]], strict=True)
+            )
+
+        with subtests.test("split groups empty"):
+            assert op.split_out_groups(group_indices=[]) == []
+
     def test_split_out_groups_err(self):
         cls = self.get_class()
 
@@ -536,3 +552,4 @@ class TestFermionOperator:
             {(cre(0), ann(1)): 1, (cre(1), ann(0)): 1, (cre(0), cre(0), ann(1), ann(1)): 2}
         )
         assert op.split_out_groups() is None
+        assert op.split_out_groups(group_indices=[0]) is None

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -473,8 +473,25 @@ class TestMajoranaOperator:
         with subtests.test("split groups"):
             assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
 
+        with subtests.test("split groups reversed"):
+            reversed_groups = op.split_out_groups(group_indices=[1, 0])
+            assert all(
+                a.equiv(b) for a, b in zip(reversed_groups, list(reversed(expected)), strict=True)
+            )
+
+        with subtests.test("split groups duplicate"):
+            duplicate_groups = op.split_out_groups(group_indices=[0, 0])
+            assert all(
+                a.equiv(b)
+                for a, b in zip(duplicate_groups, [expected[0], expected[0]], strict=True)
+            )
+
+        with subtests.test("split groups empty"):
+            assert op.split_out_groups(group_indices=[]) == []
+
     def test_split_out_groups_err(self):
         cls = self.get_class()
 
         op = cls.from_dict({(0, 1): 1, (1, 0): 1, (0, 0, 1, 1): 2})
         assert op.split_out_groups() is None
+        assert op.split_out_groups(group_indices=[0]) is None

--- a/tests/python/operators/test_transfer_vertex_operator.py
+++ b/tests/python/operators/test_transfer_vertex_operator.py
@@ -450,8 +450,25 @@ class TestTransferVertexOperator:
         with subtests.test("split groups"):
             assert all([a.equiv(b) for a, b in zip(groups, expected, strict=True)])
 
+        with subtests.test("split groups reversed"):
+            reversed_groups = op.split_out_groups(group_indices=[1, 0])
+            assert all(
+                a.equiv(b) for a, b in zip(reversed_groups, list(reversed(expected)), strict=True)
+            )
+
+        with subtests.test("split groups duplicate"):
+            duplicate_groups = op.split_out_groups(group_indices=[0, 0])
+            assert all(
+                a.equiv(b)
+                for a, b in zip(duplicate_groups, [expected[0], expected[0]], strict=True)
+            )
+
+        with subtests.test("split groups empty"):
+            assert op.split_out_groups(group_indices=[]) == []
+
     def test_split_out_groups_err(self):
         cls = self.get_class()
 
         op = cls.from_dict({((0, 1),): 1, ((2, 3),): 1, ((1, 0), (2, 3)): 2})
         assert op.split_out_groups() is None
+        assert op.split_out_groups(group_indices=[0]) is None


### PR DESCRIPTION
Implements follow-up number 1 from #229.

This reduces the average runtime of the `QDriftTrotterization` pass on a simple benchmark by ~50% (from `58-70 ms` to `~32 ms` per circuit on this particular test).

:warning: the `split_out_groups` methods now take an optional (in Python) but *REQUIRED* (in C) argument to indicate the `group_indices` to be returned!