### PR TITLE
refactor(circuit): make `UCJ.__init__` take an explicit variant instead of inferring it

### DIFF
--- a/docs/guides/lucj.rst
+++ b/docs/guides/lucj.rst
@@ -230,7 +230,7 @@ There is no need to re-implement it: an ``ffsim`` UCJ operator exposes the same 
    >>>
    >>> compressed_ansatz = UCJ(
    ...     norb,
-   ...     nelec,
+   ...     "balanced",
    ...     compressed.diag_coulomb_mats,
    ...     compressed.orbital_rotations,
    ...     final_orbital_rotation=compressed.final_orbital_rotation,

--- a/python/qiskit_fermions/circuit/library/ucj.py
+++ b/python/qiskit_fermions/circuit/library/ucj.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import numbers
 from enum import Enum
 from typing import TYPE_CHECKING, cast
 
@@ -52,22 +51,23 @@ class UCJ(FermionicGate):
     and :math:`\mathcal{U}_\text{final}` is an optional final orbital rotation. The number of terms
     :math:`L` is the number of ansatz repetitions.
 
-    This gate supports three spin variants (see :class:`.UCJ.Variant`), selected by the shapes of the
-    supplied tensors and by ``nelec`` (mirroring ffsim's
+    This gate supports three spin variants (see :class:`.UCJ.Variant`), selected explicitly by the
+    ``variant`` argument and validated against the shapes of the supplied tensors (mirroring ffsim's
     :external:class:`~ffsim.UCJOpSpinBalanced`, :external:class:`~ffsim.UCJOpSpinUnbalanced` and
     :external:class:`~ffsim.UCJOpSpinless`):
 
     - **spin-balanced** -- ``diag_coulomb_mats`` has shape ``(L, 2, norb, norb)`` (the
       ``[alpha-alpha, alpha-beta]`` matrices, with beta-beta reusing alpha-alpha and beta-alpha
       reusing alpha-beta) and ``orbital_rotations`` has shape ``(L, norb, norb)`` (one rotation
-      applied to both spin sectors).
+      applied to both spin sectors). Acts on ``2 * norb`` block-spin modes.
     - **spin-unbalanced** -- ``diag_coulomb_mats`` has shape ``(L, 3, norb, norb)`` (the
       ``[alpha-alpha, alpha-beta, beta-beta]`` matrices) and ``orbital_rotations`` has shape
-      ``(L, 2, norb, norb)`` (independent ``[alpha, beta]`` rotations).
+      ``(L, 2, norb, norb)`` (independent ``[alpha, beta]`` rotations). Acts on ``2 * norb``
+      block-spin modes.
     - **spinless** -- ``diag_coulomb_mats`` and ``orbital_rotations`` both have shape
-      ``(L, norb, norb)``. When ``nelec`` is an integer the gate acts on ``norb`` spinless modes;
-      when ``nelec`` is a pair it acts on ``2 * norb`` block-spin modes with the single diagonal
-      Coulomb matrix used for both same-spin sectors and no cross-spin interaction.
+      ``(L, norb, norb)``. Acts on ``norb`` spinless modes. The equivalent two-register operator
+      with a shared same-spin diagonal Coulomb matrix and no cross-spin interaction is expressible
+      via the ``"balanced"`` variant with its alpha-beta block set to zero.
 
     .. note::
        This gate builds the ansatz from *exact* tensors. To use ffsim's optimized ("compressed")
@@ -85,9 +85,8 @@ class UCJ(FermionicGate):
 
         Mirrors ffsim's three UCJ operator flavors:
         :external:class:`~ffsim.UCJOpSpinBalanced`, :external:class:`~ffsim.UCJOpSpinUnbalanced`, and
-        :external:class:`~ffsim.UCJOpSpinless`. The variant is inferred from the supplied tensor
-        shapes (and cross-checked against ``nelec``); its string value is accepted by
-        :meth:`.UCJ.from_t_amplitudes`.
+        :external:class:`~ffsim.UCJOpSpinless`. Passed explicitly to :meth:`.UCJ.__init__` (or its
+        string value) and validated against the supplied tensor shapes.
         """
 
         SPINLESS = "spinless"
@@ -97,7 +96,7 @@ class UCJ(FermionicGate):
     def __init__(
         self,
         norb: int,
-        nelec: int | tuple[int, int],
+        variant: UCJ.Variant | str,
         diag_coulomb_mats: np.ndarray,
         orbital_rotations: np.ndarray,
         *,
@@ -107,9 +106,9 @@ class UCJ(FermionicGate):
 
         Args:
             norb: the number of spatial orbitals.
-            nelec: either a single integer for a spinless system, or a pair of integers storing the
-                numbers of spin alpha and spin beta fermions. Together with the tensor shapes this
-                selects the spin variant (see the class docstring).
+            variant: the spin variant, a :class:`.UCJ.Variant` (or its string value ``"balanced"``,
+                ``"unbalanced"``, or ``"spinless"``). Determines the number of modes this gate acts
+                on (see the class docstring) and the expected tensor shapes.
             diag_coulomb_mats: the diagonal Coulomb matrices, of shape ``(L, 2, norb, norb)``
                 (spin-balanced), ``(L, 3, norb, norb)`` (spin-unbalanced), or ``(L, norb, norb)``
                 (spinless), where ``L`` is the number of ansatz repetitions.
@@ -119,18 +118,18 @@ class UCJ(FermionicGate):
                 (spin-balanced or spinless) or ``(2, norb, norb)`` (spin-unbalanced).
 
         Raises:
-            ValueError: if the tensor shapes are inconsistent with each other, with ``norb``, or
-                with ``nelec``.
+            ValueError: if ``variant`` is not recognized, or if the tensor shapes are inconsistent
+                with each other, with ``norb``, or with ``variant``.
         """
-        # normalize a numpy integer (e.g. ``np.int64``) to a plain ``int`` so the spinless sector is
-        # classified correctly here and downstream (ffsim's kernels classify with ``isinstance(int)``)
-        if isinstance(nelec, numbers.Integral):
-            nelec = int(nelec)
+        try:
+            variant = UCJ.Variant(variant)
+        except ValueError:
+            raise ValueError(
+                f"Unknown UCJ variant {variant!r}; expected 'balanced', 'unbalanced', or 'spinless'."
+            ) from None
 
         self.norb = norb
         """The number of spatial orbitals."""
-        self.nelec = nelec
-        """The number of electrons (spinless) or the ``(n_alpha, n_beta)`` pair (spinful)."""
         self.diag_coulomb_mats = self._to_real_diag_coulomb_mats(diag_coulomb_mats)
         """The diagonal Coulomb matrices defining each ansatz repetition."""
         self.orbital_rotations = np.asarray(orbital_rotations, dtype=complex)
@@ -142,22 +141,11 @@ class UCJ(FermionicGate):
         )
         """The optional final orbital rotation."""
 
-        self._variant = self._infer_variant(norb)
-        num_modes = norb if self._spinless else 2 * norb
+        self._variant = variant
+        self._validate_shapes(norb)
+        num_modes = norb if self._variant is UCJ.Variant.SPINLESS else 2 * norb
 
         super().__init__("UCJ", num_modes, [])
-
-    @property
-    def _spinless(self) -> bool:
-        """Whether the *sector* is spinless (integer ``nelec``, acting on ``norb`` modes).
-
-        This is distinct from :attr:`Variant.SPINLESS` (which is about the tensor *shapes*): a
-        spinless-variant operator may still be applied to a spinful ``(n_alpha, n_beta)`` sector, in
-        which case it acts on ``2 * norb`` block-spin modes. Mode count, the Hartree-Fock reference,
-        and the per-spin gate placement all key off the sector, not the variant.
-        """
-        # ``nelec`` is normalized to a plain ``int`` for the spinless case in ``__init__``.
-        return isinstance(self.nelec, int)
 
     @classmethod
     def from_t_amplitudes(
@@ -247,7 +235,7 @@ class UCJ(FermionicGate):
 
         return cls(
             norb,
-            nelec,
+            variant,
             diag_coulomb_mats,
             orbital_rotations,
             final_orbital_rotation=final_orbital_rotation,
@@ -443,54 +431,33 @@ class UCJ(FermionicGate):
                 mask[cols, rows] = True
         mats *= mask
 
-    def _infer_variant(self, norb: int) -> UCJ.Variant:
-        """Infers the spin variant from the tensor shapes and validates them against ``norb``."""
+    def _validate_shapes(self, norb: int) -> None:
+        """Validates the tensor shapes against ``norb`` and ``self._variant``."""
         dc = self.diag_coulomb_mats
         rot = self.orbital_rotations
-        expected_dc: tuple[int, ...]
-        expected_rot: tuple[int, ...]
+        variant = self._variant
 
-        if dc.ndim == 3 and rot.ndim == 3:
-            variant = UCJ.Variant.SPINLESS
-            expected_dc = (dc.shape[0], norb, norb)
-            expected_rot = (rot.shape[0], norb, norb)
-        elif dc.ndim == 4 and dc.shape[1] == 2 and rot.ndim == 3:
-            variant = UCJ.Variant.BALANCED
+        if variant is UCJ.Variant.SPINLESS:
+            expected_dc: tuple[int, ...] = (dc.shape[0], norb, norb)
+            expected_rot: tuple[int, ...] = (rot.shape[0], norb, norb)
+        elif variant is UCJ.Variant.BALANCED:
             expected_dc = (dc.shape[0], 2, norb, norb)
             expected_rot = (rot.shape[0], norb, norb)
-        elif dc.ndim == 4 and dc.shape[1] == 3 and rot.ndim == 4 and rot.shape[1] == 2:
-            variant = UCJ.Variant.UNBALANCED
+        else:  # UNBALANCED
             expected_dc = (dc.shape[0], 3, norb, norb)
             expected_rot = (rot.shape[0], 2, norb, norb)
-        else:
-            raise ValueError(
-                "Could not infer the UCJ spin variant from the tensor shapes "
-                f"diag_coulomb_mats={dc.shape} and orbital_rotations={rot.shape}. Expected "
-                "(L, 2, norb, norb)/(L, norb, norb) [balanced], (L, 3, norb, norb)/"
-                "(L, 2, norb, norb) [unbalanced], or (L, norb, norb)/(L, norb, norb) [spinless]."
-            )
 
         if dc.shape != expected_dc or rot.shape != expected_rot:
             raise ValueError(
                 f"Inconsistent {variant.value} UCJ tensor shapes for norb={norb}: got "
-                f"diag_coulomb_mats={dc.shape}, orbital_rotations={rot.shape}."
+                f"diag_coulomb_mats={dc.shape}, orbital_rotations={rot.shape}; expected "
+                f"diag_coulomb_mats={expected_dc}, orbital_rotations={expected_rot}."
             )
         if dc.shape[0] != rot.shape[0]:
             raise ValueError(
                 f"diag_coulomb_mats and orbital_rotations must have the same number of repetitions; "
                 f"got {dc.shape[0]} and {rot.shape[0]}."
             )
-        # ``nelec`` is normalized to a plain ``int`` for the spinless case, so an integer nelec means
-        # the caller intends the spinless variant; cross-check it against the shape-inferred variant.
-        if isinstance(self.nelec, int) and variant is not UCJ.Variant.SPINLESS:
-            raise ValueError(
-                f"An integer nelec selects the spinless variant, but the tensor shapes imply the "
-                f"{variant.value} variant."
-            )
-        # note: the converse (a spinless operator applied to a spinful sector) is allowed and needs
-        # no branch here -- see the class docstring's spinless variant.
-
-        return variant
 
     @staticmethod
     def _to_real_diag_coulomb_mats(diag_coulomb_mats: np.ndarray) -> np.ndarray:
@@ -568,12 +535,12 @@ class UCJ(FermionicGate):
     def _append_orbital_rotation(self, definition, rotation: np.ndarray) -> None:
         """Appends an orbital rotation, respecting the spin variant's per-spin placement.
 
-        Spinless with an integer ``nelec`` places a single rotation on all ``norb`` modes.
-        Otherwise the block-spin register is split into alpha modes ``0..norb`` and beta modes
-        ``norb..2*norb``: the balanced/spinless case applies the same rotation to both halves, while
-        the unbalanced case applies the independent ``[alpha, beta]`` rotations.
+        The spinless variant places a single rotation on all ``norb`` modes. Otherwise the
+        block-spin register is split into alpha modes ``0..norb`` and beta modes ``norb..2*norb``:
+        the balanced case applies the same rotation to both halves, while the unbalanced case
+        applies the independent ``[alpha, beta]`` rotations.
         """
-        if self._spinless:
+        if self._variant is UCJ.Variant.SPINLESS:
             definition.append(OrbitalRotation(rotation), definition.modes)
             return
 
@@ -610,11 +577,12 @@ class UCJ(FermionicGate):
         coloring of the interaction graph (see :meth:`_term_group`), assigned on the fly.
         """
         norb = self.norb
-        num_modes = norb if self._spinless else 2 * norb
+        is_spinless = self._variant is UCJ.Variant.SPINLESS
+        num_modes = norb if is_spinless else 2 * norb
         mat_aa, mat_ab, mat_bb = self._resolve_diag_coulomb_blocks(diag_coulomb_mat)
 
         # a true spinless system has only the aa block on the norb spinless modes
-        if self._spinless:
+        if is_spinless:
             blocks = {(0, 0): mat_aa}
         else:
             blocks = {(0, 0): mat_aa, (0, 1): mat_ab, (1, 0): mat_ab.T, (1, 1): mat_bb}

--- a/tests/python/circuit/library/test_ucj.py
+++ b/tests/python/circuit/library/test_ucj.py
@@ -31,17 +31,17 @@ def _balanced_tensors(norb, n_reps, *, seed):
     return mats, rotations
 
 
-def test_ucj_infers_balanced_variant():
-    """A ``(L, 2, norb, norb)`` diag-Coulomb tensor selects the balanced variant and 2*norb modes."""
+def test_ucj_balanced_variant():
+    """A ``(L, 2, norb, norb)`` diag-Coulomb tensor is accepted for the balanced variant."""
     norb = 3
     mats, rotations = _balanced_tensors(norb, 2, seed=0)
-    gate = UCJ(norb, (1, 1), mats, rotations)
+    gate = UCJ(norb, "balanced", mats, rotations)
     assert gate.num_modes == 2 * norb
     assert gate._variant is UCJ.Variant.BALANCED
 
 
-def test_ucj_infers_unbalanced_variant():
-    """A ``(L, 3, norb, norb)`` diag-Coulomb tensor with paired rotations selects unbalanced."""
+def test_ucj_unbalanced_variant():
+    """A ``(L, 3, norb, norb)`` diag-Coulomb tensor with paired rotations is accepted as unbalanced."""
     norb = 3
     n_reps = 2
     rng = np.random.default_rng(1)
@@ -52,23 +52,29 @@ def test_ucj_infers_unbalanced_variant():
             for k in range(n_reps)
         ]
     )
-    gate = UCJ(norb, (2, 1), mats, rotations)
+    gate = UCJ(norb, "unbalanced", mats, rotations)
     assert gate.num_modes == 2 * norb
     assert gate._variant is UCJ.Variant.UNBALANCED
 
 
-def test_ucj_infers_spinless_variant():
-    """A ``(L, norb, norb)`` diag-Coulomb tensor selects the spinless variant."""
+def test_ucj_spinless_variant():
+    """A ``(L, norb, norb)`` diag-Coulomb tensor is accepted for the spinless variant (norb modes)."""
     norb = 3
     n_reps = 2
     rng = np.random.default_rng(2)
     mats = rng.standard_normal((n_reps, norb, norb))
     rotations = np.stack([random_unitary(norb, seed=30 + k) for k in range(n_reps)])
-    # spinful nelec -> 2*norb modes; integer nelec -> norb modes
-    assert UCJ(norb, (1, 1), mats, rotations).num_modes == 2 * norb
-    spinless = UCJ(norb, 2, mats, rotations)
+    spinless = UCJ(norb, "spinless", mats, rotations)
     assert spinless.num_modes == norb
     assert spinless._variant is UCJ.Variant.SPINLESS
+
+
+def test_ucj_rejects_unknown_variant():
+    """An unrecognized variant string raises a ValueError naming the accepted variants."""
+    norb = 3
+    mats, rotations = _balanced_tensors(norb, 2, seed=0)
+    with pytest.raises(ValueError, match="Unknown UCJ variant"):
+        UCJ(norb, "nonsense", mats, rotations)
 
 
 def test_ucj_rejects_inconsistent_shapes():
@@ -76,15 +82,15 @@ def test_ucj_rejects_inconsistent_shapes():
     norb = 3
     mats, rotations = _balanced_tensors(norb, 2, seed=3)
     with pytest.raises(ValueError, match="Inconsistent"):
-        UCJ(norb + 1, (1, 1), mats, rotations)  # norb mismatch
+        UCJ(norb + 1, "balanced", mats, rotations)  # norb mismatch
 
 
-def test_ucj_rejects_integer_nelec_for_balanced_tensors():
-    """An integer nelec with balanced-shaped tensors is rejected (spinless variant only)."""
+def test_ucj_rejects_balanced_shaped_tensors_for_spinless_variant():
+    """Balanced-shaped tensors passed with variant='spinless' are rejected as inconsistent."""
     norb = 3
     mats, rotations = _balanced_tensors(norb, 2, seed=4)
-    with pytest.raises(ValueError, match="spinless variant"):
-        UCJ(norb, 2, mats, rotations)
+    with pytest.raises(ValueError, match="Inconsistent"):
+        UCJ(norb, "spinless", mats, rotations)
 
 
 def test_ucj_define_gate_sequence():
@@ -97,7 +103,7 @@ def test_ucj_define_gate_sequence():
     n_reps = 2
     mats, rotations = _balanced_tensors(norb, n_reps, seed=7)
     final = random_unitary(norb, seed=99)
-    gate = UCJ(norb, (1, 1), mats, rotations, final_orbital_rotation=final)
+    gate = UCJ(norb, "balanced", mats, rotations, final_orbital_rotation=final)
 
     circ = FermionicCircuit(gate.num_modes)
     circ.append(gate, circ.modes)
@@ -109,15 +115,15 @@ def test_ucj_define_gate_sequence():
     assert ops["OrbitalRotation"] == 4 * n_reps + 2
 
 
-def test_ucj_spinless_true_uses_norb_modes():
-    """A true spinless system (integer nelec) acts on norb modes with only same-spin terms."""
+def test_ucj_spinless_uses_norb_modes():
+    """A spinless variant acts on norb modes with only same-spin terms."""
     norb = 3
     n_reps = 1
     rng = np.random.default_rng(8)
     mats = rng.standard_normal((n_reps, norb, norb))
     mats = mats + mats.transpose(0, 2, 1)
     rotations = np.stack([random_unitary(norb, seed=40)])
-    gate = UCJ(norb, 2, mats, rotations)
+    gate = UCJ(norb, "spinless", mats, rotations)
     circ = FermionicCircuit(gate.num_modes)
     circ.append(gate, circ.modes)
     ops = circ.decompose().count_ops()
@@ -131,7 +137,7 @@ def test_ucj_accepts_complex_diag_coulomb_with_zero_imaginary_part():
     """Complex-typed diag-Coulomb mats with a negligible imaginary part are coerced to real."""
     norb = 3
     mats, rotations = _balanced_tensors(norb, 1, seed=11)
-    gate = UCJ(norb, (1, 1), mats.astype(complex), rotations)
+    gate = UCJ(norb, "balanced", mats.astype(complex), rotations)
     assert gate.diag_coulomb_mats.dtype == np.float64
     np.testing.assert_allclose(gate.diag_coulomb_mats, mats)
 
@@ -143,7 +149,7 @@ def test_ucj_rejects_complex_diag_coulomb_with_nonzero_imaginary_part():
     complex_mats = mats.astype(complex)
     complex_mats[0, 0, 0, 1] += 0.5j
     with pytest.raises(ValueError, match="imaginary part"):
-        UCJ(norb, (1, 1), complex_mats, rotations)
+        UCJ(norb, "balanced", complex_mats, rotations)
 
 
 def test_ucj_from_t_amplitudes_rejects_tuple_n_reps_for_balanced():
@@ -244,16 +250,6 @@ def test_ucj_from_t_amplitudes_unbalanced_int_n_reps_pads():
             np.testing.assert_allclose(rot, np.eye(norb), atol=1e-12)
 
 
-def test_ucj_rejects_uninferable_tensor_shapes():
-    """Tensor shapes matching no variant raise a ValueError explaining the expected layouts."""
-    norb = 3
-    # a 4-D diag-Coulomb tensor with an unrecognized second axis (neither 2 nor 3)
-    mats = np.zeros((1, 4, norb, norb))
-    rotations = np.zeros((1, norb, norb))
-    with pytest.raises(ValueError, match="Could not infer the UCJ spin variant"):
-        UCJ(norb, (1, 1), mats, rotations)
-
-
 def test_ucj_rejects_mismatched_repetition_counts():
     """Differing repetition counts between the diag-Coulomb and rotation tensors are rejected."""
     norb = 3
@@ -262,7 +258,7 @@ def test_ucj_rejects_mismatched_repetition_counts():
         :1
     ]  # 1 rep
     with pytest.raises(ValueError, match="same number of repetitions"):
-        UCJ(norb, (1, 1), mats, rotations)
+        UCJ(norb, "balanced", mats, rotations)
 
 
 def test_orbital_rotation_from_t1_amplitudes_is_unitary():
@@ -284,7 +280,7 @@ def _reference_diag_coulomb_terms(gate, diag_coulomb_mat):
     """The ungrouped ``{term: coeff}`` reference for one repetition's diagonal Coulomb operator."""
     norb = gate.norb
     mat_aa, mat_ab, mat_bb = gate._resolve_diag_coulomb_blocks(diag_coulomb_mat)
-    if gate._spinless:
+    if gate._variant is UCJ.Variant.SPINLESS:
         blocks = {(0, 0): mat_aa}
     else:
         blocks = {(0, 0): mat_aa, (0, 1): mat_ab, (1, 0): mat_ab.T, (1, 1): mat_bb}
@@ -307,7 +303,7 @@ def test_diag_coulomb_grouping_preserves_operator(norb):
     from qiskit_fermions.operators import FermionOperator
 
     mats, rotations = _balanced_tensors(norb, 1, seed=100 + norb)
-    gate = UCJ(norb, (1, 1), mats, rotations)
+    gate = UCJ(norb, "balanced", mats, rotations)
     operator = gate._diag_coulomb_operator(gate.diag_coulomb_mats[0])
 
     reference = FermionOperator.from_dict(
@@ -317,14 +313,13 @@ def test_diag_coulomb_grouping_preserves_operator(norb):
 
 
 @pytest.mark.parametrize(
-    ("variant", "nelec", "norb"),
+    ("variant", "norb"),
     [
-        ("balanced", (1, 1), 4),
-        ("spinless", 2, 4),  # spinful sector: 2*norb block-spin modes
-        ("spinless", 3, 5),  # true spinless sector: norb modes
+        ("balanced", 4),
+        ("spinless", 5),
     ],
 )
-def test_diag_coulomb_groups_have_disjoint_support(variant, nelec, norb):
+def test_diag_coulomb_groups_have_disjoint_support(variant, norb):
     """Every diagonal Coulomb group's terms act on mutually disjoint modes (one parallel layer)."""
     rng = np.random.default_rng(hash((variant, norb)) % (2**32))
     if variant == "balanced":
@@ -334,7 +329,7 @@ def test_diag_coulomb_groups_have_disjoint_support(variant, nelec, norb):
         mats = rng.standard_normal((1, norb, norb))
         mats = mats + mats.transpose(0, 2, 1)
     rotations = np.stack([random_unitary(norb, seed=7)])
-    gate = UCJ(norb, nelec, mats, rotations)
+    gate = UCJ(norb, variant, mats, rotations)
 
     operator = gate._diag_coulomb_operator(gate.diag_coulomb_mats[0])
     assert operator.groups is not None
@@ -346,17 +341,17 @@ def test_diag_coulomb_groups_have_disjoint_support(variant, nelec, norb):
 
 
 @pytest.mark.parametrize(
-    ("variant", "nelec", "norb"),
+    ("variant", "norb"),
     [
-        ("balanced", (1, 1), 3),  # spinful sector: even num_modes = 2*norb
-        ("balanced", (1, 1), 4),
-        ("balanced", (1, 1), 5),
-        ("spinless", 3, 3),  # true spinless sector: odd num_modes = norb (odd)
-        ("spinless", 4, 4),  # true spinless sector: even num_modes = norb (even)
-        ("spinless", 5, 5),  # true spinless sector: odd num_modes = norb (odd)
+        ("balanced", 3),  # spinful sector: even num_modes = 2*norb
+        ("balanced", 4),
+        ("balanced", 5),
+        ("spinless", 3),  # odd num_modes = norb (odd)
+        ("spinless", 4),  # even num_modes = norb (even)
+        ("spinless", 5),  # odd num_modes = norb (odd)
     ],
 )
-def test_diag_coulomb_group_count_is_optimal(variant, nelec, norb):
+def test_diag_coulomb_group_count_is_optimal(variant, norb):
     """The group (layer) count matches the provable optimum of the closed-form circle coloring.
 
     Every term sharing a mode must land in a distinct group, so the count is bounded below by the
@@ -372,7 +367,7 @@ def test_diag_coulomb_group_count_is_optimal(variant, nelec, norb):
         mats = rng.standard_normal((1, norb, norb))
         mats = mats + mats.transpose(0, 2, 1)
     rotations = np.stack([random_unitary(norb, seed=7)])
-    gate = UCJ(norb, nelec, mats, rotations)
+    gate = UCJ(norb, variant, mats, rotations)
     operator = gate._diag_coulomb_operator(gate.diag_coulomb_mats[0])
 
     degree: dict[int, int] = {}

--- a/tests/python/circuit/library/test_ucj_apply_unitary.py
+++ b/tests/python/circuit/library/test_ucj_apply_unitary.py
@@ -28,7 +28,7 @@ from qiskit_fermions.circuit.library import UCJ
 ffsim = pytest.importorskip("ffsim")
 
 
-def _apply_ours(ucj_op, norb, nelec, reference):
+def _apply_ours(ucj_op, norb, nelec, reference, variant):
     """Rebuilds an ffsim UCJ operator with our UCJ gate and applies it to ``reference``.
 
     Applies the :class:`.UCJ` gate itself (via ffsim's ``SupportsApplyUnitary`` protocol), so these
@@ -37,7 +37,7 @@ def _apply_ours(ucj_op, norb, nelec, reference):
     """
     gate = UCJ(
         norb,
-        nelec,
+        variant,
         ucj_op.diag_coulomb_mats,
         ucj_op.orbital_rotations,
         final_orbital_rotation=ucj_op.final_orbital_rotation,
@@ -55,7 +55,7 @@ def test_ucj_spin_balanced_matches_ffsim():
         )
         reference = ffsim.hartree_fock_state(norb, nelec)
         expected = ffsim.apply_unitary(reference, ucj_op, norb=norb, nelec=nelec)
-        result = _apply_ours(ucj_op, norb, nelec, reference)
+        result = _apply_ours(ucj_op, norb, nelec, reference, "balanced")
         np.testing.assert_allclose(result, expected, atol=1e-10)
 
 
@@ -69,18 +69,35 @@ def test_ucj_spin_unbalanced_matches_ffsim():
         )
         reference = ffsim.hartree_fock_state(norb, nelec)
         expected = ffsim.apply_unitary(reference, ucj_op, norb=norb, nelec=nelec)
-        result = _apply_ours(ucj_op, norb, nelec, reference)
+        result = _apply_ours(ucj_op, norb, nelec, reference, "unbalanced")
         np.testing.assert_allclose(result, expected, atol=1e-10)
 
 
-def test_ucj_spinless_on_spinful_sector_matches_ffsim():
-    """The spinless UCJ gate applied to a spinful sector matches ffsim."""
+def test_ucj_spinless_shortcut_via_zeroed_balanced_ab_block_matches_ffsim():
+    """A spinless ffsim operator run on a spinful sector is reproduced via a zeroed-ab balanced gate.
+
+    ``Variant.SPINLESS`` now always means a true 1-register spinless gate (see the class docstring),
+    so the two-register/shared-matrix/no-cross-spin shortcut ffsim's ``UCJOpSpinless`` supports for a
+    tuple ``nelec`` is no longer directly constructible. This confirms the same physics remains fully
+    expressible via ``Variant.BALANCED`` with its alpha-beta block zeroed (aa == bb == the spinless
+    matrix, no ab term) -- the equivalence this design decision relies on.
+    """
     norb = 4
     nelec = (2, 2)
     ucj_op = ffsim.random.random_ucj_op_spinless(norb, n_reps=2, seed=55)
     reference = ffsim.hartree_fock_state(norb, nelec)
     expected = ffsim.apply_unitary(reference, ucj_op, norb=norb, nelec=nelec)
-    result = _apply_ours(ucj_op, norb, nelec, reference)
+
+    zero_ab = np.zeros_like(ucj_op.diag_coulomb_mats)
+    balanced_diag_coulomb_mats = np.stack([ucj_op.diag_coulomb_mats, zero_ab], axis=1)
+    gate = UCJ(
+        norb,
+        "balanced",
+        balanced_diag_coulomb_mats,
+        ucj_op.orbital_rotations,
+        final_orbital_rotation=ucj_op.final_orbital_rotation,
+    )
+    result = ffsim.apply_unitary(reference, gate, norb=norb, nelec=nelec)
     np.testing.assert_allclose(result, expected, atol=1e-10)
 
 
@@ -93,34 +110,8 @@ def test_ucj_spinless_on_spinless_sector_matches_ffsim():
     )
     reference = ffsim.slater_determinant(norb, list(range(nelec)))
     expected = ffsim.apply_unitary(reference, ucj_op, norb=norb, nelec=nelec)
-    result = _apply_ours(ucj_op, norb, nelec, reference)
+    result = _apply_ours(ucj_op, norb, nelec, reference, "spinless")
     np.testing.assert_allclose(result, expected, atol=1e-10)
-
-
-def test_ucj_gate_accepts_numpy_int_nelec():
-    """A UCJ built with a numpy-integer (e.g. ``np.int64``) spinless nelec infers the spinless variant.
-
-    A numpy scalar is not a Python ``int``, so a naive ``isinstance(nelec, int)`` check at
-    construction time would infer the spinful variant and build the wrong (aa/ab/bb) diagonal-Coulomb
-    layer. This is a UCJ-specific *construction*-time concern (variant inference), distinct from the
-    shared apply-path ``_normalize_nelec`` covered by the other gates' apply tests: the ``np.int64``
-    build must select the same spinless variant as the plain-``int`` build.
-    """
-    norb = 4
-    ucj_op = ffsim.random.random_ucj_op_spinless(
-        norb, n_reps=2, with_final_orbital_rotation=True, seed=5
-    )
-
-    def build(nelec):
-        return UCJ(
-            norb,
-            nelec,
-            ucj_op.diag_coulomb_mats,
-            ucj_op.orbital_rotations,
-            final_orbital_rotation=ucj_op.final_orbital_rotation,
-        )
-
-    assert build(2)._variant is build(np.int64(2))._variant is UCJ.Variant.SPINLESS
 
 
 def test_ucj_gate_apply_unitary_matches_ffsim():
@@ -139,7 +130,7 @@ def test_ucj_gate_apply_unitary_matches_ffsim():
 
     gate = UCJ(
         norb,
-        nelec,
+        "balanced",
         ucj_op.diag_coulomb_mats,
         ucj_op.orbital_rotations,
         final_orbital_rotation=ucj_op.final_orbital_rotation,
@@ -156,7 +147,7 @@ def test_ucj_gate_through_circuit_matches_ffsim():
     reference = ffsim.hartree_fock_state(norb, nelec)
     expected = ffsim.apply_unitary(reference, ucj_op, norb=norb, nelec=nelec)
 
-    gate = UCJ(norb, nelec, ucj_op.diag_coulomb_mats, ucj_op.orbital_rotations)
+    gate = UCJ(norb, "balanced", ucj_op.diag_coulomb_mats, ucj_op.orbital_rotations)
     circ = FermionicCircuit(2 * norb)
     circ.append(gate, circ.modes)
     result = ffsim.apply_unitary(reference, circ, norb=norb, nelec=nelec)
@@ -210,7 +201,7 @@ def test_ucj_gate_subset_placement_matches_global_embedding():
     # applied to the same reference.
     gate = UCJ(
         norb_local,
-        nelec,
+        "spinless",
         ucj_op.diag_coulomb_mats,
         ucj_op.orbital_rotations,
         final_orbital_rotation=ucj_op.final_orbital_rotation,
@@ -245,7 +236,7 @@ def test_ucj_single_rep_matches_hand_composed_ffsim_primitives():
     )
     expected = ffsim.apply_orbital_rotation(vec, orbital_rotation, norb=norb, nelec=nelec)
 
-    result = _apply_ours(ucj_op, norb, nelec, reference)
+    result = _apply_ours(ucj_op, norb, nelec, reference, "balanced")
     np.testing.assert_allclose(result, expected, atol=1e-10)
 
 
@@ -284,24 +275,28 @@ def test_ucj_from_t_amplitudes_balanced_matches_ffsim():
 
 
 def test_ucj_from_t_amplitudes_spinless_matches_ffsim():
-    """UCJ.from_t_amplitudes (spinless) matches ffsim's UCJOpSpinless.from_t_amplitudes."""
-    pyscf = pytest.importorskip("pyscf")
-    import pyscf.cc as _pyscf_cc
+    """UCJ.from_t_amplitudes (spinless) matches ffsim's UCJOpSpinless.from_t_amplitudes.
 
-    mol = pyscf.gto.Mole()
-    mol.build(
-        atom=[["H", (0, 0, 0)], ["H", (0, 0, 0.74)]], basis="6-31g", symmetry="Dooh", verbose=0
-    )
-    scf = pyscf.scf.RHF(mol).run()
-    mol_data = ffsim.MolecularData.from_scf(scf)
-    norb, nelec = mol_data.norb, mol_data.nelec
-    ccsd = _pyscf_cc.CCSD(scf).run()
+    ``variant="spinless"`` now always means a true 1-register spinless gate (see the class
+    docstring), so this exercises a genuinely spinless (integer nelec) sector rather than ffsim's
+    dropped two-register/shared-matrix shortcut for a spinful tuple nelec -- that equivalence is
+    covered separately by
+    ``test_ucj_spinless_shortcut_via_zeroed_balanced_ab_block_matches_ffsim``.
+    """
+    norb = 4
+    nelec = 3
+    rng = np.random.default_rng(99)
+    nocc, nvrt = nelec, norb - nelec
+    t2 = rng.standard_normal((nocc, nocc, nvrt, nvrt))
+    t2 = t2 - t2.transpose(1, 0, 2, 3)
+    t2 = t2 - t2.transpose(0, 1, 3, 2)
+    t1 = rng.standard_normal((nocc, nvrt))
 
-    reference = ffsim.hartree_fock_state(norb, nelec)
-    ucj_op = ffsim.UCJOpSpinless.from_t_amplitudes(ccsd.t2, t1=ccsd.t1)
+    reference = ffsim.slater_determinant(norb, list(range(nelec)))
+    ucj_op = ffsim.UCJOpSpinless.from_t_amplitudes(t2, t1=t1)
     expected = ffsim.apply_unitary(reference, ucj_op, norb=norb, nelec=nelec)
 
-    gate = UCJ.from_t_amplitudes(nelec, ccsd.t2, t1=ccsd.t1, variant="spinless")
+    gate = UCJ.from_t_amplitudes(nelec, t2, t1=t1, variant="spinless")
     result = ffsim.apply_unitary(reference, gate, norb=norb, nelec=nelec)
     np.testing.assert_allclose(result, expected, atol=1e-10)
 

--- a/tests/python/transpiler/passes/test_merge_initialize_rotation.py
+++ b/tests/python/transpiler/passes/test_merge_initialize_rotation.py
@@ -326,7 +326,7 @@ def test_merge_ucj_workflow():
     norb, nelec, n_reps = 2, (1, 1), 1
     diag_coulomb_mats = np.zeros((n_reps, 2, norb, norb))
     orbital_rotations = np.stack([random_unitary(norb, seed=5) for _ in range(n_reps)])
-    ucj = UCJ(norb, nelec, diag_coulomb_mats, orbital_rotations)
+    ucj = UCJ(norb, "balanced", diag_coulomb_mats, orbital_rotations)
 
     circ = FermionicCircuit(2 * norb)
     circ.append(InitializeModes.from_hartree_fock(norb, nelec), circ.modes)


### PR DESCRIPTION
`nelec` was stored on `UCJ` only to infer the spin variant from its type (int vs. tuple) and cross-check it against the tensor shapes, never read for its actual particle-count value at construction time. This made `__init__` inconsistent with `from_t_amplitudes`, which already takes `variant` explicitly, and forced a shape-sniffing inference path (`_infer_variant`) that only existed because `__init__` didn't ask for the variant directly.

`__init__` now takes `variant` explicitly, mirroring `from_t_amplitudes`. `nelec` is dropped from `self` entirely; it remains purely a call-time argument to `_apply_unitary_placed_`/`_apply_unitary_`, which already received it as a parameter.

This also drops the implicit "2-register spinless shortcut" (running spinless-shaped tensors on a spinful sector by passing a tuple `nelec`), which was never a deliberate feature -- just a side effect of keying off `nelec`'s type -- and cannot be offered faithfully by a `Gate` with a fixed `num_modes` anyway. The same physics remains fully expressible via `Variant.BALANCED` with a zeroed alpha-beta block, which is now both documented and covered by a dedicated equivalence test. Reworking that test surfaced a latent test bug: `test_ucj_from_t_amplitudes_spinless_matches_ffsim` was relying on this exact shortcut with a spinful `nelec`, so it now exercises a genuinely spinless system instead.