### PR TITLE
Fix `EdgeVertexOperator.normal_ordered`

### DIFF
--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -239,8 +239,14 @@ fn _normal_ordered_term(term_view: EdgeVertexOperatorTermView) -> EdgeVertexOper
                         // whether we swap depends on the actual indices:
                         if left_1 > right_1 || (left_1 == right_1 && left_2 > right_2) {
                             term.swap(j - 1, j);
-                            // swap will commute if they do not share support
-                            if HashSet::from([right_1, right_2, left_1, left_2]).len() != 4 {
+                            // Two edge operators anticommute iff they share *exactly one* mode:
+                            // `{E_jk, E_kl} = 0`. Sharing *both* modes is the commuting case, since
+                            // `E_jk` and `E_kj = -E_jk` are collinear and every operator commutes
+                            // with itself. Disjoint supports commute too.
+                            let overlap = HashSet::from([left_1, left_2])
+                                .intersection(&HashSet::from([right_1, right_2]))
+                                .count();
+                            if overlap == 1 {
                                 parity = !parity;
                             }
                         }
@@ -346,9 +352,9 @@ impl OperatorTrait for EdgeVertexOperator {
         let mut right_indices = Vec::with_capacity(self.right_indices.len());
 
         // Besides conjugating the coefficients, the generators within each term must be reversed:
-        // `(AB)† = B†A†` and the edge/vertex generators anticommute when they share an index, so
-        // `BA != AB` in general. Both index arrays are reversed over the same span, which keeps each
-        // `(left, right)` pair intact while reversing the order of the pairs.
+        // `(AB)† = B†A†` and the edge/vertex generators anticommute when they share exactly one
+        // index, so `BA != AB` in general. Both index arrays are reversed over the same span, which
+        // keeps each `(left, right)` pair intact while reversing the order of the pairs.
         self.iter().for_each(|term| {
             coeffs.push(term.coeff.conj());
             left_indices.extend(term.left_indices.iter().rev());
@@ -1102,10 +1108,15 @@ mod tests {
     #[test]
     fn test_normal_ordered_gandon_rel2() {
         // Tests the 2. relation of Eq. (5) from arXiv:2512.11418v1: {E_{jk}, E_{kl}} = 0
+        //
+        // Eq. (5) holds for `j != k != l`, so the two edge operators must share *exactly one*
+        // mode for this relation to apply. Here that is `E_{1,2} E_{0,1}` (sharing only mode 1),
+        // which anticommutes and hence picks up a sign when reordered. See
+        // `test_normal_ordered_shared_pair_commutes` for the excluded share-both-modes case.
         let op = EdgeVertexOperator {
             coeffs: vec![Complex64::new(1.0, 0.0)],
             left_indices: vec![1, 0],
-            right_indices: vec![0, 1],
+            right_indices: vec![2, 1],
             boundaries: vec![0, 2],
             groups: None,
         };
@@ -1113,12 +1124,53 @@ mod tests {
         let expected = EdgeVertexOperator {
             coeffs: vec![Complex64::new(-1.0, 0.0)],
             left_indices: vec![0, 1],
+            right_indices: vec![1, 2],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+
+        assert_eq!(op.normal_ordered(), expected);
+    }
+
+    /// Two edge operators spanning the *same* pair of modes commute, so reordering them must not
+    /// introduce a sign.
+    ///
+    /// This is the case Eq. (5) of arXiv:2512.11418v1 does not cover: its relations are stated for
+    /// `j != k != l != m`, so neither `{E_{jk}, E_{kl}} = 0` (exactly one shared mode) nor
+    /// `[E_{jk}, E_{lm}] = 0` (disjoint modes) says anything about `E_{jk}` versus `E_{jk}` or
+    /// `E_{kj}`. Since `E_{kj} = -E_{jk}`, those are collinear and commute.
+    #[test]
+    fn test_normal_ordered_shared_pair_commutes() {
+        // E_{1,0} E_{0,1} -> E_{0,1} E_{1,0} with the coefficient *unchanged*.
+        let op = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 2.0)],
+            left_indices: vec![1, 0],
+            right_indices: vec![0, 1],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+
+        let expected = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 2.0)],
+            left_indices: vec![0, 1],
             right_indices: vec![1, 0],
             boundaries: vec![0, 2],
             groups: None,
         };
 
         assert_eq!(op.normal_ordered(), expected);
+
+        // Same for two *identical* edge operators, where the sort is a no-op but the parity rule is
+        // still consulted.
+        let op = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 2.0)],
+            left_indices: vec![1, 1],
+            right_indices: vec![0, 0],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+
+        assert_eq!(op.normal_ordered(), op);
     }
 
     #[test]

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -69,8 +69,16 @@ crate::declare_operator_iters!(
 ///     \left[ E_{jk}, E_{lm} \right] &= 0 \nonumber \, .
 ///     \end{align}
 ///
-/// In summary, edge and vertex operators commute, unless they share an index, in which case they
-/// anticommute. A simple example can be represented visually like so:
+/// In summary, edge and vertex operators commute, unless they share *exactly one* index, in which
+/// case they anticommute.
+///
+/// .. note::
+///    The relations above are stated for :math:`j \neq k \neq l \neq m`, so they do not cover two
+///    edge operators spanning the *same* pair of modes. Those commute: since :math:`E_{kj} =
+///    -E_{jk}`, such a pair is collinear, and every operator commutes with itself. This is why the
+///    condition is "exactly one" shared index rather than "at least one".
+///
+/// A simple example can be represented visually like so:
 ///
 /// .. plot::
 ///    :alt: A visual depication of an edge-vertex operator.

--- a/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
@@ -47,8 +47,16 @@ class EdgeVertexOperator:
         \left[ E_{jk}, E_{lm} \right] &= 0 \nonumber \, .
         \end{align}
     
-    In summary, edge and vertex operators commute, unless they share an index, in which case they
-    anticommute. A simple example can be represented visually like so:
+    In summary, edge and vertex operators commute, unless they share *exactly one* index, in which
+    case they anticommute.
+    
+    .. note::
+       The relations above are stated for :math:`j \neq k \neq l \neq m`, so they do not cover two
+       edge operators spanning the *same* pair of modes. Those commute: since :math:`E_{kj} =
+       -E_{jk}`, such a pair is collinear, and every operator commutes with itself. This is why the
+       condition is "exactly one" shared index rather than "at least one".
+    
+    A simple example can be represented visually like so:
     
     .. plot::
        :alt: A visual depication of an edge-vertex operator.

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -367,6 +367,19 @@ class TestEdgeVertexOperator:
             expected = cls.from_dict({((0, 0), (2, 2), (0, 1), (1, 0), (1, 2)): -1})
             assert op.normal_ordered().equiv(expected)
 
+        with subtests.test("edge operators on the same pair of modes commute"):
+            # Eq. (5) of arXiv:2512.11418v1 only covers `j != k != l != m`, so it says nothing
+            # about two edge operators spanning the *same* pair of modes. Because
+            # `E_{kj} = -E_{jk}`, those are collinear and commute: reordering them must not
+            # introduce a sign.
+            op = cls.from_dict({((1, 0), (0, 1)): 1 + 2j})
+            expected = cls.from_dict({((0, 1), (1, 0)): 1 + 2j})
+            assert op.normal_ordered().equiv(expected)
+
+            # Two identical edge operators: the sort is a no-op, but the parity rule still runs.
+            op = cls.from_dict({((1, 0), (1, 0)): 1 + 2j})
+            assert op.normal_ordered().equiv(op)
+
     def test_commutator(self, subtests):
         cls = self.get_class()
 
@@ -394,6 +407,16 @@ class TestEdgeVertexOperator:
             comm.ichop()
             assert comm.equiv(cls.zero())
 
+        with subtests.test("edge operators on the same pair of modes"):
+            # Not covered by Eq. (5), which requires `j != k != l != m`: since
+            # `E_{1,0} = -E_{0,1}`, the two are collinear and therefore commute.
+            op1 = cls.from_dict({((0, 1),): 1})
+            op2 = cls.from_dict({((1, 0),): 1})
+            comm = commutator(op1, op2)
+            comm = comm.normal_ordered()
+            comm.ichop()
+            assert comm.equiv(cls.zero())
+
     def test_anti_commutator(self, subtests):
         cls = self.get_class()
 
@@ -406,8 +429,11 @@ class TestEdgeVertexOperator:
             assert comm.equiv(cls.zero())
 
         with subtests.test("2. relation of Eq. (5) from arXiv:2512.11418v1"):
+            # Eq. (5) requires `j != k != l`, so the two edge operators must share *exactly one*
+            # mode. `E_{0,1}` and `E_{1,2}` share only mode 1. Two edge operators spanning the
+            # *same* pair of modes instead commute -- see `test_normal_ordered`.
             op1 = cls.from_dict({((0, 1),): 1})
-            op2 = cls.from_dict({((1, 0),): 1})
+            op2 = cls.from_dict({((1, 2),): 1})
             comm = anti_commutator(op1, op2)
             comm = comm.normal_ordered()
             comm.ichop()


### PR DESCRIPTION
$E_{jk}$ and $E_{kj}$ were accidentally considered anti-commuting even though they commute! This was because edge operators did not distinguish whether they overlap on exactly one mode index (anti-commute) or both (should commute).
This PR fixes that and ensures that the unittests catch this rather than enforce the bug.