### PR TITLE
perf(operators): compute group weights natively for all operator types

### DIFF
--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -439,6 +439,68 @@ pub unsafe extern "C" fn qf_ferm_op_num_groups(op: *const FermionOperator) -> u3
 
 /// @ingroup qf_ferm_op
 ///
+/// @brief Gets the mean absolute coefficient magnitude of each group.
+///
+/// @param op A pointer to the fermionic operator whose group weights to compute.
+/// @param weights_out A pointer to the array of doubles into which to write the weights. Must be
+///     sized to :c:func:`qf_ferm_op_num_groups`.
+///
+/// @rst
+///
+/// The ``i``-th entry is the sum of ``abs(coeff)`` over the terms in group ``i``, divided by the
+/// number of terms in that group. This is the sampling weight of a randomized product formula
+/// (e.g. qDRIFT) that draws whole groups rather than individual terms, and is computed in a single
+/// pass over the operator rather than by reducing :c:func:`qf_ferm_op_get_coeffs` and
+/// :c:func:`qf_ferm_op_get_groups` (one value per *ungrouped* term each) on the caller's side.
+///
+/// .. note::
+///    A group index that no term carries weighs ``0.0``, which keeps it out of the sample.
+///
+/// .. seealso::
+///    The explanation on :ref:`grouping_explanation`.
+///
+/// Example
+/// -------
+///
+/// .. code-block:: c
+///     :linenos:
+///
+///     uint64_t num_terms = 4;
+///     uint64_t num_actions = 8;
+///     bool actions[8] = {true, false, true, false, true, false, true, false};
+///     uint32_t modes[8] = {0, 1, 2, 3, 1, 0, 3, 2};
+///     QkComplex64 coeffs[4] = {{1.0, 0.0}, {2.0, 0.0}, {-1.0, 0.0}, {-2.0, 0.0}};
+///     uint32_t boundaries[5] = {0, 2, 4, 6, 8};
+///     QfFermionOperator *op =
+///         qf_ferm_op_new(num_terms, num_actions, coeffs, actions, modes, boundaries);
+///
+///     uint32_t groups_in[4] = {0, 1, 0, 1};
+///     qf_ferm_op_set_groups(op, groups_in, num_terms);
+///
+///     double weights[2];
+///     qf_ferm_op_group_weights(op, weights);
+///
+///     assert(weights[0] == 1.0);
+///     assert(weights[1] == 2.0);
+///
+/// @endrst
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qf_ferm_op_group_weights(
+    op: *const FermionOperator,
+    weights_out: *mut f64,
+) {
+    let op = unsafe { const_ptr_as_ref(op) };
+    let weights = op.group_weights().expect(
+        "Expected groups to be present. It is the user's responsibility to check this via \
+        qf_ferm_op_has_groups before calling this function.",
+    );
+    for (i, weight) in weights.iter().enumerate() {
+        unsafe { weights_out.add(i).write(*weight) };
+    }
+}
+
+/// @ingroup qf_ferm_op
+///
 /// @brief Gets the group indices for all operator terms.
 ///
 /// @param op A pointer to the fermionic operator whose group indices to get.

--- a/crates/cext/src/operators/majorana_operator.rs
+++ b/crates/cext/src/operators/majorana_operator.rs
@@ -378,6 +378,66 @@ pub unsafe extern "C" fn qf_maj_op_num_groups(op: *const MajoranaOperator) -> u3
 
 /// @ingroup qf_maj_op
 ///
+/// @brief Gets the mean absolute coefficient magnitude of each group.
+///
+/// @param op A pointer to the Majorana operator whose group weights to compute.
+/// @param weights_out A pointer to the array of doubles into which to write the weights. Must be
+///     sized to :c:func:`qf_maj_op_num_groups`.
+///
+/// @rst
+///
+/// The ``i``-th entry is the sum of ``abs(coeff)`` over the terms in group ``i``, divided by the
+/// number of terms in that group. This is the sampling weight of a randomized product formula
+/// (e.g. qDRIFT) that draws whole groups rather than individual terms, and is computed in a single
+/// pass over the operator rather than by reducing :c:func:`qf_maj_op_get_coeffs` and
+/// :c:func:`qf_maj_op_get_groups` (one value per *ungrouped* term each) on the caller's side.
+///
+/// .. note::
+///    A group index that no term carries weighs ``0.0``, which keeps it out of the sample.
+///
+/// .. seealso::
+///    The explanation on :ref:`grouping_explanation`.
+///
+/// Example
+/// -------
+///
+/// .. code-block:: c
+///     :linenos:
+///
+///     uint64_t num_terms = 4;
+///     uint64_t num_modes = 8;
+///     uint32_t modes[8] = {0, 1, 2, 3, 1, 0, 3, 2};
+///     QkComplex64 coeffs[4] = {{1.0, 0.0}, {2.0, 0.0}, {-1.0, 0.0}, {-2.0, 0.0}};
+///     uint32_t boundaries[5] = {0, 2, 4, 6, 8};
+///     QfMajoranaOperator *op = qf_maj_op_new(num_terms, num_modes, coeffs, modes, boundaries);
+///
+///     uint32_t groups_in[4] = {0, 1, 0, 1};
+///     qf_maj_op_set_groups(op, groups_in, num_terms);
+///
+///     double weights[2];
+///     qf_maj_op_group_weights(op, weights);
+///
+///     assert(weights[0] == 1.0);
+///     assert(weights[1] == 2.0);
+///
+/// @endrst
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qf_maj_op_group_weights(
+    op: *const MajoranaOperator,
+    weights_out: *mut f64,
+) {
+    let op = unsafe { const_ptr_as_ref(op) };
+    let weights = op.group_weights().expect(
+        "Expected groups to be present. It is the user's responsibility to check this via \
+        qf_maj_op_has_groups before calling this function.",
+    );
+    for (i, weight) in weights.iter().enumerate() {
+        unsafe { weights_out.add(i).write(*weight) };
+    }
+}
+
+/// @ingroup qf_maj_op
+///
 /// @brief Gets the group indices for all operator terms.
 ///
 /// @param op A pointer to the majorana operator whose group indices to get.

--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -93,11 +93,6 @@ crate::impl_operator_macro!(EdgeVertexOperator);
 
 impl EdgeVertexOperator {
     #[inline]
-    pub fn coeffs(&self) -> &[Complex64] {
-        &self.coeffs
-    }
-
-    #[inline]
     pub fn left_indices(&self) -> &[u32] {
         &self.left_indices
     }
@@ -421,6 +416,11 @@ impl OperatorTrait for EdgeVertexOperator {
                 right_indices: &self.right_indices[start..end],
             }
         })
+    }
+
+    #[inline]
+    fn coeffs(&self) -> &[Complex64] {
+        &self.coeffs
     }
 
     fn groups(&self) -> Option<&[u32]> {

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -94,11 +94,6 @@ crate::impl_operator_macro!(FermionOperator);
 
 impl FermionOperator {
     #[inline]
-    pub fn coeffs(&self) -> &[Complex64] {
-        &self.coeffs
-    }
-
-    #[inline]
     pub fn actions(&self) -> &[bool] {
         &self.actions
     }
@@ -510,6 +505,11 @@ impl OperatorTrait for FermionOperator {
                 modes: &self.modes[start..end],
             }
         })
+    }
+
+    #[inline]
+    fn coeffs(&self) -> &[Complex64] {
+        &self.coeffs
     }
 
     fn groups(&self) -> Option<&[u32]> {
@@ -1395,6 +1395,39 @@ mod tests {
 
         assert!(one.has_groups());
         assert_eq!(one.num_groups(), Some(1));
+    }
+
+    #[test]
+    fn test_group_weights() {
+        let mut op = FermionOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(-3.0, 4.0),
+                Complex64::new(2.0, 0.0),
+            ],
+            actions: vec![true, false, true, false, true, true, false, false],
+            modes: vec![0, 1, 1, 0, 0, 0, 1, 1],
+            boundaries: vec![0, 2, 4, 8],
+            groups: None,
+        };
+
+        // an ungrouped operator has no per-group weights to report
+        assert!(op.group_weights().is_none());
+
+        op.groups = Some(vec![0, 0, 1]);
+
+        // group 0 averages |1.0| and |-3.0 + 4.0j| = 5.0, i.e. (1.0 + 5.0) / 2; group 1 holds the
+        // single term |2.0|. Note that the magnitude, not the real part, is what is averaged.
+        assert_eq!(op.group_weights(), Some(vec![3.0, 2.0]));
+
+        // a grouped operator holding no terms has no groups to weight either
+        let mut zero = FermionOperator::zero();
+        zero.groups = Some(vec![]);
+        assert_eq!(zero.group_weights(), Some(vec![]));
+
+        // group 1 is carried by no term at all, so it weighs 0.0 rather than NaN-ing the sample
+        op.groups = Some(vec![0, 0, 2]);
+        assert_eq!(op.group_weights(), Some(vec![3.0, 0.0, 2.0]));
     }
 
     #[test]

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -89,11 +89,6 @@ crate::impl_operator_macro!(MajoranaOperator);
 
 impl MajoranaOperator {
     #[inline]
-    pub fn coeffs(&self) -> &[Complex64] {
-        &self.coeffs
-    }
-
-    #[inline]
     pub fn modes(&self) -> &[u32] {
         &self.modes
     }
@@ -437,6 +432,11 @@ impl OperatorTrait for MajoranaOperator {
                 modes: &self.modes[start..end],
             }
         })
+    }
+
+    #[inline]
+    fn coeffs(&self) -> &[Complex64] {
+        &self.coeffs
     }
 
     fn groups(&self) -> Option<&[u32]> {

--- a/crates/core/src/operators/mod.rs
+++ b/crates/core/src/operators/mod.rs
@@ -76,11 +76,19 @@ pub trait OperatorTrait {
     /// impl signature more specific than this one and trip the `refining_impl_trait` lint.
     fn iter(&self) -> impl ExactSizeIterator<Item = Self::TermView<'_>>;
 
+    /// Returns the operator's coefficients, one per term.
+    ///
+    /// This is the single point of access through which the trait's coefficient-dependent provided
+    /// methods ([`group_weights`](Self::group_weights)) reach the `coeffs` field, so that they need
+    /// not be reimplemented per operator type.
+    fn coeffs(&self) -> &[Complex64];
+
     /// Returns the operator's group indices, one per term, or `None` if it tracks no groups.
     ///
     /// This is the single point of access through which the trait's group-related provided methods
-    /// ([`has_groups`](Self::has_groups), [`num_groups`](Self::num_groups)) reach the `groups` field,
-    /// so that they need not be reimplemented per operator type.
+    /// ([`has_groups`](Self::has_groups), [`num_groups`](Self::num_groups),
+    /// [`group_weights`](Self::group_weights)) reach the `groups` field, so that they need not be
+    /// reimplemented per operator type.
     fn groups(&self) -> Option<&[u32]>;
 
     /// Returns whether the operator tracks group indices (i.e. `groups` is `Some`).
@@ -104,6 +112,37 @@ pub trait OperatorTrait {
             Some(max) => max + 1,
             None => 0,
         })
+    }
+
+    /// Returns the mean absolute coefficient magnitude of each group, or `None` if the operator
+    /// tracks no groups.
+    ///
+    /// The `i`-th entry is the sum of `|coeff|` over the terms in group `i`, divided by the number
+    /// of terms in that group. This is the sampling weight of a randomized product formula (e.g.
+    /// qDRIFT) that draws whole groups rather than individual terms.
+    ///
+    /// Computing this natively reduces the per-term coefficients and group indices down to one
+    /// value per group in a single pass, so a caller across an FFI boundary receives only
+    /// [`num_groups`](Self::num_groups) values instead of two arrays of one value per (ungrouped)
+    /// term that it would have to reduce itself.
+    ///
+    /// A group index that no term carries yields a weight of `0.0`: the index range is dense by
+    /// construction (see [`num_groups`](Self::num_groups)), but nothing enforces that, and a `0.0`
+    /// weight keeps such a group out of the sample rather than poisoning every weight with a `NaN`.
+    fn group_weights(&self) -> Option<Vec<f64>> {
+        let groups = self.groups()?;
+        let mut sums = vec![0.0; self.num_groups()? as usize];
+        let mut counts = vec![0_u32; sums.len()];
+        for (&group, coeff) in groups.iter().zip(self.coeffs()) {
+            sums[group as usize] += coeff.norm();
+            counts[group as usize] += 1;
+        }
+        for (sum, &count) in sums.iter_mut().zip(counts.iter()) {
+            if count > 0 {
+                *sum /= f64::from(count);
+            }
+        }
+        Some(sums)
     }
 
     /// Iterates over the terms of the operator together with their group index.

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -93,11 +93,6 @@ crate::impl_operator_macro!(TransferVertexOperator);
 
 impl TransferVertexOperator {
     #[inline]
-    pub fn coeffs(&self) -> &[Complex64] {
-        &self.coeffs
-    }
-
-    #[inline]
     pub fn left_indices(&self) -> &[u32] {
         &self.left_indices
     }
@@ -420,6 +415,11 @@ impl OperatorTrait for TransferVertexOperator {
                 right_indices: &self.right_indices[start..end],
             }
         })
+    }
+
+    #[inline]
+    fn coeffs(&self) -> &[Complex64] {
+        &self.coeffs
     }
 
     fn groups(&self) -> Option<&[u32]> {

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -902,6 +902,43 @@ impl PyEdgeVertexOperator {
         self.inner.num_groups()
     }
 
+    /// Returns the mean absolute coefficient magnitude of each group.
+    ///
+    /// The ``i``-th entry is the sum of ``abs(coeff)`` over the terms in group ``i``, divided by
+    /// the number of terms in that group. If :attr:`groups` is ``None``, this function also returns
+    /// ``None``.
+    ///
+    /// This is the sampling weight of a randomized product formula (e.g. qDRIFT) that draws whole
+    /// groups rather than individual terms. Computing it natively is considerably cheaper than
+    /// reducing :meth:`get_coeffs` and :attr:`groups` in NumPy, because those two accessors each
+    /// copy one value per *ungrouped* term out of the operator only for it to be aggregated back
+    /// down to one value per group, whereas this returns just the :meth:`num_groups` reduced
+    /// values.
+    ///
+    /// .. note::
+    ///    A group index that no term carries weighs ``0.0``, which keeps it out of the sample.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import EdgeVertexOperator
+    ///     >>> op = EdgeVertexOperator(
+    ///     ...     [1.0, 2.0, -1.0],
+    ///     ...     [0, 1, 2, 3],
+    ///     ...     [1, 0, 3, 2],
+    ///     ...     [0, 1, 3, 4],
+    ///     ... )
+    ///     >>> print(op.group_weights())
+    ///     None
+    ///     >>> op.groups = [0, 1, 0]
+    ///     >>> op.group_weights()
+    ///     [1.0, 2.0]
+    ///
+    /// Returns:
+    ///     The mean absolute coefficient magnitude of each group index.
+    pub fn group_weights(&self) -> Option<Vec<f64>> {
+        self.inner.group_weights()
+    }
+
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -869,6 +869,43 @@ impl PyFermionOperator {
         self.inner.num_groups()
     }
 
+    /// Returns the mean absolute coefficient magnitude of each group.
+    ///
+    /// The ``i``-th entry is the sum of ``abs(coeff)`` over the terms in group ``i``, divided by
+    /// the number of terms in that group. If :attr:`groups` is ``None``, this function also returns
+    /// ``None``.
+    ///
+    /// This is the sampling weight of a randomized product formula (e.g. qDRIFT) that draws whole
+    /// groups rather than individual terms. Computing it natively is considerably cheaper than
+    /// reducing :meth:`get_coeffs` and :attr:`groups` in NumPy, because those two accessors each
+    /// copy one value per *ungrouped* term out of the operator only for it to be aggregated back
+    /// down to one value per group, whereas this returns just the :meth:`num_groups` reduced
+    /// values.
+    ///
+    /// .. note::
+    ///    A group index that no term carries weighs ``0.0``, which keeps it out of the sample.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import FermionOperator
+    ///     >>> op = FermionOperator(
+    ///     ...     [1.0, 2.0, -1.0, -2.0],
+    ///     ...     [True, False, True, False, True, False, True, False],
+    ///     ...     [0, 1, 2, 3, 1, 0, 3, 2],
+    ///     ...     [0, 2, 4, 6, 8],
+    ///     ... )
+    ///     >>> print(op.group_weights())
+    ///     None
+    ///     >>> op.groups = [0, 1, 0, 1]
+    ///     >>> op.group_weights()
+    ///     [1.0, 2.0]
+    ///
+    /// Returns:
+    ///     The mean absolute coefficient magnitude of each group index.
+    pub fn group_weights(&self) -> Option<Vec<f64>> {
+        self.inner.group_weights()
+    }
+
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -814,6 +814,42 @@ impl PyMajoranaOperator {
         self.inner.num_groups()
     }
 
+    /// Returns the mean absolute coefficient magnitude of each group.
+    ///
+    /// The ``i``-th entry is the sum of ``abs(coeff)`` over the terms in group ``i``, divided by
+    /// the number of terms in that group. If :attr:`groups` is ``None``, this function also returns
+    /// ``None``.
+    ///
+    /// This is the sampling weight of a randomized product formula (e.g. qDRIFT) that draws whole
+    /// groups rather than individual terms. Computing it natively is considerably cheaper than
+    /// reducing :meth:`get_coeffs` and :attr:`groups` in NumPy, because those two accessors each
+    /// copy one value per *ungrouped* term out of the operator only for it to be aggregated back
+    /// down to one value per group, whereas this returns just the :meth:`num_groups` reduced
+    /// values.
+    ///
+    /// .. note::
+    ///    A group index that no term carries weighs ``0.0``, which keeps it out of the sample.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import MajoranaOperator
+    ///     >>> op = MajoranaOperator(
+    ///     ...     [1.0, 2.0, -1.0, -2.0],
+    ///     ...     [0, 1, 2, 3, 1, 0, 3, 2],
+    ///     ...     [0, 2, 4, 6, 8],
+    ///     ... )
+    ///     >>> print(op.group_weights())
+    ///     None
+    ///     >>> op.groups = [0, 1, 0, 1]
+    ///     >>> op.group_weights()
+    ///     [1.0, 2.0]
+    ///
+    /// Returns:
+    ///     The mean absolute coefficient magnitude of each group index.
+    pub fn group_weights(&self) -> Option<Vec<f64>> {
+        self.inner.group_weights()
+    }
+
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -908,6 +908,43 @@ impl PyTransferVertexOperator {
         self.inner.num_groups()
     }
 
+    /// Returns the mean absolute coefficient magnitude of each group.
+    ///
+    /// The ``i``-th entry is the sum of ``abs(coeff)`` over the terms in group ``i``, divided by
+    /// the number of terms in that group. If :attr:`groups` is ``None``, this function also returns
+    /// ``None``.
+    ///
+    /// This is the sampling weight of a randomized product formula (e.g. qDRIFT) that draws whole
+    /// groups rather than individual terms. Computing it natively is considerably cheaper than
+    /// reducing :meth:`get_coeffs` and :attr:`groups` in NumPy, because those two accessors each
+    /// copy one value per *ungrouped* term out of the operator only for it to be aggregated back
+    /// down to one value per group, whereas this returns just the :meth:`num_groups` reduced
+    /// values.
+    ///
+    /// .. note::
+    ///    A group index that no term carries weighs ``0.0``, which keeps it out of the sample.
+    ///
+    /// .. doctest::
+    ///
+    ///     >>> from qiskit_fermions.operators import TransferVertexOperator
+    ///     >>> op = TransferVertexOperator(
+    ///     ...     [1.0, 2.0, -1.0],
+    ///     ...     [0, 1, 2, 3],
+    ///     ...     [1, 0, 3, 2],
+    ///     ...     [0, 1, 3, 4],
+    ///     ... )
+    ///     >>> print(op.group_weights())
+    ///     None
+    ///     >>> op.groups = [0, 1, 0]
+    ///     >>> op.group_weights()
+    ///     [1.0, 2.0]
+    ///
+    /// Returns:
+    ///     The mean absolute coefficient magnitude of each group index.
+    pub fn group_weights(&self) -> Option<Vec<f64>> {
+        self.inner.group_weights()
+    }
+
     /// Splits this operator into an optional list of new operators based on :attr:`groups`.
     ///
     /// If :attr:`groups` is ``None``, this function also returns ``None``. Otherwise, if

--- a/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
@@ -736,6 +736,42 @@ class EdgeVertexOperator:
         Returns:
             The largest group index in :attr:`groups` plus 1.
         """
+    def group_weights(self) -> typing.Optional[builtins.list[builtins.float]]:
+        r"""
+        Returns the mean absolute coefficient magnitude of each group.
+        
+        The ``i``-th entry is the sum of ``abs(coeff)`` over the terms in group ``i``, divided by
+        the number of terms in that group. If :attr:`groups` is ``None``, this function also returns
+        ``None``.
+        
+        This is the sampling weight of a randomized product formula (e.g. qDRIFT) that draws whole
+        groups rather than individual terms. Computing it natively is considerably cheaper than
+        reducing :meth:`get_coeffs` and :attr:`groups` in NumPy, because those two accessors each
+        copy one value per *ungrouped* term out of the operator only for it to be aggregated back
+        down to one value per group, whereas this returns just the :meth:`num_groups` reduced
+        values.
+        
+        .. note::
+           A group index that no term carries weighs ``0.0``, which keeps it out of the sample.
+        
+        .. doctest::
+        
+            >>> from qiskit_fermions.operators import EdgeVertexOperator
+            >>> op = EdgeVertexOperator(
+            ...     [1.0, 2.0, -1.0],
+            ...     [0, 1, 2, 3],
+            ...     [1, 0, 3, 2],
+            ...     [0, 1, 3, 4],
+            ... )
+            >>> print(op.group_weights())
+            None
+            >>> op.groups = [0, 1, 0]
+            >>> op.group_weights()
+            [1.0, 2.0]
+        
+        Returns:
+            The mean absolute coefficient magnitude of each group index.
+        """
     def split_out_groups(self, group_indices: typing.Optional[typing.Sequence[builtins.int]] = None) -> typing.Optional[builtins.list[EdgeVertexOperator]]:
         r"""
         Splits this operator into an optional list of new operators based on :attr:`groups`.

--- a/python/qiskit_fermions/_lib/operators/fermion_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/fermion_operator/__init__.pyi
@@ -702,6 +702,42 @@ class FermionOperator:
         Returns:
             The largest group index in :attr:`groups` plus 1.
         """
+    def group_weights(self) -> typing.Optional[builtins.list[builtins.float]]:
+        r"""
+        Returns the mean absolute coefficient magnitude of each group.
+        
+        The ``i``-th entry is the sum of ``abs(coeff)`` over the terms in group ``i``, divided by
+        the number of terms in that group. If :attr:`groups` is ``None``, this function also returns
+        ``None``.
+        
+        This is the sampling weight of a randomized product formula (e.g. qDRIFT) that draws whole
+        groups rather than individual terms. Computing it natively is considerably cheaper than
+        reducing :meth:`get_coeffs` and :attr:`groups` in NumPy, because those two accessors each
+        copy one value per *ungrouped* term out of the operator only for it to be aggregated back
+        down to one value per group, whereas this returns just the :meth:`num_groups` reduced
+        values.
+        
+        .. note::
+           A group index that no term carries weighs ``0.0``, which keeps it out of the sample.
+        
+        .. doctest::
+        
+            >>> from qiskit_fermions.operators import FermionOperator
+            >>> op = FermionOperator(
+            ...     [1.0, 2.0, -1.0, -2.0],
+            ...     [True, False, True, False, True, False, True, False],
+            ...     [0, 1, 2, 3, 1, 0, 3, 2],
+            ...     [0, 2, 4, 6, 8],
+            ... )
+            >>> print(op.group_weights())
+            None
+            >>> op.groups = [0, 1, 0, 1]
+            >>> op.group_weights()
+            [1.0, 2.0]
+        
+        Returns:
+            The mean absolute coefficient magnitude of each group index.
+        """
     def split_out_groups(self, group_indices: typing.Optional[typing.Sequence[builtins.int]] = None) -> typing.Optional[builtins.list[FermionOperator]]:
         r"""
         Splits this operator into an optional list of new operators based on :attr:`groups`.

--- a/python/qiskit_fermions/_lib/operators/majorana_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/majorana_operator/__init__.pyi
@@ -670,6 +670,41 @@ class MajoranaOperator:
         Returns:
             The largest group index in :attr:`groups` plus 1.
         """
+    def group_weights(self) -> typing.Optional[builtins.list[builtins.float]]:
+        r"""
+        Returns the mean absolute coefficient magnitude of each group.
+        
+        The ``i``-th entry is the sum of ``abs(coeff)`` over the terms in group ``i``, divided by
+        the number of terms in that group. If :attr:`groups` is ``None``, this function also returns
+        ``None``.
+        
+        This is the sampling weight of a randomized product formula (e.g. qDRIFT) that draws whole
+        groups rather than individual terms. Computing it natively is considerably cheaper than
+        reducing :meth:`get_coeffs` and :attr:`groups` in NumPy, because those two accessors each
+        copy one value per *ungrouped* term out of the operator only for it to be aggregated back
+        down to one value per group, whereas this returns just the :meth:`num_groups` reduced
+        values.
+        
+        .. note::
+           A group index that no term carries weighs ``0.0``, which keeps it out of the sample.
+        
+        .. doctest::
+        
+            >>> from qiskit_fermions.operators import MajoranaOperator
+            >>> op = MajoranaOperator(
+            ...     [1.0, 2.0, -1.0, -2.0],
+            ...     [0, 1, 2, 3, 1, 0, 3, 2],
+            ...     [0, 2, 4, 6, 8],
+            ... )
+            >>> print(op.group_weights())
+            None
+            >>> op.groups = [0, 1, 0, 1]
+            >>> op.group_weights()
+            [1.0, 2.0]
+        
+        Returns:
+            The mean absolute coefficient magnitude of each group index.
+        """
     def split_out_groups(self, group_indices: typing.Optional[typing.Sequence[builtins.int]] = None) -> typing.Optional[builtins.list[MajoranaOperator]]:
         r"""
         Splits this operator into an optional list of new operators based on :attr:`groups`.

--- a/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
@@ -747,6 +747,42 @@ class TransferVertexOperator:
         Returns:
             The largest group index in :attr:`groups` plus 1.
         """
+    def group_weights(self) -> typing.Optional[builtins.list[builtins.float]]:
+        r"""
+        Returns the mean absolute coefficient magnitude of each group.
+        
+        The ``i``-th entry is the sum of ``abs(coeff)`` over the terms in group ``i``, divided by
+        the number of terms in that group. If :attr:`groups` is ``None``, this function also returns
+        ``None``.
+        
+        This is the sampling weight of a randomized product formula (e.g. qDRIFT) that draws whole
+        groups rather than individual terms. Computing it natively is considerably cheaper than
+        reducing :meth:`get_coeffs` and :attr:`groups` in NumPy, because those two accessors each
+        copy one value per *ungrouped* term out of the operator only for it to be aggregated back
+        down to one value per group, whereas this returns just the :meth:`num_groups` reduced
+        values.
+        
+        .. note::
+           A group index that no term carries weighs ``0.0``, which keeps it out of the sample.
+        
+        .. doctest::
+        
+            >>> from qiskit_fermions.operators import TransferVertexOperator
+            >>> op = TransferVertexOperator(
+            ...     [1.0, 2.0, -1.0],
+            ...     [0, 1, 2, 3],
+            ...     [1, 0, 3, 2],
+            ...     [0, 1, 3, 4],
+            ... )
+            >>> print(op.group_weights())
+            None
+            >>> op.groups = [0, 1, 0]
+            >>> op.group_weights()
+            [1.0, 2.0]
+        
+        Returns:
+            The mean absolute coefficient magnitude of each group index.
+        """
     def split_out_groups(self, group_indices: typing.Optional[typing.Sequence[builtins.int]] = None) -> typing.Optional[builtins.list[TransferVertexOperator]]:
         r"""
         Splits this operator into an optional list of new operators based on :attr:`groups`.

--- a/python/qiskit_fermions/operators/operator_trait.py
+++ b/python/qiskit_fermions/operators/operator_trait.py
@@ -140,6 +140,14 @@ class OperatorTrait(Protocol):
     def num_groups(self) -> int | None:
         """Returns the number of groups."""
 
+    def group_weights(self) -> list[float] | None:
+        """Returns the mean absolute coefficient magnitude of each group.
+
+        This is equivalent to (but cheaper than) reducing :meth:`get_coeffs` and :attr:`groups`
+        down to one value per group in NumPy, because it does not copy one value per *ungrouped*
+        term out of the operator just to aggregate it away again.
+        """
+
     def split_out_groups(self, group_indices: Sequence[int] | None = None) -> list[Self]:
         """Splits this operator into an optional list of new operators based on its :attr:`.groups`.
 

--- a/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
+++ b/python/qiskit_fermions/transpiler/passes/optimization/qdrift.py
@@ -220,11 +220,12 @@ class QDriftTrotterization(FermionicDAGCircuitPass):
                 terms = [(actions, np.sign(coeff)) for actions, coeff in hamil.iter_terms()]
                 weights = np.abs(hamil.get_coeffs())
             else:
-                all_coeffs = hamil.get_coeffs()
-                groups = hamil.groups
-                weights = np.zeros((hamil.num_groups(),))
-                np.add.at(weights, groups, np.abs(all_coeffs))
-                weights /= np.unique(groups, return_counts=True)[1]
+                # NOTE: computed natively rather than by reducing `hamil.get_coeffs()` and
+                # `hamil.groups` here. Those two accessors each copy one value per *ungrouped*
+                # term out of the operator, only for both arrays to be aggregated straight back
+                # down to one weight per group -- which dominates the cost of the reduction itself
+                # for a Hamiltonian holding far more terms than groups.
+                weights = np.array(hamil.group_weights())
                 # NOTE: we do not materialize the group operators here. Since only a small
                 # fraction of the (potentially much larger) set of groups ends up being sampled,
                 # we look up each sampled group's operator lazily via `split_out_groups`, once we

--- a/tests/c/test_fermion_operator.c
+++ b/tests/c/test_fermion_operator.c
@@ -678,6 +678,50 @@ static int test_groups(void) {
     return Ok;
 }
 
+static int test_group_weights(void) {
+    uint64_t num_terms = 4;
+    uint64_t num_actions = 8;
+    bool actions[8] = {true, false, true, false, true, false, true, false};
+    uint32_t modes[8] = {0, 1, 2, 3, 1, 0, 3, 2};
+    // the second term of each group is the negative of the first, so averaging the magnitudes
+    // (rather than the signed coefficients) is what makes the group weights non-zero
+    QkComplex64 coeffs[4] = {{1.0, 0.0}, {2.0, 0.0}, {-1.0, 0.0}, {-2.0, 0.0}};
+    uint32_t boundaries[5] = {0, 2, 4, 6, 8};
+    QfFermionOperator *op =
+        qf_ferm_op_new(num_terms, num_actions, coeffs, actions, modes, boundaries);
+
+    uint32_t groups_in[4] = {0, 1, 0, 1};
+    qf_ferm_op_set_groups(op, groups_in, num_terms);
+
+    double weights[2];
+    qf_ferm_op_group_weights(op, weights);
+
+    // both averages are exactly representable, so an exact comparison is safe here
+    bool correct_weight0 = weights[0] == 1.0;
+    bool correct_weight1 = weights[1] == 2.0;
+
+    // a group index carried by no term weighs 0.0 rather than NaN
+    uint32_t sparse_groups[4] = {0, 2, 0, 2};
+    qf_ferm_op_set_groups(op, sparse_groups, num_terms);
+
+    double sparse_weights[3];
+    qf_ferm_op_group_weights(op, sparse_weights);
+
+    bool correct_sparse0 = sparse_weights[0] == 1.0;
+    bool correct_sparse1 = sparse_weights[1] == 0.0;
+    bool correct_sparse2 = sparse_weights[2] == 2.0;
+
+    bool passed_all =
+        correct_weight0 && correct_weight1 && correct_sparse0 && correct_sparse1 && correct_sparse2;
+
+    qf_ferm_op_free(op);
+
+    if (!passed_all) {
+        return EqualityError;
+    }
+    return Ok;
+}
+
 int test_fermion_operator(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_new);
@@ -703,6 +747,7 @@ int test_fermion_operator(void) {
     num_failed += RUN_TEST(test_relabel_modes_duplicate_err);
     num_failed += RUN_TEST(test_relabel_modes_too_small_err);
     num_failed += RUN_TEST(test_groups);
+    num_failed += RUN_TEST(test_group_weights);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);

--- a/tests/c/test_majorana_operator.c
+++ b/tests/c/test_majorana_operator.c
@@ -582,6 +582,48 @@ static int test_groups(void) {
     return Ok;
 }
 
+static int test_group_weights(void) {
+    uint64_t num_terms = 4;
+    uint64_t num_modes = 8;
+    uint32_t modes[8] = {0, 1, 2, 3, 1, 0, 3, 2};
+    // the second term of each group is the negative of the first, so averaging the magnitudes
+    // (rather than the signed coefficients) is what makes the group weights non-zero
+    QkComplex64 coeffs[4] = {{1.0, 0.0}, {2.0, 0.0}, {-1.0, 0.0}, {-2.0, 0.0}};
+    uint32_t boundaries[5] = {0, 2, 4, 6, 8};
+    QfMajoranaOperator *op = qf_maj_op_new(num_terms, num_modes, coeffs, modes, boundaries);
+
+    uint32_t groups_in[4] = {0, 1, 0, 1};
+    qf_maj_op_set_groups(op, groups_in, num_terms);
+
+    double weights[2];
+    qf_maj_op_group_weights(op, weights);
+
+    // both averages are exactly representable, so an exact comparison is safe here
+    bool correct_weight0 = weights[0] == 1.0;
+    bool correct_weight1 = weights[1] == 2.0;
+
+    // a group index carried by no term weighs 0.0 rather than NaN
+    uint32_t sparse_groups[4] = {0, 2, 0, 2};
+    qf_maj_op_set_groups(op, sparse_groups, num_terms);
+
+    double sparse_weights[3];
+    qf_maj_op_group_weights(op, sparse_weights);
+
+    bool correct_sparse0 = sparse_weights[0] == 1.0;
+    bool correct_sparse1 = sparse_weights[1] == 0.0;
+    bool correct_sparse2 = sparse_weights[2] == 2.0;
+
+    bool passed_all =
+        correct_weight0 && correct_weight1 && correct_sparse0 && correct_sparse1 && correct_sparse2;
+
+    qf_maj_op_free(op);
+
+    if (!passed_all) {
+        return EqualityError;
+    }
+    return Ok;
+}
+
 int test_majorana_operator(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_new);
@@ -605,6 +647,7 @@ int test_majorana_operator(void) {
     num_failed += RUN_TEST(test_relabel_modes_duplicate_err);
     num_failed += RUN_TEST(test_relabel_modes_too_small_err);
     num_failed += RUN_TEST(test_groups);
+    num_failed += RUN_TEST(test_group_weights);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -476,6 +476,36 @@ class TestEdgeVertexOperator:
             op.groups = None
             assert not op.has_groups()
 
+    def test_group_weights(self, subtests):
+        cls = self.get_class()
+
+        op = cls.from_dict({((0, 1),): 1.0, ((2, 3),): -3.0 + 4.0j, ((1, 0), (2, 3)): 2.0})
+
+        with subtests.test("unset"):
+            assert op.group_weights() is None
+
+        # NOTE: `from_dict` does not preserve the insertion order of its keys, so the expected
+        # weights are derived from the operator's actual coefficient order rather than hardcoded.
+        # The magnitude, not the real part, is what gets averaged (hence `abs` below).
+        coeffs = op.get_coeffs()
+        first_two = (abs(coeffs[0]) + abs(coeffs[1])) / 2
+        last = abs(coeffs[2])
+
+        op.groups = [0, 0, 1]
+
+        with subtests.test("assigned"):
+            assert op.group_weights() == [first_two, last]
+
+        with subtests.test("sparse group index"):
+            # group 1 is carried by no term at all, so it weighs 0.0 rather than NaN
+            op.groups = [0, 0, 2]
+            assert op.group_weights() == [first_two, 0.0, last]
+
+        with subtests.test("empty list"):
+            empty = cls.zero()
+            empty.groups = []
+            assert empty.group_weights() == []
+
     def test_split_out_groups_err(self):
         cls = self.get_class()
 

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -571,6 +571,56 @@ class TestFermionOperator:
             op.groups = None
             assert not op.has_groups()
 
+    def test_group_weights(self, subtests):
+        cls = self.get_class()
+
+        op = cls.from_dict(
+            {
+                (cre(0), ann(1)): 1.0,
+                (cre(1), ann(0)): -3.0 + 4.0j,
+                (cre(0), cre(0), ann(1), ann(1)): 2.0,
+            }
+        )
+
+        with subtests.test("unset"):
+            assert op.group_weights() is None
+
+        # NOTE: `from_dict` does not preserve the insertion order of its keys, so the expected
+        # weights are derived from the operator's actual coefficient order rather than hardcoded.
+        # The magnitude, not the real part, is what gets averaged (hence `abs` below).
+        coeffs = op.get_coeffs()
+        first_two = (abs(coeffs[0]) + abs(coeffs[1])) / 2
+        last = abs(coeffs[2])
+
+        op.groups = [0, 0, 1]
+
+        with subtests.test("assigned"):
+            assert op.group_weights() == [first_two, last]
+
+        with subtests.test("sparse group index"):
+            # group 1 is carried by no term at all, so it weighs 0.0 rather than NaN
+            op.groups = [0, 0, 2]
+            assert op.group_weights() == [first_two, 0.0, last]
+
+        with subtests.test("empty list"):
+            empty = cls.zero()
+            empty.groups = []
+            assert empty.group_weights() == []
+
+        with subtests.test("exact averages"):
+            # built positionally (rather than via `from_dict`) so that the term order -- and hence
+            # the pairing with the group indices below -- is fixed, pinning the exact expected
+            # averages: group 0 is (|1.0| + |-3.0 + 4.0j|) / 2 == (1.0 + 5.0) / 2, and group 1 is
+            # the lone |2.0|.
+            exact = cls(
+                [1.0, -3.0 + 4.0j, 2.0],
+                [True, False, True, False, True, False],
+                [0, 1, 1, 0, 2, 3],
+                [0, 2, 4, 6],
+            )
+            exact.groups = [0, 0, 1]
+            assert exact.group_weights() == [3.0, 2.0]
+
     def test_split_out_groups_err(self):
         cls = self.get_class()
 

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -515,6 +515,36 @@ class TestMajoranaOperator:
             op.groups = None
             assert not op.has_groups()
 
+    def test_group_weights(self, subtests):
+        cls = self.get_class()
+
+        op = cls.from_dict({(0, 1): 1.0, (1, 0): -3.0 + 4.0j, (0, 0, 1, 1): 2.0})
+
+        with subtests.test("unset"):
+            assert op.group_weights() is None
+
+        # NOTE: `from_dict` does not preserve the insertion order of its keys, so the expected
+        # weights are derived from the operator's actual coefficient order rather than hardcoded.
+        # The magnitude, not the real part, is what gets averaged (hence `abs` below).
+        coeffs = op.get_coeffs()
+        first_two = (abs(coeffs[0]) + abs(coeffs[1])) / 2
+        last = abs(coeffs[2])
+
+        op.groups = [0, 0, 1]
+
+        with subtests.test("assigned"):
+            assert op.group_weights() == [first_two, last]
+
+        with subtests.test("sparse group index"):
+            # group 1 is carried by no term at all, so it weighs 0.0 rather than NaN
+            op.groups = [0, 0, 2]
+            assert op.group_weights() == [first_two, 0.0, last]
+
+        with subtests.test("empty list"):
+            empty = cls.zero()
+            empty.groups = []
+            assert empty.group_weights() == []
+
     def test_split_out_groups_err(self):
         cls = self.get_class()
 

--- a/tests/python/operators/test_transfer_vertex_operator.py
+++ b/tests/python/operators/test_transfer_vertex_operator.py
@@ -492,6 +492,36 @@ class TestTransferVertexOperator:
             op.groups = None
             assert not op.has_groups()
 
+    def test_group_weights(self, subtests):
+        cls = self.get_class()
+
+        op = cls.from_dict({((0, 1),): 1.0, ((2, 3),): -3.0 + 4.0j, ((1, 0), (2, 3)): 2.0})
+
+        with subtests.test("unset"):
+            assert op.group_weights() is None
+
+        # NOTE: `from_dict` does not preserve the insertion order of its keys, so the expected
+        # weights are derived from the operator's actual coefficient order rather than hardcoded.
+        # The magnitude, not the real part, is what gets averaged (hence `abs` below).
+        coeffs = op.get_coeffs()
+        first_two = (abs(coeffs[0]) + abs(coeffs[1])) / 2
+        last = abs(coeffs[2])
+
+        op.groups = [0, 0, 1]
+
+        with subtests.test("assigned"):
+            assert op.group_weights() == [first_two, last]
+
+        with subtests.test("sparse group index"):
+            # group 1 is carried by no term at all, so it weighs 0.0 rather than NaN
+            op.groups = [0, 0, 2]
+            assert op.group_weights() == [first_two, 0.0, last]
+
+        with subtests.test("empty list"):
+            empty = cls.zero()
+            empty.groups = []
+            assert empty.group_weights() == []
+
     def test_split_out_groups_err(self):
         cls = self.get_class()
 


### PR DESCRIPTION
This implements the remaining Python-level follow-up suggested by #229.

Running the same benchmark as in #232 and #233, we can further reduce the average runtime of the transpiler pass down to `~4-5 ms` per call, an almost 8x speedup!

Since this is the final Python-level follow-up, this PR
Closes #229