### PR TITLE
Fix the `adjoint` of `Edge/TransferVertexOperator`

### DIFF
--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -341,11 +341,25 @@ impl OperatorTrait for EdgeVertexOperator {
     }
 
     fn adjoint(&self) -> Self {
+        let mut coeffs = Vec::with_capacity(self.coeffs.len());
+        let mut left_indices = Vec::with_capacity(self.left_indices.len());
+        let mut right_indices = Vec::with_capacity(self.right_indices.len());
+
+        // Besides conjugating the coefficients, the generators within each term must be reversed:
+        // `(AB)† = B†A†` and the edge/vertex generators anticommute when they share an index, so
+        // `BA != AB` in general. Both index arrays are reversed over the same span, which keeps each
+        // `(left, right)` pair intact while reversing the order of the pairs.
+        self.iter().for_each(|term| {
+            coeffs.push(term.coeff.conj());
+            left_indices.extend(term.left_indices.iter().rev());
+            right_indices.extend(term.right_indices.iter().rev());
+        });
+
         Self {
-            coeffs: self.coeffs.iter().map(|c| c.conj()).collect(),
-            left_indices: self.left_indices.clone(),
-            right_indices: self.right_indices.clone(),
-            boundaries: self.boundaries.clone(),
+            coeffs,
+            left_indices,
+            right_indices,
+            boundaries: self.boundaries.to_vec(),
             groups: self.groups.clone(),
         }
     }
@@ -979,22 +993,67 @@ mod tests {
 
     #[test]
     fn test_adjoint() {
+        // The second term is `V(0) E(0,1) E(1,2)`, i.e. multi-factor, so that the reversal of the
+        // operator string is actually observable. A single-factor term would make it a no-op.
         let op1 = EdgeVertexOperator {
-            coeffs: vec![Complex64::new(0.0, 2.0), Complex64::new(3.0, 0.0)],
-            left_indices: vec![0],
-            right_indices: vec![1],
-            boundaries: vec![0, 0, 1],
+            coeffs: vec![Complex64::new(0.0, 2.0), Complex64::new(3.0, -4.0)],
+            left_indices: vec![0, 0, 1],
+            right_indices: vec![0, 1, 2],
+            boundaries: vec![0, 0, 3],
             groups: None,
         };
         let adj = op1.adjoint();
         let expected = EdgeVertexOperator {
-            coeffs: vec![Complex64::new(0.0, -2.0), Complex64::new(3.0, 0.0)],
-            left_indices: vec![0],
-            right_indices: vec![1],
-            boundaries: vec![0, 0, 1],
+            coeffs: vec![Complex64::new(0.0, -2.0), Complex64::new(3.0, 4.0)],
+            left_indices: vec![1, 0, 0],
+            right_indices: vec![2, 1, 0],
+            boundaries: vec![0, 0, 3],
             groups: None,
         };
         assert_eq!(adj, expected);
+    }
+
+    #[test]
+    fn test_adjoint_is_antihomomorphism() {
+        // `(A B)† == B† A†`. This identity only holds if `adjoint` reverses the operator string, so
+        // it directly guards against dropping that reversal.
+        let op1 = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(2.0, 1.0)],
+            left_indices: vec![0, 0],
+            right_indices: vec![0, 1],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        let op2 = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(-1.0, 3.0)],
+            left_indices: vec![1, 2],
+            right_indices: vec![2, 2],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+
+        let lhs = op1.__matmul__(&op2).adjoint();
+        let rhs = op2.adjoint().__matmul__(&op1.adjoint());
+        assert!(lhs.equiv(&rhs, 1e-12));
+    }
+
+    #[test]
+    fn test_is_hermitian_requires_reversal() {
+        // `V(0) E(0,1)` is *not* Hermitian: the two generators share the index 0 and therefore
+        // anticommute, so `(V(0) E(0,1))† = E(0,1) V(0) = -V(0) E(0,1)`.
+        let op = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0)],
+            left_indices: vec![0, 0],
+            right_indices: vec![0, 1],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        assert!(!op.is_hermitian(1e-10));
+
+        // Symmetrizing it does give a Hermitian operator.
+        let mut sym = op.clone();
+        sym.__iadd__(&op.adjoint());
+        assert!(sym.is_hermitian(1e-10));
     }
 
     #[test]
@@ -1128,6 +1187,10 @@ mod tests {
         assert_eq!(op.normal_ordered(), expected);
     }
 
+    /// Exercises the `atol` boundary of `is_hermitian`.
+    ///
+    /// Note that these are single-factor terms, so this test is insensitive to whether `adjoint`
+    /// reverses the operator string; see `test_is_hermitian_requires_reversal` for that.
     #[test]
     fn test_is_hermitian() {
         let op = EdgeVertexOperator {

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -340,11 +340,25 @@ impl OperatorTrait for TransferVertexOperator {
     }
 
     fn adjoint(&self) -> Self {
+        let mut coeffs = Vec::with_capacity(self.coeffs.len());
+        let mut left_indices = Vec::with_capacity(self.left_indices.len());
+        let mut right_indices = Vec::with_capacity(self.right_indices.len());
+
+        // Besides conjugating the coefficients, the generators within each term must be reversed:
+        // `(AB)† = B†A†` and the transfer/vertex generators anticommute when they share an index, so
+        // `BA != AB` in general. Both index arrays are reversed over the same span, which keeps each
+        // `(left, right)` pair intact while reversing the order of the pairs.
+        self.iter().for_each(|term| {
+            coeffs.push(term.coeff.conj());
+            left_indices.extend(term.left_indices.iter().rev());
+            right_indices.extend(term.right_indices.iter().rev());
+        });
+
         Self {
-            coeffs: self.coeffs.iter().map(|c| c.conj()).collect(),
-            left_indices: self.left_indices.clone(),
-            right_indices: self.right_indices.clone(),
-            boundaries: self.boundaries.clone(),
+            coeffs,
+            left_indices,
+            right_indices,
+            boundaries: self.boundaries.to_vec(),
             groups: self.groups.clone(),
         }
     }
@@ -978,22 +992,67 @@ mod tests {
 
     #[test]
     fn test_adjoint() {
+        // The second term is `V(0) T(0,1) T(1,2)`, i.e. multi-factor, so that the reversal of the
+        // operator string is actually observable. A single-factor term would make it a no-op.
         let op1 = TransferVertexOperator {
-            coeffs: vec![Complex64::new(0.0, 2.0), Complex64::new(3.0, 0.0)],
-            left_indices: vec![0],
-            right_indices: vec![1],
-            boundaries: vec![0, 0, 1],
+            coeffs: vec![Complex64::new(0.0, 2.0), Complex64::new(3.0, -4.0)],
+            left_indices: vec![0, 0, 1],
+            right_indices: vec![0, 1, 2],
+            boundaries: vec![0, 0, 3],
             groups: None,
         };
         let adj = op1.adjoint();
         let expected = TransferVertexOperator {
-            coeffs: vec![Complex64::new(0.0, -2.0), Complex64::new(3.0, 0.0)],
-            left_indices: vec![0],
-            right_indices: vec![1],
-            boundaries: vec![0, 0, 1],
+            coeffs: vec![Complex64::new(0.0, -2.0), Complex64::new(3.0, 4.0)],
+            left_indices: vec![1, 0, 0],
+            right_indices: vec![2, 1, 0],
+            boundaries: vec![0, 0, 3],
             groups: None,
         };
         assert_eq!(adj, expected);
+    }
+
+    #[test]
+    fn test_adjoint_is_antihomomorphism() {
+        // `(A B)† == B† A†`. This identity only holds if `adjoint` reverses the operator string, so
+        // it directly guards against dropping that reversal.
+        let op1 = TransferVertexOperator {
+            coeffs: vec![Complex64::new(2.0, 1.0)],
+            left_indices: vec![0, 0],
+            right_indices: vec![0, 1],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        let op2 = TransferVertexOperator {
+            coeffs: vec![Complex64::new(-1.0, 3.0)],
+            left_indices: vec![1, 2],
+            right_indices: vec![2, 2],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+
+        let lhs = op1.__matmul__(&op2).adjoint();
+        let rhs = op2.adjoint().__matmul__(&op1.adjoint());
+        assert!(lhs.equiv(&rhs, 1e-12));
+    }
+
+    #[test]
+    fn test_is_hermitian_requires_reversal() {
+        // `V(0) T(0,1)` is *not* Hermitian: the two generators share the index 0 and therefore
+        // anticommute, so `(V(0) T(0,1))† = T(0,1) V(0) = -V(0) T(0,1)`.
+        let op = TransferVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0)],
+            left_indices: vec![0, 0],
+            right_indices: vec![0, 1],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        assert!(!op.is_hermitian(1e-10));
+
+        // Symmetrizing it does give a Hermitian operator.
+        let mut sym = op.clone();
+        sym.__iadd__(&op.adjoint());
+        assert!(sym.is_hermitian(1e-10));
     }
 
     #[test]
@@ -1171,6 +1230,10 @@ mod tests {
         assert_eq!(op.normal_ordered(), expected);
     }
 
+    /// Exercises the `atol` boundary of `is_hermitian`.
+    ///
+    /// Note that these are single-factor terms, so this test is insensitive to whether `adjoint`
+    /// reverses the operator string; see `test_is_hermitian_requires_reversal` for that.
     #[test]
     fn test_is_hermitian() {
         let op = TransferVertexOperator {

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -996,10 +996,15 @@ impl PyEdgeVertexOperator {
 
     /// Returns the Hermitian conjugate (or adjoint) of this operator.
     ///
-    /// The generators of this operator (the vertex and edge operators) are individually Hermitian,
-    /// so the terms themselves are unchanged by the adjoint; only the coefficients are affected:
+    /// Two things happen to every term:
     ///
     /// - the coefficients are complex conjugated
+    /// - the generators within each term are reversed in order
+    ///
+    /// The reversal is required because :math:`(AB)^\dagger = B^\dagger A^\dagger`. While the
+    /// individual vertex and edge generators *are* Hermitian, they **anticommute when they share an
+    /// index** (see :ref:`the definition above <EdgeVertexOperator-definition>`), so the reversed
+    /// product is not equal to the original one and the order cannot simply be dropped.
     ///
     /// Note that this does not make the operator self-adjoint in general: an operator with complex
     /// coefficients differs from its adjoint (as the doctest below illustrates).
@@ -1011,7 +1016,7 @@ impl PyEdgeVertexOperator {
     ///     >>> adj = op.adjoint()
     ///     >>> print(format(adj))
     ///      -0.000000e0 +1.000000e0j * ()
-    ///       1.000000e0 -0.000000e0j * (V(0) E(0,1))
+    ///       1.000000e0 -0.000000e0j * (E(0,1) V(0))
     ///
     /// ..
     fn adjoint(&self) -> Self {
@@ -1082,6 +1087,13 @@ impl PyEdgeVertexOperator {
     /// .. note::
     ///    This check is implemented using :meth:`.equiv` on the :meth:`.normal_ordered` difference
     ///    of ``self`` and its :meth:`.adjoint` and :meth:`.zero`.
+    ///
+    /// .. note::
+    ///    This check is *conservative*: it can return ``False`` for an operator that is in fact
+    ///    Hermitian. :meth:`.normal_ordered` does not contract repeated generators into scalars
+    ///    (for example :math:`V_j V_j = 1` and :math:`E_{jk} E_{kj} = -1`), so a term that would
+    ///    only cancel against its adjoint *after* such a contraction is not recognized as zero.
+    ///    A ``True`` result is always reliable.
     ///
     /// Args:
     ///     atol: The numerical accuracy upto which coefficients are considered equal. This value

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -53,9 +53,9 @@ crate::declare_operator_iters!(
 ///             = -(a_j a_j - a_j a^\dagger_j + a^\dagger_j a_j - a^\dagger_j a^\dagger_j)
 ///             = 1 - 2 a^\dagger_j a_j \, , \nonumber \\
 ///     T_{jk} &= \frac{i}{2} V_j E_{jk}
-///             = \frac{1}{2} \gamma_{2j} \gamma_{2k-1} \, , \nonumber \\
+///             = \frac{i}{2} \gamma_{2j} \gamma_{2k-1} \, , \nonumber \\
 ///     T_{kj} &= \frac{i}{2} E_{jk} V_k
-///             = -\frac{1}{2} \gamma_{2j-1} \gamma_{2k} \nonumber
+///             = -\frac{i}{2} \gamma_{2j-1} \gamma_{2k} \nonumber
 ///     \end{align}
 ///
 /// where :math:`E_{jk}` is an edge operator of the :class:`.EdgeVertexOperator` and
@@ -1002,11 +1002,15 @@ impl PyTransferVertexOperator {
 
     /// Returns the Hermitian conjugate (or adjoint) of this operator.
     ///
-    /// The generators of this operator (the vertex and transfer operators) are individually
-    /// Hermitian, so the terms themselves are unchanged by the adjoint; only the coefficients are
-    /// affected:
+    /// Two things happen to every term:
     ///
     /// - the coefficients are complex conjugated
+    /// - the generators within each term are reversed in order
+    ///
+    /// The reversal is required because :math:`(AB)^\dagger = B^\dagger A^\dagger`. While the
+    /// individual vertex and transfer generators *are* Hermitian, they **anticommute when they share
+    /// an index** (see :ref:`the definition above <TransferVertexOperator-definition>`), so the
+    /// reversed product is not equal to the original one and the order cannot simply be dropped.
     ///
     /// Note that this does not make the operator self-adjoint in general: an operator with complex
     /// coefficients differs from its adjoint (as the doctest below illustrates).
@@ -1018,7 +1022,7 @@ impl PyTransferVertexOperator {
     ///     >>> adj = op.adjoint()
     ///     >>> print(format(adj))
     ///      -0.000000e0 +1.000000e0j * ()
-    ///       1.000000e0 -0.000000e0j * (V(0) T(0,1))
+    ///       1.000000e0 -0.000000e0j * (T(0,1) V(0))
     ///
     /// ..
     fn adjoint(&self) -> Self {
@@ -1089,6 +1093,13 @@ impl PyTransferVertexOperator {
     /// .. note::
     ///    This check is implemented using :meth:`.equiv` on the :meth:`.normal_ordered` difference
     ///    of ``self`` and its :meth:`.adjoint` and :meth:`.zero`.
+    ///
+    /// .. note::
+    ///    This check is *conservative*: it can return ``False`` for an operator that is in fact
+    ///    Hermitian. :meth:`.normal_ordered` does not contract repeated generators into scalars
+    ///    (for example :math:`V_j V_j = 1`), so a term that would only cancel against its adjoint
+    ///    *after* such a contraction is not recognized as zero. A ``True`` result is always
+    ///    reliable.
     ///
     /// Args:
     ///     atol: The numerical accuracy upto which coefficients are considered equal. This value

--- a/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
@@ -818,10 +818,15 @@ class EdgeVertexOperator:
         r"""
         Returns the Hermitian conjugate (or adjoint) of this operator.
         
-        The generators of this operator (the vertex and edge operators) are individually Hermitian,
-        so the terms themselves are unchanged by the adjoint; only the coefficients are affected:
+        Two things happen to every term:
         
         - the coefficients are complex conjugated
+        - the generators within each term are reversed in order
+        
+        The reversal is required because :math:`(AB)^\dagger = B^\dagger A^\dagger`. While the
+        individual vertex and edge generators *are* Hermitian, they **anticommute when they share an
+        index** (see :ref:`the definition above <EdgeVertexOperator-definition>`), so the reversed
+        product is not equal to the original one and the order cannot simply be dropped.
         
         Note that this does not make the operator self-adjoint in general: an operator with complex
         coefficients differs from its adjoint (as the doctest below illustrates).
@@ -833,7 +838,7 @@ class EdgeVertexOperator:
             >>> adj = op.adjoint()
             >>> print(format(adj))
              -0.000000e0 +1.000000e0j * ()
-              1.000000e0 -0.000000e0j * (V(0) E(0,1))
+              1.000000e0 -0.000000e0j * (E(0,1) V(0))
         
         ..
         """
@@ -900,6 +905,13 @@ class EdgeVertexOperator:
         .. note::
            This check is implemented using :meth:`.equiv` on the :meth:`.normal_ordered` difference
            of ``self`` and its :meth:`.adjoint` and :meth:`.zero`.
+        
+        .. note::
+           This check is *conservative*: it can return ``False`` for an operator that is in fact
+           Hermitian. :meth:`.normal_ordered` does not contract repeated generators into scalars
+           (for example :math:`V_j V_j = 1` and :math:`E_{jk} E_{kj} = -1`), so a term that would
+           only cancel against its adjoint *after* such a contraction is not recognized as zero.
+           A ``True`` result is always reliable.
         
         Args:
             atol: The numerical accuracy upto which coefficients are considered equal. This value

--- a/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
@@ -31,9 +31,9 @@ class TransferVertexOperator:
                 = -(a_j a_j - a_j a^\dagger_j + a^\dagger_j a_j - a^\dagger_j a^\dagger_j)
                 = 1 - 2 a^\dagger_j a_j \, , \nonumber \\
         T_{jk} &= \frac{i}{2} V_j E_{jk}
-                = \frac{1}{2} \gamma_{2j} \gamma_{2k-1} \, , \nonumber \\
+                = \frac{i}{2} \gamma_{2j} \gamma_{2k-1} \, , \nonumber \\
         T_{kj} &= \frac{i}{2} E_{jk} V_k
-                = -\frac{1}{2} \gamma_{2j-1} \gamma_{2k} \nonumber
+                = -\frac{i}{2} \gamma_{2j-1} \gamma_{2k} \nonumber
         \end{align}
     
     where :math:`E_{jk}` is an edge operator of the :class:`.EdgeVertexOperator` and
@@ -829,11 +829,15 @@ class TransferVertexOperator:
         r"""
         Returns the Hermitian conjugate (or adjoint) of this operator.
         
-        The generators of this operator (the vertex and transfer operators) are individually
-        Hermitian, so the terms themselves are unchanged by the adjoint; only the coefficients are
-        affected:
+        Two things happen to every term:
         
         - the coefficients are complex conjugated
+        - the generators within each term are reversed in order
+        
+        The reversal is required because :math:`(AB)^\dagger = B^\dagger A^\dagger`. While the
+        individual vertex and transfer generators *are* Hermitian, they **anticommute when they share
+        an index** (see :ref:`the definition above <TransferVertexOperator-definition>`), so the
+        reversed product is not equal to the original one and the order cannot simply be dropped.
         
         Note that this does not make the operator self-adjoint in general: an operator with complex
         coefficients differs from its adjoint (as the doctest below illustrates).
@@ -845,7 +849,7 @@ class TransferVertexOperator:
             >>> adj = op.adjoint()
             >>> print(format(adj))
              -0.000000e0 +1.000000e0j * ()
-              1.000000e0 -0.000000e0j * (V(0) T(0,1))
+              1.000000e0 -0.000000e0j * (T(0,1) V(0))
         
         ..
         """
@@ -912,6 +916,13 @@ class TransferVertexOperator:
         .. note::
            This check is implemented using :meth:`.equiv` on the :meth:`.normal_ordered` difference
            of ``self`` and its :meth:`.adjoint` and :meth:`.zero`.
+        
+        .. note::
+           This check is *conservative*: it can return ``False`` for an operator that is in fact
+           Hermitian. :meth:`.normal_ordered` does not contract repeated generators into scalars
+           (for example :math:`V_j V_j = 1`), so a term that would only cancel against its adjoint
+           *after* such a contraction is not recognized as zero. A ``True`` result is always
+           reliable.
         
         Args:
             atol: The numerical accuracy upto which coefficients are considered equal. This value

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -318,10 +318,34 @@ class TestEdgeVertexOperator:
         with subtests.test("pow==2"):
             assert (op**2).equiv(cls.from_dict({((0, 1), (0, 1)): 4}))
 
-    def test_adjoint(self):
+    def test_adjoint(self, subtests):
         cls = self.get_class()
-        op = cls.from_dict({(): 2j, ((0, 1),): 3})
-        assert op.adjoint().equiv(cls.from_dict({(): -2j, ((0, 1),): 3}))
+
+        with subtests.test("single-factor terms"):
+            op = cls.from_dict({(): 2j, ((0, 1),): 3})
+            assert op.adjoint().equiv(cls.from_dict({(): -2j, ((0, 1),): 3}))
+
+        with subtests.test("multi-factor term is reversed"):
+            op = cls.from_dict({((0, 0), (0, 1), (1, 2)): 3 - 4j})
+            assert op.adjoint().equiv(cls.from_dict({((1, 2), (0, 1), (0, 0)): 3 + 4j}))
+
+        with subtests.test("(A @ B).adjoint() == B.adjoint() @ A.adjoint()"):
+            op_a = cls.from_dict({((0, 0), (0, 1)): 2 + 1j})
+            op_b = cls.from_dict({((1, 2), (2, 2)): -1 + 3j})
+            assert (op_a @ op_b).adjoint().equiv(op_b.adjoint() @ op_a.adjoint())
+
+    def test_is_hermitian(self, subtests):
+        cls = self.get_class()
+
+        # V(0) and E(0,1) share the index 0 and therefore anticommute, so
+        # (V(0) E(0,1))† = E(0,1) V(0) = -V(0) E(0,1) and the operator is not Hermitian.
+        op = cls.from_dict({((0, 0), (0, 1)): 1.0})
+
+        with subtests.test("anticommuting product is not Hermitian"):
+            assert not op.is_hermitian()
+
+        with subtests.test("symmetrized product is Hermitian"):
+            assert (op + op.adjoint()).is_hermitian()
 
     def test_equiv(self):
         cls = self.get_class()

--- a/tests/python/operators/test_transfer_vertex_operator.py
+++ b/tests/python/operators/test_transfer_vertex_operator.py
@@ -318,10 +318,34 @@ class TestTransferVertexOperator:
         with subtests.test("pow==2"):
             assert (op**2).equiv(cls.from_dict({((0, 1), (0, 1)): 4}))
 
-    def test_adjoint(self):
+    def test_adjoint(self, subtests):
         cls = self.get_class()
-        op = cls.from_dict({(): 2j, ((0, 1),): 3})
-        assert op.adjoint().equiv(cls.from_dict({(): -2j, ((0, 1),): 3}))
+
+        with subtests.test("single-factor terms"):
+            op = cls.from_dict({(): 2j, ((0, 1),): 3})
+            assert op.adjoint().equiv(cls.from_dict({(): -2j, ((0, 1),): 3}))
+
+        with subtests.test("multi-factor term is reversed"):
+            op = cls.from_dict({((0, 0), (0, 1), (1, 2)): 3 - 4j})
+            assert op.adjoint().equiv(cls.from_dict({((1, 2), (0, 1), (0, 0)): 3 + 4j}))
+
+        with subtests.test("(A @ B).adjoint() == B.adjoint() @ A.adjoint()"):
+            op_a = cls.from_dict({((0, 0), (0, 1)): 2 + 1j})
+            op_b = cls.from_dict({((1, 2), (2, 2)): -1 + 3j})
+            assert (op_a @ op_b).adjoint().equiv(op_b.adjoint() @ op_a.adjoint())
+
+    def test_is_hermitian(self, subtests):
+        cls = self.get_class()
+
+        # V(0) and T(0,1) share the index 0 and therefore anticommute, so
+        # (V(0) T(0,1))† = T(0,1) V(0) = -V(0) T(0,1) and the operator is not Hermitian.
+        op = cls.from_dict({((0, 0), (0, 1)): 1.0})
+
+        with subtests.test("anticommuting product is not Hermitian"):
+            assert not op.is_hermitian()
+
+        with subtests.test("symmetrized product is Hermitian"):
+            assert (op + op.adjoint()).is_hermitian()
 
     def test_equiv(self):
         cls = self.get_class()


### PR DESCRIPTION
The `adjoint` implementation (and `is_hermitian` by extension) of the `EdgeVertexOperator` and `TransferVertexOperator` classes were buggy. This PR fixes that.

It also addresses a type in the `TransferVertexOperator` defintions.