### PR TITLE
refactor(circuit): remove `norb` from `UCJ.__init__`

### DIFF
--- a/docs/guides/lucj.rst
+++ b/docs/guides/lucj.rst
@@ -229,7 +229,6 @@ There is no need to re-implement it: an ``ffsim`` UCJ operator exposes the same 
    ... )
    >>>
    >>> compressed_ansatz = UCJ(
-   ...     norb,
    ...     "balanced",
    ...     compressed.diag_coulomb_mats,
    ...     compressed.orbital_rotations,

--- a/python/qiskit_fermions/circuit/library/ucj.py
+++ b/python/qiskit_fermions/circuit/library/ucj.py
@@ -62,7 +62,8 @@ class UCJ(FermionicGate):
     This gate supports three spin variants (see :class:`.UCJ.Variant`), selected explicitly by the
     ``variant`` argument and validated against the shapes of the supplied tensors (mirroring ffsim's
     :external:class:`~ffsim.UCJOpSpinBalanced`, :external:class:`~ffsim.UCJOpSpinUnbalanced` and
-    :external:class:`~ffsim.UCJOpSpinless`):
+    :external:class:`~ffsim.UCJOpSpinless`). The number of spatial orbitals is *not* a constructor
+    argument -- it is inferred from those same tensor shapes (see :attr:`.norb`):
 
     - **spin-balanced** -- ``diag_coulomb_mats`` has shape ``(L, 2, norb, norb)`` (the
       ``[alpha-alpha, alpha-beta]`` matrices, with beta-beta reusing alpha-alpha and beta-alpha
@@ -103,7 +104,6 @@ class UCJ(FermionicGate):
 
     def __init__(
         self,
-        norb: int,
         variant: UCJ.Variant | str,
         diag_coulomb_mats: np.ndarray,
         orbital_rotations: np.ndarray,
@@ -112,8 +112,10 @@ class UCJ(FermionicGate):
     ) -> None:
         r"""Initializing an instance of this gate can be done with the arguments listed below.
 
+        The number of spatial orbitals is inferred from the supplied tensor shapes (see
+        :attr:`.norb`).
+
         Args:
-            norb: the number of spatial orbitals.
             variant: the spin variant, a :class:`.UCJ.Variant` (or its string value ``"balanced"``,
                 ``"unbalanced"``, or ``"spinless"``). Determines the number of modes this gate acts
                 on (see the class docstring) and the expected tensor shapes.
@@ -127,12 +129,10 @@ class UCJ(FermionicGate):
 
         Raises:
             ValueError: if ``variant`` is not recognized, or if the tensor shapes are inconsistent
-                with each other, with ``norb``, or with ``variant``.
+                with each other or with ``variant``.
         """
         variant = UCJ._normalize_variant(variant)
 
-        self.norb = norb
-        """The number of spatial orbitals."""
         self.diag_coulomb_mats = self._to_real_diag_coulomb_mats(diag_coulomb_mats)
         """The diagonal Coulomb matrices defining each ansatz repetition."""
         self.orbital_rotations = np.asarray(orbital_rotations, dtype=complex)
@@ -145,7 +145,10 @@ class UCJ(FermionicGate):
         """The optional final orbital rotation."""
 
         self._variant = variant
-        self._validate_shapes(norb)
+        norb = self._validate_shapes()
+
+        self.norb = norb
+        """The number of spatial orbitals, inferred from the tensor shapes."""
         num_modes = norb if self._variant is UCJ.Variant.SPINLESS else 2 * norb
 
         super().__init__("UCJ", num_modes, [])
@@ -228,11 +231,9 @@ class UCJ(FermionicGate):
                 tol,
             )
 
-        norb = orbital_rotations.shape[-1]
         final_orbital_rotation = cls._final_rotation_from_t1(t1, variant)
 
         return cls(
-            norb,
             variant,
             diag_coulomb_mats,
             orbital_rotations,
@@ -375,7 +376,6 @@ class UCJ(FermionicGate):
             diag_coulomb_mats = diag_coulomb_mats[:, 0]
 
         return cls(
-            norb,
             variant,
             diag_coulomb_mats,
             orbital_rotations,
@@ -772,11 +772,40 @@ class UCJ(FermionicGate):
             case _:  # UNBALANCED: aa, ab, bb
                 return [(0, True), (1, False), (2, True)]
 
-    def _validate_shapes(self, norb: int) -> None:
-        """Validates the tensor shapes against ``norb`` and ``self._variant``."""
+    def _validate_shapes(self) -> int:
+        """Validates the tensor shapes against ``self._variant``, returning the implied ``norb``.
+
+        ``norb`` is inferred from the trailing axis of ``orbital_rotations``, which carries it in
+        every variant. The rank is checked first, so that trailing axis is only read once it is known
+        to mean what it should: a tensor of the wrong ``ndim`` would otherwise infer a bogus ``norb``
+        and then be "validated" against it.
+
+        Raises:
+            ValueError: if the tensor shapes are inconsistent with each other or with the variant.
+        """
         dc = self.diag_coulomb_mats
         rot = self.orbital_rotations
         variant = self._variant
+
+        # the expected rank of each tensor per variant; the exact axis sizes are checked below, once
+        # the rank makes the inferred norb meaningful
+        match variant:
+            case UCJ.Variant.SPINLESS:
+                dc_ndim, rot_ndim = 3, 3
+            case UCJ.Variant.BALANCED:
+                dc_ndim, rot_ndim = 4, 3
+            case _:  # UNBALANCED
+                dc_ndim, rot_ndim = 4, 4
+        if dc.ndim != dc_ndim or rot.ndim != rot_ndim:
+            raise ValueError(
+                f"Inconsistent {variant.value} UCJ tensor shapes: got "
+                f"diag_coulomb_mats={dc.shape} ({dc.ndim}-dimensional), "
+                f"orbital_rotations={rot.shape} ({rot.ndim}-dimensional); expected a "
+                f"{dc_ndim}-dimensional diag_coulomb_mats and a {rot_ndim}-dimensional "
+                f"orbital_rotations."
+            )
+
+        norb = int(rot.shape[-1])
 
         expected_dc: tuple[int, ...]
         expected_rot: tuple[int, ...]
@@ -793,7 +822,7 @@ class UCJ(FermionicGate):
 
         if dc.shape != expected_dc or rot.shape != expected_rot:
             raise ValueError(
-                f"Inconsistent {variant.value} UCJ tensor shapes for norb={norb}: got "
+                f"Inconsistent {variant.value} UCJ tensor shapes for the inferred norb={norb}: got "
                 f"diag_coulomb_mats={dc.shape}, orbital_rotations={rot.shape}; expected "
                 f"diag_coulomb_mats={expected_dc}, orbital_rotations={expected_rot}."
             )
@@ -802,6 +831,8 @@ class UCJ(FermionicGate):
                 f"diag_coulomb_mats and orbital_rotations must have the same number of repetitions; "
                 f"got {dc.shape[0]} and {rot.shape[0]}."
             )
+
+        return norb
 
     @staticmethod
     def _to_real_diag_coulomb_mats(diag_coulomb_mats: np.ndarray) -> np.ndarray:

--- a/tests/python/circuit/library/test_ucj.py
+++ b/tests/python/circuit/library/test_ucj.py
@@ -35,7 +35,7 @@ def test_ucj_balanced_variant():
     """A ``(L, 2, norb, norb)`` diag-Coulomb tensor is accepted for the balanced variant."""
     norb = 3
     mats, rotations = _balanced_tensors(norb, 2, seed=0)
-    gate = UCJ(norb, "balanced", mats, rotations)
+    gate = UCJ("balanced", mats, rotations)
     assert gate.num_modes == 2 * norb
     assert gate._variant is UCJ.Variant.BALANCED
 
@@ -52,7 +52,7 @@ def test_ucj_unbalanced_variant():
             for k in range(n_reps)
         ]
     )
-    gate = UCJ(norb, "unbalanced", mats, rotations)
+    gate = UCJ("unbalanced", mats, rotations)
     assert gate.num_modes == 2 * norb
     assert gate._variant is UCJ.Variant.UNBALANCED
 
@@ -64,7 +64,7 @@ def test_ucj_spinless_variant():
     rng = np.random.default_rng(2)
     mats = rng.standard_normal((n_reps, norb, norb))
     rotations = np.stack([random_unitary(norb, seed=30 + k) for k in range(n_reps)])
-    spinless = UCJ(norb, "spinless", mats, rotations)
+    spinless = UCJ("spinless", mats, rotations)
     assert spinless.num_modes == norb
     assert spinless._variant is UCJ.Variant.SPINLESS
 
@@ -74,15 +74,34 @@ def test_ucj_rejects_unknown_variant():
     norb = 3
     mats, rotations = _balanced_tensors(norb, 2, seed=0)
     with pytest.raises(ValueError, match="Unknown UCJ variant"):
-        UCJ(norb, "nonsense", mats, rotations)
+        UCJ("nonsense", mats, rotations)
 
 
 def test_ucj_rejects_inconsistent_shapes():
-    """Tensor shapes inconsistent with norb or with each other raise ValueError."""
+    """Tensor shapes inconsistent with each other raise ValueError.
+
+    ``norb`` is inferred from ``orbital_rotations``' trailing axis, so the two tensors validate
+    against each other: a ``diag_coulomb_mats`` implying a different ``norb`` is what makes the pair
+    inconsistent.
+    """
     norb = 3
-    mats, rotations = _balanced_tensors(norb, 2, seed=3)
+    _, rotations = _balanced_tensors(norb, 2, seed=3)
+    mats_wrong_norb, _ = _balanced_tensors(norb + 1, 2, seed=3)
     with pytest.raises(ValueError, match="Inconsistent"):
-        UCJ(norb + 1, "balanced", mats, rotations)  # norb mismatch
+        UCJ("balanced", mats_wrong_norb, rotations)
+
+
+def test_ucj_rejects_wrong_rank_tensors():
+    """A tensor of the wrong rank is rejected rather than inferring a bogus norb from its last axis.
+
+    ``norb`` is read off ``orbital_rotations``' trailing axis, so the rank has to be checked first --
+    otherwise a wrongly ranked tensor would infer some ``norb`` and then be "validated" against it.
+    """
+    norb = 3
+    mats, _ = _balanced_tensors(norb, 2, seed=3)
+    # a balanced orbital_rotations must be 3-dimensional (L, norb, norb), not 4-dimensional
+    with pytest.raises(ValueError, match="dimensional"):
+        UCJ("balanced", mats, np.zeros((2, 2, norb, norb)))
 
 
 def test_ucj_rejects_balanced_shaped_tensors_for_spinless_variant():
@@ -90,7 +109,34 @@ def test_ucj_rejects_balanced_shaped_tensors_for_spinless_variant():
     norb = 3
     mats, rotations = _balanced_tensors(norb, 2, seed=4)
     with pytest.raises(ValueError, match="Inconsistent"):
-        UCJ(norb, "spinless", mats, rotations)
+        UCJ("spinless", mats, rotations)
+
+
+def test_ucj_zero_reps_infers_norb():
+    """A zero-repetition ansatz is legal and still infers ``norb`` from the tensors' trailing axes.
+
+    ``norb`` lives in the trailing axes, so it survives an empty repetition axis. This is worth
+    pinning down because the zero-rep case is reachable from ``from_t_amplitudes`` -- an all-zero
+    ``t2``, or a ``tol`` above every factorization weight, truncates away every term -- and it is the
+    case where the shape inference has the least to go on.
+    """
+    norb = 3
+    gate = UCJ("balanced", np.empty((0, 2, norb, norb)), np.empty((0, norb, norb)))
+    assert gate.norb == norb
+    assert gate.num_modes == 2 * norb
+
+    # the same via the public factorization path: a vanishing t2 yields no terms at all
+    from_t2 = UCJ.from_t_amplitudes(
+        (1, 1), np.zeros((1, 1, norb - 1, norb - 1)), variant="balanced"
+    )
+    assert from_t2.norb == norb
+    assert from_t2.num_modes == 2 * norb
+    assert from_t2.diag_coulomb_mats.shape[0] == 0
+
+    # a zero-rep ansatz is the identity, so its definition carries no ansatz layers
+    circ = FermionicCircuit(gate.num_modes)
+    circ.append(gate, circ.modes)
+    assert circ.decompose().count_ops() == {}
 
 
 def test_ucj_define_gate_sequence():
@@ -103,7 +149,7 @@ def test_ucj_define_gate_sequence():
     n_reps = 2
     mats, rotations = _balanced_tensors(norb, n_reps, seed=7)
     final = random_unitary(norb, seed=99)
-    gate = UCJ(norb, "balanced", mats, rotations, final_orbital_rotation=final)
+    gate = UCJ("balanced", mats, rotations, final_orbital_rotation=final)
 
     circ = FermionicCircuit(gate.num_modes)
     circ.append(gate, circ.modes)
@@ -123,7 +169,7 @@ def test_ucj_spinless_uses_norb_modes():
     mats = rng.standard_normal((n_reps, norb, norb))
     mats = mats + mats.transpose(0, 2, 1)
     rotations = np.stack([random_unitary(norb, seed=40)])
-    gate = UCJ(norb, "spinless", mats, rotations)
+    gate = UCJ("spinless", mats, rotations)
     circ = FermionicCircuit(gate.num_modes)
     circ.append(gate, circ.modes)
     ops = circ.decompose().count_ops()
@@ -137,7 +183,7 @@ def test_ucj_accepts_complex_diag_coulomb_with_zero_imaginary_part():
     """Complex-typed diag-Coulomb mats with a negligible imaginary part are coerced to real."""
     norb = 3
     mats, rotations = _balanced_tensors(norb, 1, seed=11)
-    gate = UCJ(norb, "balanced", mats.astype(complex), rotations)
+    gate = UCJ("balanced", mats.astype(complex), rotations)
     assert gate.diag_coulomb_mats.dtype == np.float64
     np.testing.assert_allclose(gate.diag_coulomb_mats, mats)
 
@@ -149,7 +195,7 @@ def test_ucj_rejects_complex_diag_coulomb_with_nonzero_imaginary_part():
     complex_mats = mats.astype(complex)
     complex_mats[0, 0, 0, 1] += 0.5j
     with pytest.raises(ValueError, match="imaginary part"):
-        UCJ(norb, "balanced", complex_mats, rotations)
+        UCJ("balanced", complex_mats, rotations)
 
 
 def test_ucj_from_t_amplitudes_rejects_tuple_n_reps_for_balanced():
@@ -258,7 +304,7 @@ def test_ucj_rejects_mismatched_repetition_counts():
         :1
     ]  # 1 rep
     with pytest.raises(ValueError, match="same number of repetitions"):
-        UCJ(norb, "balanced", mats, rotations)
+        UCJ("balanced", mats, rotations)
 
 
 @pytest.mark.parametrize("variant", ["balanced", "unbalanced", "spinless"])
@@ -407,7 +453,7 @@ def test_diag_coulomb_grouping_preserves_operator(norb):
     from qiskit_fermions.operators import FermionOperator
 
     mats, rotations = _balanced_tensors(norb, 1, seed=100 + norb)
-    gate = UCJ(norb, "balanced", mats, rotations)
+    gate = UCJ("balanced", mats, rotations)
     operator = gate._diag_coulomb_operator(gate.diag_coulomb_mats[0])
 
     reference = FermionOperator.from_dict(
@@ -433,7 +479,7 @@ def test_diag_coulomb_groups_have_disjoint_support(variant, norb):
         mats = rng.standard_normal((1, norb, norb))
         mats = mats + mats.transpose(0, 2, 1)
     rotations = np.stack([random_unitary(norb, seed=7)])
-    gate = UCJ(norb, variant, mats, rotations)
+    gate = UCJ(variant, mats, rotations)
 
     operator = gate._diag_coulomb_operator(gate.diag_coulomb_mats[0])
     assert operator.groups is not None
@@ -471,7 +517,7 @@ def test_diag_coulomb_group_count_is_optimal(variant, norb):
         mats = rng.standard_normal((1, norb, norb))
         mats = mats + mats.transpose(0, 2, 1)
     rotations = np.stack([random_unitary(norb, seed=7)])
-    gate = UCJ(norb, variant, mats, rotations)
+    gate = UCJ(variant, mats, rotations)
     operator = gate._diag_coulomb_operator(gate.diag_coulomb_mats[0])
 
     degree: dict[int, int] = {}

--- a/tests/python/circuit/library/test_ucj_apply_unitary.py
+++ b/tests/python/circuit/library/test_ucj_apply_unitary.py
@@ -36,7 +36,6 @@ def _apply_ours(ucj_op, norb, nelec, reference, variant):
     delegates to its ``_build_definition()`` -- rather than the definition circuit directly.
     """
     gate = UCJ(
-        norb,
         variant,
         ucj_op.diag_coulomb_mats,
         ucj_op.orbital_rotations,
@@ -91,7 +90,6 @@ def test_ucj_spinless_shortcut_via_zeroed_balanced_ab_block_matches_ffsim():
     zero_ab = np.zeros_like(ucj_op.diag_coulomb_mats)
     balanced_diag_coulomb_mats = np.stack([ucj_op.diag_coulomb_mats, zero_ab], axis=1)
     gate = UCJ(
-        norb,
         "balanced",
         balanced_diag_coulomb_mats,
         ucj_op.orbital_rotations,
@@ -129,7 +127,6 @@ def test_ucj_gate_apply_unitary_matches_ffsim():
     expected = ffsim.apply_unitary(reference, ucj_op, norb=norb, nelec=nelec)
 
     gate = UCJ(
-        norb,
         "balanced",
         ucj_op.diag_coulomb_mats,
         ucj_op.orbital_rotations,
@@ -147,7 +144,7 @@ def test_ucj_gate_through_circuit_matches_ffsim():
     reference = ffsim.hartree_fock_state(norb, nelec)
     expected = ffsim.apply_unitary(reference, ucj_op, norb=norb, nelec=nelec)
 
-    gate = UCJ(norb, "balanced", ucj_op.diag_coulomb_mats, ucj_op.orbital_rotations)
+    gate = UCJ("balanced", ucj_op.diag_coulomb_mats, ucj_op.orbital_rotations)
     circ = FermionicCircuit(2 * norb)
     circ.append(gate, circ.modes)
     result = ffsim.apply_unitary(reference, circ, norb=norb, nelec=nelec)
@@ -200,7 +197,6 @@ def test_ucj_gate_subset_placement_matches_global_embedding():
     # our path: the local UCJ gate, placed on the global orbitals via ``placement`` in the circuit,
     # applied to the same reference.
     gate = UCJ(
-        norb_local,
         "spinless",
         ucj_op.diag_coulomb_mats,
         ucj_op.orbital_rotations,

--- a/tests/python/transpiler/passes/test_merge_initialize_rotation.py
+++ b/tests/python/transpiler/passes/test_merge_initialize_rotation.py
@@ -326,7 +326,7 @@ def test_merge_ucj_workflow():
     norb, nelec, n_reps = 2, (1, 1), 1
     diag_coulomb_mats = np.zeros((n_reps, 2, norb, norb))
     orbital_rotations = np.stack([random_unitary(norb, seed=5) for _ in range(n_reps)])
-    ucj = UCJ(norb, "balanced", diag_coulomb_mats, orbital_rotations)
+    ucj = UCJ("balanced", diag_coulomb_mats, orbital_rotations)
 
     circ = FermionicCircuit(2 * norb)
     circ.append(InitializeModes.from_hartree_fock(norb, nelec), circ.modes)


### PR DESCRIPTION
Previously, the `UCJ` class would take `norb` as its first input argument to the initializer method. This was inconsistent with `UCC` and in fact not needed, since it can be inferred from the provided tensors.