### PR TITLE
feat(operators): add `has_groups()` to the Python API

### DIFF
--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -369,11 +369,11 @@ pub unsafe extern "C" fn qf_ferm_op_one() -> *mut FermionOperator {
 
 /// @ingroup qf_ferm_op
 ///
-/// @brief Checks whether this operator has a ``groups`` attribute that is not empty.
+/// @brief Checks whether this operator tracks group indices.
 ///
 /// @param op A pointer to the fermionic operator to be checked.
 ///
-/// @return Whether the provided operator has a non-empty ``groups`` attribute.
+/// @return Whether the provided operator has a ``groups`` attribute.
 ///
 /// @rst
 ///
@@ -397,7 +397,7 @@ pub unsafe extern "C" fn qf_ferm_op_one() -> *mut FermionOperator {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qf_ferm_op_has_groups(op: *const FermionOperator) -> bool {
     let op = unsafe { const_ptr_as_ref(op) };
-    op.groups.is_some()
+    op.has_groups()
 }
 
 /// @ingroup qf_ferm_op

--- a/crates/cext/src/operators/majorana_operator.rs
+++ b/crates/cext/src/operators/majorana_operator.rs
@@ -312,11 +312,11 @@ pub unsafe extern "C" fn qf_maj_op_one() -> *mut MajoranaOperator {
 
 /// @ingroup qf_maj_op
 ///
-/// @brief Checks whether this operator has a ``groups`` attribute that is not empty.
+/// @brief Checks whether this operator tracks group indices.
 ///
 /// @param op A pointer to the majorana operator to be checked.
 ///
-/// @return Whether the provided operator has a non-empty ``groups`` attribute.
+/// @return Whether the provided operator has a ``groups`` attribute.
 ///
 /// @rst
 ///
@@ -337,7 +337,7 @@ pub unsafe extern "C" fn qf_maj_op_one() -> *mut MajoranaOperator {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qf_maj_op_has_groups(op: *const MajoranaOperator) -> bool {
     let op = unsafe { const_ptr_as_ref(op) };
-    op.groups.is_some()
+    op.has_groups()
 }
 
 /// @ingroup qf_maj_op

--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -423,8 +423,8 @@ impl OperatorTrait for EdgeVertexOperator {
         })
     }
 
-    fn has_groups(&self) -> bool {
-        self.groups.is_some()
+    fn groups(&self) -> Option<&[u32]> {
+        self.groups.as_deref()
     }
 
     fn iter_with_groups(&self) -> impl ExactSizeIterator<Item = Self::GroupTermView<'_>> {
@@ -1187,18 +1187,22 @@ mod tests {
     }
 
     #[test]
-    fn test_num_groups() {
+    fn test_has_and_num_groups() {
         let mut zero = EdgeVertexOperator::zero();
 
+        assert!(!zero.has_groups());
         assert!(zero.num_groups().is_none());
 
         zero.groups = Some(vec![]);
 
+        // an operator may track groups while holding no terms at all
+        assert!(zero.has_groups());
         assert_eq!(zero.num_groups(), Some(0));
 
         let mut one = EdgeVertexOperator::one();
         one.groups = Some(vec![0]);
 
+        assert!(one.has_groups());
         assert_eq!(one.num_groups(), Some(1));
     }
 

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -512,8 +512,8 @@ impl OperatorTrait for FermionOperator {
         })
     }
 
-    fn has_groups(&self) -> bool {
-        self.groups.is_some()
+    fn groups(&self) -> Option<&[u32]> {
+        self.groups.as_deref()
     }
 
     fn iter_with_groups(&self) -> impl ExactSizeIterator<Item = Self::GroupTermView<'_>> {
@@ -1378,18 +1378,22 @@ mod tests {
     }
 
     #[test]
-    fn test_num_groups() {
+    fn test_has_and_num_groups() {
         let mut zero = FermionOperator::zero();
 
+        assert!(!zero.has_groups());
         assert!(zero.num_groups().is_none());
 
         zero.groups = Some(vec![]);
 
+        // an operator may track groups while holding no terms at all
+        assert!(zero.has_groups());
         assert_eq!(zero.num_groups(), Some(0));
 
         let mut one = FermionOperator::one();
         one.groups = Some(vec![0]);
 
+        assert!(one.has_groups());
         assert_eq!(one.num_groups(), Some(1));
     }
 

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -439,8 +439,8 @@ impl OperatorTrait for MajoranaOperator {
         })
     }
 
-    fn has_groups(&self) -> bool {
-        self.groups.is_some()
+    fn groups(&self) -> Option<&[u32]> {
+        self.groups.as_deref()
     }
 
     fn iter_with_groups(&self) -> impl ExactSizeIterator<Item = Self::GroupTermView<'_>> {
@@ -1144,18 +1144,22 @@ mod tests {
     }
 
     #[test]
-    fn test_num_groups() {
+    fn test_has_and_num_groups() {
         let mut zero = MajoranaOperator::zero();
 
+        assert!(!zero.has_groups());
         assert!(zero.num_groups().is_none());
 
         zero.groups = Some(vec![]);
 
+        // an operator may track groups while holding no terms at all
+        assert!(zero.has_groups());
         assert_eq!(zero.num_groups(), Some(0));
 
         let mut one = MajoranaOperator::one();
         one.groups = Some(vec![0]);
 
+        assert!(one.has_groups());
         assert_eq!(one.num_groups(), Some(1));
     }
 

--- a/crates/core/src/operators/mod.rs
+++ b/crates/core/src/operators/mod.rs
@@ -76,10 +76,35 @@ pub trait OperatorTrait {
     /// impl signature more specific than this one and trip the `refining_impl_trait` lint.
     fn iter(&self) -> impl ExactSizeIterator<Item = Self::TermView<'_>>;
 
+    /// Returns the operator's group indices, one per term, or `None` if it tracks no groups.
+    ///
+    /// This is the single point of access through which the trait's group-related provided methods
+    /// ([`has_groups`](Self::has_groups), [`num_groups`](Self::num_groups)) reach the `groups` field,
+    /// so that they need not be reimplemented per operator type.
+    fn groups(&self) -> Option<&[u32]>;
+
     /// Returns whether the operator tracks group indices (i.e. `groups` is `Some`).
     ///
+    /// Note that this is `true` even for an operator whose group indices are an empty slice, which
+    /// is the state of a grouped operator with no terms (see [`num_groups`](Self::num_groups)).
+    ///
     /// [`iter_with_groups`](Self::iter_with_groups) may only be called when this is `true`.
-    fn has_groups(&self) -> bool;
+    fn has_groups(&self) -> bool {
+        self.groups().is_some()
+    }
+
+    /// Returns the number of groups tracked by the operator, or `None` if it tracks no groups.
+    ///
+    /// The number of groups is evaluated lazily as the largest occurring group index plus 1, so it
+    /// may be used as the index for the next group. An operator that tracks groups but holds no
+    /// terms reports `Some(0)`.
+    fn num_groups(&self) -> Option<u32> {
+        let groups = self.groups()?;
+        Some(match groups.iter().max() {
+            Some(max) => max + 1,
+            None => 0,
+        })
+    }
 
     /// Iterates over the terms of the operator together with their group index.
     ///

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -422,8 +422,8 @@ impl OperatorTrait for TransferVertexOperator {
         })
     }
 
-    fn has_groups(&self) -> bool {
-        self.groups.is_some()
+    fn groups(&self) -> Option<&[u32]> {
+        self.groups.as_deref()
     }
 
     fn iter_with_groups(&self) -> impl ExactSizeIterator<Item = Self::GroupTermView<'_>> {
@@ -1230,18 +1230,22 @@ mod tests {
     }
 
     #[test]
-    fn test_num_groups() {
+    fn test_has_and_num_groups() {
         let mut zero = TransferVertexOperator::zero();
 
+        assert!(!zero.has_groups());
         assert!(zero.num_groups().is_none());
 
         zero.groups = Some(vec![]);
 
+        // an operator may track groups while holding no terms at all
+        assert!(zero.has_groups());
         assert_eq!(zero.num_groups(), Some(0));
 
         let mut one = TransferVertexOperator::one();
         one.groups = Some(vec![0]);
 
+        assert!(one.has_groups());
         assert_eq!(one.num_groups(), Some(1));
     }
 

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -847,6 +847,36 @@ impl PyEdgeVertexOperator {
         self.inner.groups = groups;
     }
 
+    /// Returns whether this operator tracks group indices.
+    ///
+    /// This is equivalent to (but cheaper than) checking ``op.groups is not None``, because it does
+    /// not copy the group indices out of the operator in order to inspect them.
+    ///
+    /// .. note::
+    ///    This returns ``True`` even when :attr:`groups` is an empty list, which is the state of a
+    ///    grouped operator that holds no terms.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import EdgeVertexOperator
+    ///     >>> op = EdgeVertexOperator(
+    ///     ...     [1.0, 2.0, -1.0],
+    ///     ...     [0, 1, 2, 3],
+    ///     ...     [1, 0, 3, 2],
+    ///     ...     [0, 1, 3, 4],
+    ///     ... )
+    ///     >>> op.has_groups()
+    ///     False
+    ///     >>> op.groups = [0, 1, 0]
+    ///     >>> op.has_groups()
+    ///     True
+    ///
+    /// Returns:
+    ///     Whether :attr:`groups` is set on this operator.
+    pub fn has_groups(&self) -> bool {
+        self.inner.has_groups()
+    }
+
     /// Returns the number of groups.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -814,6 +814,36 @@ impl PyFermionOperator {
         self.inner.groups = groups;
     }
 
+    /// Returns whether this operator tracks group indices.
+    ///
+    /// This is equivalent to (but cheaper than) checking ``op.groups is not None``, because it does
+    /// not copy the group indices out of the operator in order to inspect them.
+    ///
+    /// .. note::
+    ///    This returns ``True`` even when :attr:`groups` is an empty list, which is the state of a
+    ///    grouped operator that holds no terms.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator(
+    ///     ...     [1.0, 2.0, -1.0, -2.0],
+    ///     ...     [True, False, True, False, True, False, True, False],
+    ///     ...     [0, 1, 2, 3, 1, 0, 3, 2],
+    ///     ...     [0, 2, 4, 6, 8],
+    ///     ... )
+    ///     >>> op.has_groups()
+    ///     False
+    ///     >>> op.groups = [0, 1, 0, 1]
+    ///     >>> op.has_groups()
+    ///     True
+    ///
+    /// Returns:
+    ///     Whether :attr:`groups` is set on this operator.
+    pub fn has_groups(&self) -> bool {
+        self.inner.has_groups()
+    }
+
     /// Returns the number of groups.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -761,6 +761,35 @@ impl PyMajoranaOperator {
         self.inner.groups = groups;
     }
 
+    /// Returns whether this operator tracks group indices.
+    ///
+    /// This is equivalent to (but cheaper than) checking ``op.groups is not None``, because it does
+    /// not copy the group indices out of the operator in order to inspect them.
+    ///
+    /// .. note::
+    ///    This returns ``True`` even when :attr:`groups` is an empty list, which is the state of a
+    ///    grouped operator that holds no terms.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import MajoranaOperator
+    ///     >>> op = MajoranaOperator(
+    ///     ...     [1.0, 2.0, -1.0, -2.0],
+    ///     ...     [0, 1, 2, 3, 1, 0, 3, 2],
+    ///     ...     [0, 2, 4, 6, 8],
+    ///     ... )
+    ///     >>> op.has_groups()
+    ///     False
+    ///     >>> op.groups = [0, 1, 0, 1]
+    ///     >>> op.has_groups()
+    ///     True
+    ///
+    /// Returns:
+    ///     Whether :attr:`groups` is set on this operator.
+    pub fn has_groups(&self) -> bool {
+        self.inner.has_groups()
+    }
+
     /// Returns the number of groups.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will

--- a/crates/pyext/src/operators/terms/grouping/electronic_structure.rs
+++ b/crates/pyext/src/operators/terms/grouping/electronic_structure.rs
@@ -55,7 +55,7 @@ use qiskit_fermions_core::operators::terms::grouping::electronic_structure::grou
 ///
 ///    group_terms_by_electronic_structure(normal, 2 * fcidump.norb, two_body_physicist_order=False)
 ///
-///    assert normal.groups is not None
+///    assert normal.has_groups()
 ///
 /// Args:
 ///     op: the normal-ordered operator whose terms to group.

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -853,6 +853,36 @@ impl PyTransferVertexOperator {
         self.inner.groups = groups;
     }
 
+    /// Returns whether this operator tracks group indices.
+    ///
+    /// This is equivalent to (but cheaper than) checking ``op.groups is not None``, because it does
+    /// not copy the group indices out of the operator in order to inspect them.
+    ///
+    /// .. note::
+    ///    This returns ``True`` even when :attr:`groups` is an empty list, which is the state of a
+    ///    grouped operator that holds no terms.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import TransferVertexOperator
+    ///     >>> op = TransferVertexOperator(
+    ///     ...     [1.0, 2.0, -1.0],
+    ///     ...     [0, 1, 2, 3],
+    ///     ...     [1, 0, 3, 2],
+    ///     ...     [0, 1, 3, 4],
+    ///     ... )
+    ///     >>> op.has_groups()
+    ///     False
+    ///     >>> op.groups = [0, 1, 0]
+    ///     >>> op.has_groups()
+    ///     True
+    ///
+    /// Returns:
+    ///     Whether :attr:`groups` is set on this operator.
+    pub fn has_groups(&self) -> bool {
+        self.inner.has_groups()
+    }
+
     /// Returns the number of groups.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, it will

--- a/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
@@ -683,6 +683,35 @@ class EdgeVertexOperator:
         Returns:
             A new operator.
         """
+    def has_groups(self) -> builtins.bool:
+        r"""
+        Returns whether this operator tracks group indices.
+        
+        This is equivalent to (but cheaper than) checking ``op.groups is not None``, because it does
+        not copy the group indices out of the operator in order to inspect them.
+        
+        .. note::
+           This returns ``True`` even when :attr:`groups` is an empty list, which is the state of a
+           grouped operator that holds no terms.
+        
+        .. doctest::
+        
+            >>> from qiskit_fermions.operators import EdgeVertexOperator
+            >>> op = EdgeVertexOperator(
+            ...     [1.0, 2.0, -1.0],
+            ...     [0, 1, 2, 3],
+            ...     [1, 0, 3, 2],
+            ...     [0, 1, 3, 4],
+            ... )
+            >>> op.has_groups()
+            False
+            >>> op.groups = [0, 1, 0]
+            >>> op.has_groups()
+            True
+        
+        Returns:
+            Whether :attr:`groups` is set on this operator.
+        """
     def num_groups(self) -> typing.Optional[builtins.int]:
         r"""
         Returns the number of groups.

--- a/python/qiskit_fermions/_lib/operators/fermion_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/fermion_operator/__init__.pyi
@@ -649,6 +649,35 @@ class FermionOperator:
         Returns:
             A new operator.
         """
+    def has_groups(self) -> builtins.bool:
+        r"""
+        Returns whether this operator tracks group indices.
+        
+        This is equivalent to (but cheaper than) checking ``op.groups is not None``, because it does
+        not copy the group indices out of the operator in order to inspect them.
+        
+        .. note::
+           This returns ``True`` even when :attr:`groups` is an empty list, which is the state of a
+           grouped operator that holds no terms.
+        
+        .. doctest::
+        
+            >>> from qiskit_fermions.operators import FermionOperator
+            >>> op = FermionOperator(
+            ...     [1.0, 2.0, -1.0, -2.0],
+            ...     [True, False, True, False, True, False, True, False],
+            ...     [0, 1, 2, 3, 1, 0, 3, 2],
+            ...     [0, 2, 4, 6, 8],
+            ... )
+            >>> op.has_groups()
+            False
+            >>> op.groups = [0, 1, 0, 1]
+            >>> op.has_groups()
+            True
+        
+        Returns:
+            Whether :attr:`groups` is set on this operator.
+        """
     def num_groups(self) -> typing.Optional[builtins.int]:
         r"""
         Returns the number of groups.

--- a/python/qiskit_fermions/_lib/operators/majorana_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/majorana_operator/__init__.pyi
@@ -619,6 +619,34 @@ class MajoranaOperator:
         Returns:
             A new operator.
         """
+    def has_groups(self) -> builtins.bool:
+        r"""
+        Returns whether this operator tracks group indices.
+        
+        This is equivalent to (but cheaper than) checking ``op.groups is not None``, because it does
+        not copy the group indices out of the operator in order to inspect them.
+        
+        .. note::
+           This returns ``True`` even when :attr:`groups` is an empty list, which is the state of a
+           grouped operator that holds no terms.
+        
+        .. doctest::
+        
+            >>> from qiskit_fermions.operators import MajoranaOperator
+            >>> op = MajoranaOperator(
+            ...     [1.0, 2.0, -1.0, -2.0],
+            ...     [0, 1, 2, 3, 1, 0, 3, 2],
+            ...     [0, 2, 4, 6, 8],
+            ... )
+            >>> op.has_groups()
+            False
+            >>> op.groups = [0, 1, 0, 1]
+            >>> op.has_groups()
+            True
+        
+        Returns:
+            Whether :attr:`groups` is set on this operator.
+        """
     def num_groups(self) -> typing.Optional[builtins.int]:
         r"""
         Returns the number of groups.

--- a/python/qiskit_fermions/_lib/operators/operators_terms/grouping/electronic_structure/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/operators_terms/grouping/electronic_structure/__init__.pyi
@@ -49,7 +49,7 @@ def group_terms_by_electronic_structure(op: fermion_operator.FermionOperator, nu
     
        group_terms_by_electronic_structure(normal, 2 * fcidump.norb, two_body_physicist_order=False)
     
-       assert normal.groups is not None
+       assert normal.has_groups()
     
     Args:
         op: the normal-ordered operator whose terms to group.

--- a/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
@@ -694,6 +694,35 @@ class TransferVertexOperator:
         Returns:
             A new operator.
         """
+    def has_groups(self) -> builtins.bool:
+        r"""
+        Returns whether this operator tracks group indices.
+        
+        This is equivalent to (but cheaper than) checking ``op.groups is not None``, because it does
+        not copy the group indices out of the operator in order to inspect them.
+        
+        .. note::
+           This returns ``True`` even when :attr:`groups` is an empty list, which is the state of a
+           grouped operator that holds no terms.
+        
+        .. doctest::
+        
+            >>> from qiskit_fermions.operators import TransferVertexOperator
+            >>> op = TransferVertexOperator(
+            ...     [1.0, 2.0, -1.0],
+            ...     [0, 1, 2, 3],
+            ...     [1, 0, 3, 2],
+            ...     [0, 1, 3, 4],
+            ... )
+            >>> op.has_groups()
+            False
+            >>> op.groups = [0, 1, 0]
+            >>> op.has_groups()
+            True
+        
+        Returns:
+            Whether :attr:`groups` is set on this operator.
+        """
     def num_groups(self) -> typing.Optional[builtins.int]:
         r"""
         Returns the number of groups.

--- a/python/qiskit_fermions/circuit/library/evolution.py
+++ b/python/qiskit_fermions/circuit/library/evolution.py
@@ -74,9 +74,9 @@ class Evolution(FermionicGate):
         # when the operator being evolved has groups use those for the decomposition, otherwise
         # decompose into all individual terms
         iterator = (
-            self.operator.iter_terms
-            if self.operator.groups is None
-            else self.operator.split_out_groups
+            self.operator.split_out_groups
+            if self.operator.has_groups()
+            else self.operator.iter_terms
         )
 
         for item in iterator():

--- a/python/qiskit_fermions/operators/operator_trait.py
+++ b/python/qiskit_fermions/operators/operator_trait.py
@@ -130,6 +130,13 @@ class OperatorTrait(Protocol):
     def groups(self, groups: list[int] | None) -> None:
         """Sets the groups indices."""
 
+    def has_groups(self) -> bool:
+        """Returns whether this operator tracks group indices.
+
+        This is equivalent to (but cheaper than) checking ``op.groups is not None``, because it does
+        not copy the group indices out of the operator in order to inspect them.
+        """
+
     def num_groups(self) -> int | None:
         """Returns the number of groups."""
 

--- a/python/qiskit_fermions/operators/terms/ordering/callable.py
+++ b/python/qiskit_fermions/operators/terms/ordering/callable.py
@@ -72,7 +72,7 @@ def order_terms(
     Returns:
         A new operator of the same type with its terms in the requested order.
     """
-    if op.groups is None:
+    if not op.has_groups():
         terms = sorted(op.iter_terms(), key=key, reverse=reverse)
         return op.__class__.from_terms(terms)
 

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -209,8 +209,9 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
             time = node.op.params[0]
             num_modes = len(node.qargs)
 
-            terms: list[Any] | None  # a list of operator terms, or None when `hamil.groups` is set
-            if hamil.groups is None:
+            # `terms` is a list of operator terms, or None when `hamil.has_groups()` is False
+            terms: list[Any] | None
+            if not hamil.has_groups():
                 # NOTE: the qDRIFT protocol normalizes each term to unit magnitude because the
                 # evolution time is entirely dictated by `delta` (computed below). Only the
                 # magnitude of a coefficient sets its sampling probability, but its sign fixes the

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -421,11 +421,13 @@ class TestEdgeVertexOperator:
         op += cls.from_dict(group1)
 
         with subtests.test("num_groups none"):
+            assert not op.has_groups()
             assert op.num_groups() is None
 
         op.groups = [0, 0, 1]
 
         with subtests.test("num_groups some"):
+            assert op.has_groups()
             assert op.num_groups() == 2
 
         groups = op.split_out_groups()
@@ -449,6 +451,30 @@ class TestEdgeVertexOperator:
 
         with subtests.test("split groups empty"):
             assert op.split_out_groups(group_indices=[]) == []
+
+    def test_has_groups(self, subtests):
+        cls = self.get_class()
+
+        op = cls.from_dict({((0, 1),): 1.0})
+
+        with subtests.test("unset"):
+            assert not op.has_groups()
+
+        with subtests.test("assigned"):
+            op.groups = [0]
+            assert op.has_groups()
+
+        with subtests.test("empty list"):
+            # an operator may track groups while carrying no group indices at all, which
+            # `has_groups` reports as `True` even though `num_groups` is 0
+            empty = cls.zero()
+            empty.groups = []
+            assert empty.has_groups()
+            assert empty.num_groups() == 0
+
+        with subtests.test("reset to None"):
+            op.groups = None
+            assert not op.has_groups()
 
     def test_split_out_groups_err(self):
         cls = self.get_class()

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -516,11 +516,13 @@ class TestFermionOperator:
         op += cls.from_dict(group1)
 
         with subtests.test("num_groups none"):
+            assert not op.has_groups()
             assert op.num_groups() is None
 
         op.groups = [0, 0, 1]
 
         with subtests.test("num_groups some"):
+            assert op.has_groups()
             assert op.num_groups() == 2
 
         groups = op.split_out_groups()
@@ -544,6 +546,30 @@ class TestFermionOperator:
 
         with subtests.test("split groups empty"):
             assert op.split_out_groups(group_indices=[]) == []
+
+    def test_has_groups(self, subtests):
+        cls = self.get_class()
+
+        op = cls.from_dict({(cre(0), ann(1)): 1.0})
+
+        with subtests.test("unset"):
+            assert not op.has_groups()
+
+        with subtests.test("assigned"):
+            op.groups = [0]
+            assert op.has_groups()
+
+        with subtests.test("empty list"):
+            # an operator may track groups while carrying no group indices at all, which
+            # `has_groups` reports as `True` even though `num_groups` is 0
+            empty = cls.zero()
+            empty.groups = []
+            assert empty.has_groups()
+            assert empty.num_groups() == 0
+
+        with subtests.test("reset to None"):
+            op.groups = None
+            assert not op.has_groups()
 
     def test_split_out_groups_err(self):
         cls = self.get_class()

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -460,11 +460,13 @@ class TestMajoranaOperator:
         op += cls.from_dict(group1)
 
         with subtests.test("num_groups none"):
+            assert not op.has_groups()
             assert op.num_groups() is None
 
         op.groups = [0, 0, 1]
 
         with subtests.test("num_groups some"):
+            assert op.has_groups()
             assert op.num_groups() == 2
 
         groups = op.split_out_groups()
@@ -488,6 +490,30 @@ class TestMajoranaOperator:
 
         with subtests.test("split groups empty"):
             assert op.split_out_groups(group_indices=[]) == []
+
+    def test_has_groups(self, subtests):
+        cls = self.get_class()
+
+        op = cls.from_dict({(0, 1): 1.0})
+
+        with subtests.test("unset"):
+            assert not op.has_groups()
+
+        with subtests.test("assigned"):
+            op.groups = [0]
+            assert op.has_groups()
+
+        with subtests.test("empty list"):
+            # an operator may track groups while carrying no group indices at all, which
+            # `has_groups` reports as `True` even though `num_groups` is 0
+            empty = cls.zero()
+            empty.groups = []
+            assert empty.has_groups()
+            assert empty.num_groups() == 0
+
+        with subtests.test("reset to None"):
+            op.groups = None
+            assert not op.has_groups()
 
     def test_split_out_groups_err(self):
         cls = self.get_class()

--- a/tests/python/operators/test_transfer_vertex_operator.py
+++ b/tests/python/operators/test_transfer_vertex_operator.py
@@ -437,11 +437,13 @@ class TestTransferVertexOperator:
         op += cls.from_dict(group1)
 
         with subtests.test("num_groups none"):
+            assert not op.has_groups()
             assert op.num_groups() is None
 
         op.groups = [0, 0, 1]
 
         with subtests.test("num_groups some"):
+            assert op.has_groups()
             assert op.num_groups() == 2
 
         groups = op.split_out_groups()
@@ -465,6 +467,30 @@ class TestTransferVertexOperator:
 
         with subtests.test("split groups empty"):
             assert op.split_out_groups(group_indices=[]) == []
+
+    def test_has_groups(self, subtests):
+        cls = self.get_class()
+
+        op = cls.from_dict({((0, 1),): 1.0})
+
+        with subtests.test("unset"):
+            assert not op.has_groups()
+
+        with subtests.test("assigned"):
+            op.groups = [0]
+            assert op.has_groups()
+
+        with subtests.test("empty list"):
+            # an operator may track groups while carrying no group indices at all, which
+            # `has_groups` reports as `True` even though `num_groups` is 0
+            empty = cls.zero()
+            empty.groups = []
+            assert empty.has_groups()
+            assert empty.num_groups() == 0
+
+        with subtests.test("reset to None"):
+            op.groups = None
+            assert not op.has_groups()
 
     def test_split_out_groups_err(self):
         cls = self.get_class()


### PR DESCRIPTION
Following up on #232, this PR implements the third follow-up suggested in #229: `OperatorTrait.has_groups()` for the Python API.

This brings the average runtime of the same benchmark mentioned in #232 down from its `~32 ms` by ~10% (as expected from #229) to `~29 ms`.