### PR TITLE
Fix accidental term conjugation during `OperatorTrait.ichop`

### DIFF
--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -393,7 +393,7 @@ impl OperatorTrait for EdgeVertexOperator {
         self.iter()
             .filter(|term| term.coeff.abs() > atol)
             .for_each(|term| {
-                coeffs.push(term.coeff.conj());
+                coeffs.push(term.coeff);
                 left_indices.extend_from_slice(term.left_indices);
                 right_indices.extend_from_slice(term.right_indices);
                 boundaries.push(right_indices.len());
@@ -948,6 +948,33 @@ mod tests {
         };
 
         assert_eq!(op, expected2);
+    }
+
+    #[test]
+    fn test_ichop_preserves_complex_coeffs() {
+        let mut op = EdgeVertexOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 2.0),
+                Complex64::new(0.0, -3.0),
+                Complex64::new(1e-8, 1e-8),
+            ],
+            left_indices: vec![0, 1],
+            right_indices: vec![1, 2],
+            boundaries: vec![0, 0, 1, 2],
+            groups: None,
+        };
+
+        op.ichop(1e-7);
+
+        let expected = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 2.0), Complex64::new(0.0, -3.0)],
+            left_indices: vec![0],
+            right_indices: vec![1],
+            boundaries: vec![0, 0, 1],
+            groups: None,
+        };
+
+        assert_eq!(op, expected);
     }
 
     #[test]

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -482,7 +482,7 @@ impl OperatorTrait for FermionOperator {
         self.iter()
             .filter(|term| term.coeff.abs() > atol)
             .for_each(|term| {
-                coeffs.push(term.coeff.conj());
+                coeffs.push(term.coeff);
                 actions.extend_from_slice(term.actions);
                 modes.extend_from_slice(term.modes);
                 boundaries.push(modes.len());
@@ -1024,6 +1024,33 @@ mod tests {
         };
 
         assert_eq!(op, expected2);
+    }
+
+    #[test]
+    fn test_ichop_preserves_complex_coeffs() {
+        let mut op = FermionOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 2.0),
+                Complex64::new(0.0, -3.0),
+                Complex64::new(1e-8, 1e-8),
+            ],
+            actions: vec![true, false],
+            modes: vec![0, 0],
+            boundaries: vec![0, 0, 1, 2],
+            groups: None,
+        };
+
+        op.ichop(1e-7);
+
+        let expected = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 2.0), Complex64::new(0.0, -3.0)],
+            actions: vec![true],
+            modes: vec![0],
+            boundaries: vec![0, 0, 1],
+            groups: None,
+        };
+
+        assert_eq!(op, expected);
     }
 
     #[test]

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -412,7 +412,7 @@ impl OperatorTrait for MajoranaOperator {
         self.iter()
             .filter(|term| term.coeff.abs() > atol)
             .for_each(|term| {
-                coeffs.push(term.coeff.conj());
+                coeffs.push(term.coeff);
                 modes.extend_from_slice(term.modes);
                 boundaries.push(modes.len());
             });
@@ -915,6 +915,31 @@ mod tests {
         };
 
         assert_eq!(op, expected2);
+    }
+
+    #[test]
+    fn test_ichop_preserves_complex_coeffs() {
+        let mut op = MajoranaOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 2.0),
+                Complex64::new(0.0, -3.0),
+                Complex64::new(1e-8, 1e-8),
+            ],
+            modes: vec![0, 1],
+            boundaries: vec![0, 0, 1, 2],
+            groups: None,
+        };
+
+        op.ichop(1e-7);
+
+        let expected = MajoranaOperator {
+            coeffs: vec![Complex64::new(1.0, 2.0), Complex64::new(0.0, -3.0)],
+            modes: vec![0],
+            boundaries: vec![0, 0, 1],
+            groups: None,
+        };
+
+        assert_eq!(op, expected);
     }
 
     #[test]

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -392,7 +392,7 @@ impl OperatorTrait for TransferVertexOperator {
         self.iter()
             .filter(|term| term.coeff.abs() > atol)
             .for_each(|term| {
-                coeffs.push(term.coeff.conj());
+                coeffs.push(term.coeff);
                 left_indices.extend_from_slice(term.left_indices);
                 right_indices.extend_from_slice(term.right_indices);
                 boundaries.push(right_indices.len());
@@ -947,6 +947,33 @@ mod tests {
         };
 
         assert_eq!(op, expected2);
+    }
+
+    #[test]
+    fn test_ichop_preserves_complex_coeffs() {
+        let mut op = TransferVertexOperator {
+            coeffs: vec![
+                Complex64::new(1.0, 2.0),
+                Complex64::new(0.0, -3.0),
+                Complex64::new(1e-8, 1e-8),
+            ],
+            left_indices: vec![0, 1],
+            right_indices: vec![1, 2],
+            boundaries: vec![0, 0, 1, 2],
+            groups: None,
+        };
+
+        op.ichop(1e-7);
+
+        let expected = TransferVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 2.0), Complex64::new(0.0, -3.0)],
+            left_indices: vec![0],
+            right_indices: vec![1],
+            boundaries: vec![0, 0, 1],
+            groups: None,
+        };
+
+        assert_eq!(op, expected);
     }
 
     #[test]

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -182,6 +182,12 @@ class TestEdgeVertexOperator:
         op.ichop(1e-5)
         assert op.equiv(cls.from_dict({(): 1e-4}))
 
+    def test_ichop_preserves_complex_coeffs(self):
+        cls = self.get_class()
+        op = cls.from_dict({(): 1 + 2j, ((0, 1),): -3j, ((1, 2),): 1e-10})
+        op.ichop()
+        assert op.equiv(cls.from_dict({(): 1 + 2j, ((0, 1),): -3j}))
+
     def test_simplify(self):
         cls = self.get_class()
         coeffs = [1e-10, 2, 3, 4, -4]

--- a/tests/python/operators/test_fermion_operator.py
+++ b/tests/python/operators/test_fermion_operator.py
@@ -184,6 +184,12 @@ class TestFermionOperator:
         op.ichop(1e-5)
         assert op.equiv(cls.from_dict({(): 1e-4}))
 
+    def test_ichop_preserves_complex_coeffs(self):
+        cls = self.get_class()
+        op = cls.from_dict({(): 1 + 2j, ((True, 0),): -3j, ((False, 0),): 1e-10})
+        op.ichop()
+        assert op.equiv(cls.from_dict({(): 1 + 2j, ((True, 0),): -3j}))
+
     def test_simplify(self):
         cls = self.get_class()
         coeffs = [1e-10, 2, 3, 4, -4]

--- a/tests/python/operators/test_majorana_operator.py
+++ b/tests/python/operators/test_majorana_operator.py
@@ -177,6 +177,12 @@ class TestMajoranaOperator:
         op.ichop(1e-5)
         assert op.equiv(cls.from_dict({(): 1e-4}))
 
+    def test_ichop_preserves_complex_coeffs(self):
+        cls = self.get_class()
+        op = cls.from_dict({(): 1 + 2j, (0,): -3j, (1,): 1e-10})
+        op.ichop()
+        assert op.equiv(cls.from_dict({(): 1 + 2j, (0,): -3j}))
+
     def test_simplify(self):
         cls = self.get_class()
         coeffs = [1e-10, 2, 3, 4, -4]

--- a/tests/python/operators/test_transfer_vertex_operator.py
+++ b/tests/python/operators/test_transfer_vertex_operator.py
@@ -182,6 +182,12 @@ class TestTransferVertexOperator:
         op.ichop(1e-5)
         assert op.equiv(cls.from_dict({(): 1e-4}))
 
+    def test_ichop_preserves_complex_coeffs(self):
+        cls = self.get_class()
+        op = cls.from_dict({(): 1 + 2j, ((0, 1),): -3j, ((1, 2),): 1e-10})
+        op.ichop()
+        assert op.equiv(cls.from_dict({(): 1 + 2j, ((0, 1),): -3j}))
+
     def test_simplify(self):
         cls = self.get_class()
         coeffs = [1e-10, 2, 3, 4, -4]


### PR DESCRIPTION
`ichop` on operators was accidentally conjugating operator coefficients.
This was likely caused by a copy-paste from the adjacent `adjoint` method.