### PR TITLE
perf(operators): stop copying operator buffers that are never read

### DIFF
--- a/crates/core/src/linalg/givens.rs
+++ b/crates/core/src/linalg/givens.rs
@@ -117,8 +117,10 @@ fn zrot(target: &mut Array2<Complex64>, givens: &GivensRotation, slice_type: Sli
 /// - A vector of Givens rotations, each given as (real cosine, complex sine, index i, index j)
 /// - A vector of complex diagonal phase factors
 pub fn givens_decomposition(unitary: Array2<Complex64>) -> (Vec<GivensRotation>, Vec<Complex64>) {
-    let n = unitary.nrows();
-    let mut matrix = unitary.clone();
+    // The input is taken by value and never read again, so it becomes the working matrix directly
+    // (as in `givens_decomposition_slater` below).
+    let mut matrix = unitary;
+    let n = matrix.nrows();
     let mut left_rotations: Vec<GivensRotation> = Vec::new();
     let mut right_rotations: Vec<GivensRotation> = Vec::new();
 

--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -37,7 +37,11 @@ impl EdgeVertexOperatorTermView<'_> {
     }
 
     pub fn into_vec(&'_ self) -> Vec<(u32, u32)> {
-        zip(self.left_indices.to_vec(), self.right_indices.to_vec()).collect()
+        zip(
+            self.left_indices.iter().copied(),
+            self.right_indices.iter().copied(),
+        )
+        .collect()
     }
 }
 
@@ -68,7 +72,11 @@ impl EdgeVertexOperatorGroupTermView<'_> {
     }
 
     pub fn into_vec(&'_ self) -> Vec<(u32, u32)> {
-        zip(self.left_indices.to_vec(), self.right_indices.to_vec()).collect()
+        zip(
+            self.left_indices.iter().copied(),
+            self.right_indices.iter().copied(),
+        )
+        .collect()
     }
 }
 
@@ -522,39 +530,45 @@ impl OperatorTrait for EdgeVertexOperator {
     }
 
     fn get_support(&self) -> HashSet<u32> {
-        let support_left: HashSet<u32> = HashSet::from_iter(self.left_indices.clone());
-        let support_right: HashSet<u32> = HashSet::from_iter(self.right_indices.clone());
-        support_left.union(&support_right).copied().collect()
+        // Both index buffers feed a single set, rather than each building its own set to be unioned
+        // afterwards: the union of two sets of mode indices is the set of all of them.
+        self.left_indices
+            .iter()
+            .chain(&self.right_indices)
+            .copied()
+            .collect()
     }
 
     fn relabel_modes(&self, permutation: Vec<u32>) -> Result<Self, CoherenceError> {
         if permutation.iter().collect::<HashSet<_>>().len() != permutation.len() {
             return Err(CoherenceError::DuplicateIndices);
         }
-        let mut out = self.clone();
-        let new_left: Result<Vec<u32>, CoherenceError> = self
-            .left_indices
-            .iter()
-            .map(|&idx| {
-                permutation
-                    .get(idx as usize)
-                    .cloned()
-                    .ok_or(CoherenceError::IndexMapTooSmall)
-            })
-            .collect();
-        out.left_indices = new_left?;
-        let new_right: Result<Vec<u32>, CoherenceError> = self
-            .right_indices
-            .iter()
-            .map(|&idx| {
-                permutation
-                    .get(idx as usize)
-                    .cloned()
-                    .ok_or(CoherenceError::IndexMapTooSmall)
-            })
-            .collect();
-        out.right_indices = new_right?;
-        Ok(out)
+        let relabel = |indices: &[u32]| -> Result<Vec<u32>, CoherenceError> {
+            indices
+                .iter()
+                .map(|&idx| {
+                    permutation
+                        .get(idx as usize)
+                        .copied()
+                        .ok_or(CoherenceError::IndexMapTooSmall)
+                })
+                .collect()
+        };
+        // Both index buffers are relabelled before anything is copied, so that the error path does
+        // not first clone the entire operator only to discard it. The left buffer is still mapped
+        // first, keeping the error it reports ahead of the right buffer's.
+        let left_indices = relabel(&self.left_indices)?;
+        let right_indices = relabel(&self.right_indices)?;
+        Ok(Self {
+            coeffs: self.coeffs.clone(),
+            left_indices,
+            right_indices,
+            boundaries: self.boundaries.clone(),
+            // Relabelling permutes mode indices without reordering, splitting or merging terms, so
+            // any grouping of those terms carries over unchanged. This is the one operation that
+            // preserves `groups` rather than dropping it.
+            groups: self.groups.clone(),
+        })
     }
 }
 
@@ -1611,5 +1625,65 @@ mod tests {
 
         assert_eq!(op1, op1_before);
         assert_eq!(op2, op2_before);
+    }
+
+    /// The support of both index buffers, where the two only partially overlap.
+    ///
+    /// A single set now collects both buffers instead of unioning a set per buffer; overlapping but
+    /// unequal sides are what distinguishes that from taking only one side, or their intersection.
+    #[test]
+    fn test_get_support_overlapping_sides() {
+        let op = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(1.0, 0.0)],
+            left_indices: vec![0, 2, 4],
+            right_indices: vec![2, 4, 7],
+            boundaries: vec![0, 2, 3],
+            groups: None,
+        };
+
+        assert_eq!(op.get_support(), HashSet::from([0, 2, 4, 7]));
+    }
+
+    /// A right-side index outside the permutation must still be reported.
+    ///
+    /// Both buffers are relabelled through one closure now, so the right side needs its own case to
+    /// show it is mapped at all rather than copied through.
+    #[test]
+    fn test_relabel_modes_index_too_small_err_from_right() {
+        let op = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0)],
+            left_indices: vec![0],
+            right_indices: vec![3],
+            boundaries: vec![0, 1],
+            groups: None,
+        };
+
+        let relabeled = op.relabel_modes(vec![1, 0, 2]);
+
+        assert!(matches!(relabeled, Err(CoherenceError::IndexMapTooSmall)));
+    }
+
+    #[test]
+    fn test_relabel_modes_preserves_groups() {
+        let op = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+            left_indices: vec![0, 2],
+            right_indices: vec![1, 3],
+            boundaries: vec![0, 1, 2],
+            groups: Some(vec![0, 1]),
+        };
+
+        let relabeled = op.relabel_modes(vec![3, 2, 1, 0]).unwrap();
+
+        assert_eq!(
+            relabeled,
+            EdgeVertexOperator {
+                coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+                left_indices: vec![3, 1],
+                right_indices: vec![2, 0],
+                boundaries: vec![0, 1, 2],
+                groups: Some(vec![0, 1]),
+            }
+        );
     }
 }

--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::operators::{CoherenceError, OperatorMacro, OperatorTrait, TermSortKey};
+use crate::operators::{CoherenceError, OperatorMacro, OperatorTrait, ScaledTerm, TermSortKey};
 use num_complex::{Complex64, ComplexFloat};
 use std::collections::{HashMap, HashSet};
 use std::iter::zip;
@@ -54,6 +54,13 @@ impl TermSortKey for EdgeVertexOperatorTermView<'_> {
     }
 }
 
+impl ScaledTerm for EdgeVertexOperatorTermView<'_> {
+    fn scaled(mut self, factor: Complex64) -> Self {
+        self.coeff *= factor;
+        self
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EdgeVertexOperatorGroupTermView<'a> {
     pub coeff: Complex64,
@@ -85,6 +92,13 @@ impl TermSortKey for EdgeVertexOperatorGroupTermView<'_> {
         // Match the ungrouped `TermView` key exactly (ignoring `group`), so ordering a grouped
         // operator agrees with ordering the same terms ungrouped.
         self.into_vec()
+    }
+}
+
+impl ScaledTerm for EdgeVertexOperatorGroupTermView<'_> {
+    fn scaled(mut self, factor: Complex64) -> Self {
+        self.coeff *= factor;
+        self
     }
 }
 

--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -275,10 +275,16 @@ fn _compose(
     a: &EdgeVertexOperator,
     b: &EdgeVertexOperator,
 ) -> (Vec<Complex64>, Vec<u32>, Vec<u32>, Vec<usize>) {
-    let mut coeffs = vec![];
-    let mut left_indices = vec![];
-    let mut right_indices = vec![];
-    let mut boundaries = vec![0];
+    // The output size is known exactly: one term per (left, right) pair, each holding the factors
+    // of both inputs. Reserving up front turns the inner loop's repeated `extend_from_slice` into
+    // plain memcpy without the reallocation-and-copy rounds an unreserved vector would incur.
+    let num_terms = a.coeffs.len() * b.coeffs.len();
+    let num_factors = a.left_indices.len() * b.coeffs.len() + b.left_indices.len() * a.coeffs.len();
+    let mut coeffs = Vec::with_capacity(num_terms);
+    let mut left_indices = Vec::with_capacity(num_factors);
+    let mut right_indices = Vec::with_capacity(num_factors);
+    let mut boundaries = Vec::with_capacity(num_terms + 1);
+    boundaries.push(0);
 
     for left in a.iter() {
         for right in b.iter() {
@@ -384,24 +390,44 @@ impl OperatorTrait for EdgeVertexOperator {
         self.coeffs.iter_mut().for_each(|c| *c *= other);
     }
 
-    fn __iand__(&mut self, other: &Self) {
-        (
-            self.coeffs,
-            self.left_indices,
-            self.right_indices,
-            self.boundaries,
-        ) = _compose(self, other);
+    fn __isub__(&mut self, other: &Self) {
+        self.coeffs.extend(other.coeffs.iter().map(|c| -c));
+        self.left_indices.extend_from_slice(&other.left_indices);
+        self.right_indices.extend_from_slice(&other.right_indices);
+        let offset = self.boundaries[self.boundaries.len() - 1];
+        self.boundaries
+            .extend(other.boundaries[1..].iter().map(|b| b + offset));
         self.groups = None;
     }
 
+    fn composed(&self, other: &Self) -> Self {
+        let (coeffs, left_indices, right_indices, boundaries) = _compose(self, other);
+        Self {
+            coeffs,
+            left_indices,
+            right_indices,
+            boundaries,
+            groups: None,
+        }
+    }
+
+    fn matmul(&self, other: &Self) -> Self {
+        let (coeffs, left_indices, right_indices, boundaries) = _compose(other, self);
+        Self {
+            coeffs,
+            left_indices,
+            right_indices,
+            boundaries,
+            groups: None,
+        }
+    }
+
+    fn __iand__(&mut self, other: &Self) {
+        *self = self.composed(other);
+    }
+
     fn __imatmul__(&mut self, other: &Self) {
-        (
-            self.coeffs,
-            self.left_indices,
-            self.right_indices,
-            self.boundaries,
-        ) = _compose(other, self);
-        self.groups = None;
+        *self = self.matmul(other);
     }
 
     fn ichop(&mut self, atol: f64) {
@@ -1500,5 +1526,90 @@ mod tests {
         let round_trip = EdgeVertexOperator::from_terms_with_groups(op.iter_with_groups());
 
         assert_eq!(round_trip, op);
+    }
+
+    /// Two grouped, non-commuting operands for the allocation-free rewrites below.
+    ///
+    /// Grouped so that the tests can also assert that the out-of-place operations drop `groups`
+    /// exactly where their in-place counterparts do, and non-commuting so that an operand swap
+    /// cannot pass unnoticed.
+    fn operand_pair() -> (EdgeVertexOperator, EdgeVertexOperator) {
+        let op1 = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(2.0, -1.0), Complex64::new(3.0, 0.5)],
+            left_indices: vec![0, 2],
+            right_indices: vec![1, 3],
+            boundaries: vec![0, 1, 2],
+            groups: Some(vec![0, 1]),
+        };
+        let op2 = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(1.5, 2.0), Complex64::new(0.0, 4.0)],
+            left_indices: vec![1, 3],
+            right_indices: vec![2, 0],
+            boundaries: vec![0, 1, 2],
+            groups: Some(vec![0, 0]),
+        };
+        (op1, op2)
+    }
+
+    #[test]
+    fn test_and_matches_clone_then_and_assign() {
+        let (op1, op2) = operand_pair();
+
+        let mut expected = op1.clone();
+        expected.__iand__(&op2);
+
+        assert_eq!(op1.__and__(&op2), expected);
+        assert!(!op1.__and__(&op2).has_groups());
+    }
+
+    #[test]
+    fn test_matmul_matches_clone_then_matmul_assign() {
+        let (op1, op2) = operand_pair();
+
+        let mut expected = op1.clone();
+        expected.__imatmul__(&op2);
+
+        assert_eq!(op1.__matmul__(&op2), expected);
+        assert!(!op1.__matmul__(&op2).has_groups());
+    }
+
+    #[test]
+    fn test_sub_matches_add_of_negation() {
+        let (op1, op2) = operand_pair();
+
+        // The formulation `__sub__` used before it was fused, spelled out here so that the fused
+        // version is pinned to it. Complex coefficients matter: a sign error in the real part alone
+        // would survive real-only operands.
+        let mut expected = op1.clone();
+        expected.__iadd__(&op2.__neg__());
+
+        assert_eq!(op1.__sub__(&op2), expected);
+
+        let mut in_place = op1.clone();
+        in_place.__isub__(&op2);
+        assert_eq!(in_place, expected);
+    }
+
+    /// The out-of-place operations must not write through to either operand.
+    ///
+    /// `composed`/`matmul` take `&self`, so this cannot regress without a signature change, but the
+    /// in-place counterparts they now back (`*self = self.composed(other)`) make the property worth
+    /// stating outright.
+    #[test]
+    fn test_out_of_place_operations_leave_operands_untouched() {
+        let (op1, op2) = operand_pair();
+        let (op1_before, op2_before) = (op1.clone(), op2.clone());
+
+        let _ = op1.__and__(&op2);
+        let _ = op1.__matmul__(&op2);
+        let _ = op1.__sub__(&op2);
+        let _ = op1.__add__(&op2);
+        let _ = op1.__neg__();
+        let _ = op1.__pow__(2);
+        let _ = op1.adjoint();
+        let _ = op1.relabel_modes(vec![3, 2, 1, 0]);
+
+        assert_eq!(op1, op1_before);
+        assert_eq!(op2, op2_before);
     }
 }

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -38,7 +38,7 @@ impl FermionOperatorTermView<'_> {
     }
 
     pub fn into_vec(&'_ self) -> Vec<(bool, u32)> {
-        zip(self.actions.to_vec(), self.modes.to_vec()).collect()
+        zip(self.actions.iter().copied(), self.modes.iter().copied()).collect()
     }
 }
 
@@ -69,7 +69,7 @@ impl FermionOperatorGroupTermView<'_> {
     }
 
     pub fn into_vec(&'_ self) -> Vec<(bool, u32)> {
-        zip(self.actions.to_vec(), self.modes.to_vec()).collect()
+        zip(self.actions.iter().copied(), self.modes.iter().copied()).collect()
     }
 }
 
@@ -450,7 +450,7 @@ impl OperatorTrait for FermionOperator {
             coeffs,
             actions,
             modes,
-            boundaries: self.boundaries.to_vec(),
+            boundaries: self.boundaries.clone(),
             groups: self.groups.clone(),
         }
     }
@@ -601,26 +601,35 @@ impl OperatorTrait for FermionOperator {
     }
 
     fn get_support(&self) -> HashSet<u32> {
-        HashSet::from_iter(self.modes.clone())
+        self.modes.iter().copied().collect()
     }
 
     fn relabel_modes(&self, permutation: Vec<u32>) -> Result<Self, CoherenceError> {
         if permutation.iter().collect::<HashSet<_>>().len() != permutation.len() {
             return Err(CoherenceError::DuplicateIndices);
         }
-        let mut out = self.clone();
-        let new_modes: Result<Vec<u32>, CoherenceError> = self
+        // The relabelled modes are computed before anything is copied, so that the error path does
+        // not first clone the entire operator only to discard it.
+        let modes: Vec<u32> = self
             .modes
             .iter()
             .map(|&idx| {
                 permutation
                     .get(idx as usize)
-                    .cloned()
+                    .copied()
                     .ok_or(CoherenceError::IndexMapTooSmall)
             })
-            .collect();
-        out.modes = new_modes?;
-        Ok(out)
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
+            coeffs: self.coeffs.clone(),
+            actions: self.actions.clone(),
+            modes,
+            boundaries: self.boundaries.clone(),
+            // Relabelling permutes mode indices without reordering, splitting or merging terms, so
+            // any grouping of those terms carries over unchanged. This is the one operation that
+            // preserves `groups` rather than dropping it.
+            groups: self.groups.clone(),
+        })
     }
 }
 
@@ -1730,5 +1739,29 @@ mod tests {
 
         assert_eq!(op1, op1_before);
         assert_eq!(op2, op2_before);
+    }
+
+    #[test]
+    fn test_relabel_modes_preserves_groups() {
+        let op = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+            actions: vec![true, false, true, false],
+            modes: vec![0, 1, 2, 3],
+            boundaries: vec![0, 2, 4],
+            groups: Some(vec![0, 1]),
+        };
+
+        let relabeled = op.relabel_modes(vec![3, 2, 1, 0]).unwrap();
+
+        assert_eq!(
+            relabeled,
+            FermionOperator {
+                coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+                actions: vec![true, false, true, false],
+                modes: vec![3, 2, 1, 0],
+                boundaries: vec![0, 2, 4],
+                groups: Some(vec![0, 1]),
+            }
+        );
     }
 }

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -360,10 +360,16 @@ fn _compose(
     a: &FermionOperator,
     b: &FermionOperator,
 ) -> (Vec<Complex64>, Vec<bool>, Vec<u32>, Vec<usize>) {
-    let mut coeffs = vec![];
-    let mut actions = vec![];
-    let mut modes = vec![];
-    let mut boundaries = vec![0];
+    // The output size is known exactly: one term per (left, right) pair, each holding the factors
+    // of both inputs. Reserving up front turns the inner loop's repeated `extend_from_slice` into
+    // plain memcpy without the reallocation-and-copy rounds an unreserved vector would incur.
+    let num_terms = a.coeffs.len() * b.coeffs.len();
+    let num_factors = a.modes.len() * b.coeffs.len() + b.modes.len() * a.coeffs.len();
+    let mut coeffs = Vec::with_capacity(num_terms);
+    let mut actions = Vec::with_capacity(num_factors);
+    let mut modes = Vec::with_capacity(num_factors);
+    let mut boundaries = Vec::with_capacity(num_terms + 1);
+    boundaries.push(0);
 
     for left in a.iter() {
         for right in b.iter() {
@@ -463,14 +469,44 @@ impl OperatorTrait for FermionOperator {
         self.coeffs.iter_mut().for_each(|c| *c *= other);
     }
 
-    fn __iand__(&mut self, other: &Self) {
-        (self.coeffs, self.actions, self.modes, self.boundaries) = _compose(self, other);
+    fn __isub__(&mut self, other: &Self) {
+        self.coeffs.extend(other.coeffs.iter().map(|c| -c));
+        self.actions.extend_from_slice(&other.actions);
+        self.modes.extend_from_slice(&other.modes);
+        let offset = self.boundaries[self.boundaries.len() - 1];
+        self.boundaries
+            .extend(other.boundaries[1..].iter().map(|b| b + offset));
         self.groups = None;
     }
 
+    fn composed(&self, other: &Self) -> Self {
+        let (coeffs, actions, modes, boundaries) = _compose(self, other);
+        Self {
+            coeffs,
+            actions,
+            modes,
+            boundaries,
+            groups: None,
+        }
+    }
+
+    fn matmul(&self, other: &Self) -> Self {
+        let (coeffs, actions, modes, boundaries) = _compose(other, self);
+        Self {
+            coeffs,
+            actions,
+            modes,
+            boundaries,
+            groups: None,
+        }
+    }
+
+    fn __iand__(&mut self, other: &Self) {
+        *self = self.composed(other);
+    }
+
     fn __imatmul__(&mut self, other: &Self) {
-        (self.coeffs, self.actions, self.modes, self.boundaries) = _compose(other, self);
-        self.groups = None;
+        *self = self.matmul(other);
     }
 
     fn ichop(&mut self, atol: f64) {
@@ -1609,5 +1645,90 @@ mod tests {
         let round_trip = FermionOperator::from_terms_with_groups(op.iter_with_groups());
 
         assert_eq!(round_trip, op);
+    }
+
+    /// Two grouped, non-commuting operands for the allocation-free rewrites below.
+    ///
+    /// Grouped so that the tests can also assert that the out-of-place operations drop `groups`
+    /// exactly where their in-place counterparts do, and non-commuting so that an operand swap
+    /// cannot pass unnoticed.
+    fn operand_pair() -> (FermionOperator, FermionOperator) {
+        let op1 = FermionOperator {
+            coeffs: vec![Complex64::new(2.0, -1.0), Complex64::new(3.0, 0.5)],
+            actions: vec![true, false],
+            modes: vec![0, 1],
+            boundaries: vec![0, 0, 2],
+            groups: Some(vec![0, 1]),
+        };
+        let op2 = FermionOperator {
+            coeffs: vec![Complex64::new(1.5, 2.0), Complex64::new(0.0, 4.0)],
+            actions: vec![true, false],
+            modes: vec![1, 0],
+            boundaries: vec![0, 0, 2],
+            groups: Some(vec![0, 0]),
+        };
+        (op1, op2)
+    }
+
+    #[test]
+    fn test_and_matches_clone_then_and_assign() {
+        let (op1, op2) = operand_pair();
+
+        let mut expected = op1.clone();
+        expected.__iand__(&op2);
+
+        assert_eq!(op1.__and__(&op2), expected);
+        assert!(!op1.__and__(&op2).has_groups());
+    }
+
+    #[test]
+    fn test_matmul_matches_clone_then_matmul_assign() {
+        let (op1, op2) = operand_pair();
+
+        let mut expected = op1.clone();
+        expected.__imatmul__(&op2);
+
+        assert_eq!(op1.__matmul__(&op2), expected);
+        assert!(!op1.__matmul__(&op2).has_groups());
+    }
+
+    #[test]
+    fn test_sub_matches_add_of_negation() {
+        let (op1, op2) = operand_pair();
+
+        // The formulation `__sub__` used before it was fused, spelled out here so that the fused
+        // version is pinned to it. Complex coefficients matter: a sign error in the real part alone
+        // would survive real-only operands.
+        let mut expected = op1.clone();
+        expected.__iadd__(&op2.__neg__());
+
+        assert_eq!(op1.__sub__(&op2), expected);
+
+        let mut in_place = op1.clone();
+        in_place.__isub__(&op2);
+        assert_eq!(in_place, expected);
+    }
+
+    /// The out-of-place operations must not write through to either operand.
+    ///
+    /// `composed`/`matmul` take `&self`, so this cannot regress without a signature change, but the
+    /// in-place counterparts they now back (`*self = self.composed(other)`) make the property worth
+    /// stating outright.
+    #[test]
+    fn test_out_of_place_operations_leave_operands_untouched() {
+        let (op1, op2) = operand_pair();
+        let (op1_before, op2_before) = (op1.clone(), op2.clone());
+
+        let _ = op1.__and__(&op2);
+        let _ = op1.__matmul__(&op2);
+        let _ = op1.__sub__(&op2);
+        let _ = op1.__add__(&op2);
+        let _ = op1.__neg__();
+        let _ = op1.__pow__(2);
+        let _ = op1.adjoint();
+        let _ = op1.relabel_modes(vec![1, 0]);
+
+        assert_eq!(op1, op1_before);
+        assert_eq!(op2, op2_before);
     }
 }

--- a/crates/core/src/operators/fermion_operator.rs
+++ b/crates/core/src/operators/fermion_operator.rs
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::operators::{CoherenceError, OperatorMacro, OperatorTrait, TermSortKey};
+use crate::operators::{CoherenceError, OperatorMacro, OperatorTrait, ScaledTerm, TermSortKey};
 use num_complex::{Complex64, ComplexFloat};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
@@ -51,6 +51,15 @@ impl TermSortKey for FermionOperatorTermView<'_> {
     }
 }
 
+impl ScaledTerm for FermionOperatorTermView<'_> {
+    fn scaled(mut self, factor: Complex64) -> Self {
+        // Only the coefficient changes; the index data stays borrowed from the operator this view
+        // came from, so nothing is copied.
+        self.coeff *= factor;
+        self
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FermionOperatorGroupTermView<'a> {
     pub coeff: Complex64,
@@ -78,6 +87,13 @@ impl TermSortKey for FermionOperatorGroupTermView<'_> {
         // Match the ungrouped `TermView` key exactly (ignoring `group`), so ordering a grouped
         // operator agrees with ordering the same terms ungrouped.
         self.into_vec()
+    }
+}
+
+impl ScaledTerm for FermionOperatorGroupTermView<'_> {
+    fn scaled(mut self, factor: Complex64) -> Self {
+        self.coeff *= factor;
+        self
     }
 }
 

--- a/crates/core/src/operators/library/commutators.rs
+++ b/crates/core/src/operators/library/commutators.rs
@@ -10,15 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::operators::OperatorMacro;
+use crate::operators::{OperatorMacro, OperatorTrait, ScaledTerm};
 use num_complex::Complex64;
-
-// PERF: we should be able to improve the efficiency of all three functions below by writing one
-// function that computes the pair of BitAnd products (A&B, B&A) during a single loop rather than
-// two separate loops (in the respective BitAnd implementations). Doing so for a generic type T
-// will likely require a custom iterator to be implemented by the OperatorMacro. But this should
-// directly benefit the commutator, anti_commutator, and various computations inside the
-// double_commutator functions.
 
 pub fn commutator<T>(op_a: &T, op_b: &T) -> T
 where
@@ -36,7 +29,7 @@ where
 
 pub fn double_commutator<T>(op_a: &T, op_b: &T, op_c: &T, sign: bool) -> T
 where
-    T: OperatorMacro,
+    T: OperatorMacro + OperatorTrait,
 {
     let sign_num = if sign {
         Complex64::new(1.0, 0.0)
@@ -56,24 +49,56 @@ where
     let op_acb = op_ac.__matmul__(op_b);
     let op_bca = op_b.__matmul__(&op_ca);
 
-    // The bracketed half-weighted part is a single four-term sum: splitting it into two halves and
-    // subtracting them would flip the sign of the `op_bca` contribution.
-    let inner = op_bac
-        .__neg__()
-        .__add__(&op_cab.__mul__(sign_num))
-        .__sub__(&op_acb)
-        .__add__(&op_bca.__mul__(sign_num));
+    // Rescales every term of `op` by `weight`, allocating nothing: a term view owns its coefficient
+    // and only borrows the index data. A local `fn` rather than a closure because the borrow of
+    // `op` outlives the call, and a closure's return type cannot be generic over that lifetime.
+    fn weighted<'a, T: OperatorTrait>(
+        op: &'a T,
+        weight: Complex64,
+    ) -> impl Iterator<Item = T::TermView<'a>> {
+        op.iter().map(move |term| term.scaled(weight))
+    }
 
-    op_abc
-        .__sub__(&op_cba.__mul__(sign_num))
-        .__add__(&inner.__mul__(Complex64::new(0.5, 0.0)))
+    let half = Complex64::new(0.5, 0.0);
+
+    // The result is the six triple products, each carrying a fixed weight:
+    //
+    //     ABC - s CBA - BAC/2 + s CAB/2 - ACB/2 + s BCA/2,    s = sign_num = +-1
+    //
+    // which reproduces both documented forms: `sign = false` gives
+    // `(2 ABC + 2 CBA - BAC - CAB - ACB - BCA)/2` and `sign = true` gives
+    // `(2 ABC - 2 CBA - BAC + CAB - ACB + BCA)/2`. Mind the `+s BCA/2`: the four half-weighted
+    // products form a single sum, so grouping them into two halves in order to subtract one from
+    // the other would flip that sign. Folding each weight into its own block removes that hazard
+    // rather than merely warning about it.
+    //
+    // Appending all six blocks in a single pass replaces a chain of nine
+    // `__mul__`/`__add__`/`__sub__` calls, each of which copied its left operand - an operand that
+    // grew with every step, so early terms were copied over and over. Here every term is copied
+    // exactly once. All weights are +-1 or +-1/2, so folding them into the coefficients is exact.
+    //
+    // The append order is the order the old chain emitted, which is *not* the order in which the
+    // products are computed above: `op_cba` comes second, before `op_bac`. Keeping it makes the
+    // result's term order - and hence its buffers - identical to the previous formulation rather
+    // than merely equivalent. `test_double_commutator_layout` pins this down, and
+    // `test_double_commutator_weights_*` pin the weights independently of that order.
+    T::from_terms(
+        weighted(&op_abc, Complex64::new(1.0, 0.0))
+            .chain(weighted(&op_cba, -sign_num))
+            .chain(weighted(&op_bac, -half))
+            .chain(weighted(&op_cab, sign_num * half))
+            .chain(weighted(&op_acb, -half))
+            .chain(weighted(&op_bca, sign_num * half)),
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::operators::OperatorTrait;
+    use crate::operators::edge_vertex_operator::EdgeVertexOperator;
     use crate::operators::fermion_operator::FermionOperator;
+    use crate::operators::majorana_operator::MajoranaOperator;
+    use crate::operators::transfer_vertex_operator::TransferVertexOperator;
 
     #[test]
     fn test_commutators() {
@@ -212,5 +237,287 @@ mod tests {
         let normal_ordered = comm.normal_ordered(None);
         let canon = normal_ordered.simplify(1e-8);
         assert_eq!(canon, FermionOperator::zero());
+    }
+
+    /// Pins down the exact memory layout of the double commutator's result.
+    ///
+    /// This is a layout pin, not an algebraic claim: it guards the order in which the six triple
+    /// products are appended, and the exact order in which their weights are multiplied into the
+    /// coefficients. Every other double-commutator test routes through `normal_ordered`,
+    /// `simplify` or `equiv`, all of which are insensitive to term order, so none of them can
+    /// detect a reordering. Two of the coefficients below differ from their partners in the last
+    /// bit, which is real floating-point structure of the weighting order.
+    ///
+    /// The operands are deliberately non-commuting, non-symmetric, of differing lengths, with
+    /// differing creation/annihilation patterns and complex coefficients, so that every one of the
+    /// five buffers is actually constrained.
+    #[test]
+    fn test_double_commutator_layout() {
+        // (1 + 0.25i) a^\dagger_0 a_1
+        let op_a = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 0.25)],
+            actions: vec![true, false],
+            modes: vec![0, 1],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        // (0.5 - 0.75i) a^\dagger_1 a^\dagger_2
+        let op_b = FermionOperator {
+            coeffs: vec![Complex64::new(0.5, -0.75)],
+            actions: vec![true, true],
+            modes: vec![1, 2],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        // (-0.3 + 1.5i) a_2
+        let op_c = FermionOperator {
+            coeffs: vec![Complex64::new(-0.3, 1.5)],
+            actions: vec![false],
+            modes: vec![2],
+            boundaries: vec![0, 1],
+            groups: None,
+        };
+
+        // The index buffers do not depend on `sign`, only the coefficients do.
+        let actions = vec![
+            true, false, true, true, false, // ABC
+            false, true, true, true, false, // CBA
+            true, true, true, false, false, // BAC
+            false, true, false, true, true, // CAB
+            true, false, false, true, true, // ACB
+            true, true, false, true, false, // BCA
+        ];
+        let modes = vec![
+            0, 1, 1, 2, 2, // ABC
+            2, 1, 2, 0, 1, // CBA
+            1, 2, 0, 1, 2, // BAC
+            2, 0, 1, 1, 2, // CAB
+            0, 1, 2, 1, 2, // ACB
+            1, 2, 2, 0, 1, // BCA
+        ];
+        let boundaries = vec![0, 5, 10, 15, 20, 25, 30];
+
+        let comm = double_commutator(&op_a, &op_b, &op_c, false);
+        assert_eq!(
+            comm,
+            FermionOperator {
+                coeffs: vec![
+                    Complex64::new(0.73125, 1.21875),
+                    Complex64::new(0.73125, 1.21875),
+                    Complex64::new(-0.365625, -0.609375),
+                    Complex64::new(-0.365625, -0.609375),
+                    Complex64::new(-0.36562500000000003, -0.609375),
+                    Complex64::new(-0.36562500000000003, -0.609375),
+                ],
+                actions: actions.clone(),
+                modes: modes.clone(),
+                boundaries: boundaries.clone(),
+                groups: None,
+            }
+        );
+
+        let comm = double_commutator(&op_a, &op_b, &op_c, true);
+        assert_eq!(
+            comm,
+            FermionOperator {
+                coeffs: vec![
+                    Complex64::new(0.73125, 1.21875),
+                    Complex64::new(-0.73125, -1.21875),
+                    Complex64::new(-0.365625, -0.609375),
+                    Complex64::new(0.365625, 0.609375),
+                    Complex64::new(-0.36562500000000003, -0.609375),
+                    Complex64::new(0.36562500000000003, 0.609375),
+                ],
+                actions,
+                modes,
+                boundaries,
+                groups: None,
+            }
+        );
+    }
+
+    /// Checks the weighted sum term-order-blindly, but sensitively to every weight's sign.
+    ///
+    /// Builds `ABC - s CBA - BAC/2 + s CAB/2 - ACB/2 + s BCA/2` explicitly from the ten products
+    /// and compares with `equiv`, which is insensitive to term order. This is the check that
+    /// catches a wrong sign or a wrong weight, complementing the layout pin (which catches a
+    /// reordering but would also flag a harmless one). It is generic so that it exercises the
+    /// `ScaledTerm` impls of all four operator types.
+    fn assert_double_commutator_weights<T>(op_a: &T, op_b: &T, op_c: &T)
+    where
+        T: OperatorMacro + OperatorTrait + std::fmt::Debug,
+    {
+        let half = Complex64::new(0.5, 0.0);
+        for sign in [false, true] {
+            let sign_num = if sign {
+                Complex64::new(1.0, 0.0)
+            } else {
+                Complex64::new(-1.0, 0.0)
+            };
+
+            let op_ab = op_a.__matmul__(op_b);
+            let op_ba = op_b.__matmul__(op_a);
+            let op_ac = op_a.__matmul__(op_c);
+            let op_ca = op_c.__matmul__(op_a);
+
+            let expected = op_ab
+                .__matmul__(op_c)
+                .__sub__(&op_c.__matmul__(&op_ba).__mul__(sign_num))
+                .__sub__(&op_ba.__matmul__(op_c).__mul__(half))
+                .__add__(&op_c.__matmul__(&op_ab).__mul__(sign_num * half))
+                .__sub__(&op_ac.__matmul__(op_b).__mul__(half))
+                .__add__(&op_b.__matmul__(&op_ca).__mul__(sign_num * half));
+
+            let actual = double_commutator(op_a, op_b, op_c, sign);
+            assert!(
+                actual.equiv(&expected, 1e-12),
+                "weights disagree for sign={sign}"
+            );
+            // Guard against a slip to `from_terms_with_groups`: every product comes from `matmul`,
+            // which tracks no groups, so neither may the sum.
+            assert!(actual.groups().is_none());
+        }
+    }
+
+    #[test]
+    fn test_double_commutator_weights_fermion() {
+        let op_a = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 0.25), Complex64::new(-0.4, 0.0)],
+            actions: vec![true, false, true],
+            modes: vec![0, 1, 2],
+            boundaries: vec![0, 2, 3],
+            groups: None,
+        };
+        let op_b = FermionOperator {
+            coeffs: vec![Complex64::new(0.5, -0.75)],
+            actions: vec![true, true],
+            modes: vec![1, 2],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        let op_c = FermionOperator {
+            coeffs: vec![Complex64::new(-0.3, 1.5), Complex64::new(0.0, 0.6)],
+            actions: vec![false, false, true],
+            modes: vec![2, 0, 1],
+            boundaries: vec![0, 1, 3],
+            groups: None,
+        };
+        assert_double_commutator_weights(&op_a, &op_b, &op_c);
+    }
+
+    #[test]
+    fn test_double_commutator_weights_majorana() {
+        let op_a = MajoranaOperator {
+            coeffs: vec![Complex64::new(1.0, 0.25), Complex64::new(-0.4, 0.0)],
+            modes: vec![0, 1, 2],
+            boundaries: vec![0, 2, 3],
+            groups: None,
+        };
+        let op_b = MajoranaOperator {
+            coeffs: vec![Complex64::new(0.5, -0.75)],
+            modes: vec![1, 3],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        let op_c = MajoranaOperator {
+            coeffs: vec![Complex64::new(-0.3, 1.5), Complex64::new(0.0, 0.6)],
+            modes: vec![2, 0, 1],
+            boundaries: vec![0, 1, 3],
+            groups: None,
+        };
+        assert_double_commutator_weights(&op_a, &op_b, &op_c);
+    }
+
+    #[test]
+    fn test_double_commutator_weights_edge_vertex() {
+        let op_a = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 0.25), Complex64::new(-0.4, 0.0)],
+            left_indices: vec![0, 1, 2],
+            right_indices: vec![1, 2, 2],
+            boundaries: vec![0, 2, 3],
+            groups: None,
+        };
+        let op_b = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(0.5, -0.75)],
+            left_indices: vec![1, 3],
+            right_indices: vec![2, 3],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        let op_c = EdgeVertexOperator {
+            coeffs: vec![Complex64::new(-0.3, 1.5), Complex64::new(0.0, 0.6)],
+            left_indices: vec![2, 0, 1],
+            right_indices: vec![2, 1, 1],
+            boundaries: vec![0, 1, 3],
+            groups: None,
+        };
+        assert_double_commutator_weights(&op_a, &op_b, &op_c);
+    }
+
+    #[test]
+    fn test_double_commutator_weights_transfer_vertex() {
+        let op_a = TransferVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 0.25), Complex64::new(-0.4, 0.0)],
+            left_indices: vec![0, 1, 2],
+            right_indices: vec![1, 2, 2],
+            boundaries: vec![0, 2, 3],
+            groups: None,
+        };
+        let op_b = TransferVertexOperator {
+            coeffs: vec![Complex64::new(0.5, -0.75)],
+            left_indices: vec![1, 3],
+            right_indices: vec![2, 3],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        let op_c = TransferVertexOperator {
+            coeffs: vec![Complex64::new(-0.3, 1.5), Complex64::new(0.0, 0.6)],
+            left_indices: vec![2, 0, 1],
+            right_indices: vec![2, 1, 1],
+            boundaries: vec![0, 1, 3],
+            groups: None,
+        };
+        assert_double_commutator_weights(&op_a, &op_b, &op_c);
+    }
+
+    /// The result tracks no groups even when the inputs do.
+    ///
+    /// `matmul` drops groups, so all ten products are already ungrouped; this pins that the
+    /// single-pass sum does not reintroduce them by reaching for `from_terms_with_groups`.
+    #[test]
+    fn test_double_commutator_drops_groups() {
+        let grouped = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(0.5, 0.0)],
+            actions: vec![true, false, true, false],
+            modes: vec![0, 1, 1, 2],
+            boundaries: vec![0, 2, 4],
+            groups: Some(vec![0, 1]),
+        };
+        assert!(grouped.groups().is_some());
+        for sign in [false, true] {
+            let comm = double_commutator(&grouped, &grouped, &grouped, sign);
+            assert!(comm.groups().is_none());
+        }
+    }
+
+    /// A zero operand annihilates every one of the six products, so the sum is empty.
+    ///
+    /// Worth pinning because an empty result must still carry the leading `0` boundary that every
+    /// operator has - a single-pass build that forgot to start from `zero()` would produce an
+    /// operator with an empty `boundaries` vector instead.
+    #[test]
+    fn test_double_commutator_zero_operand() {
+        let op = FermionOperator {
+            coeffs: vec![Complex64::new(1.0, 0.5)],
+            actions: vec![true, false],
+            modes: vec![0, 1],
+            boundaries: vec![0, 2],
+            groups: None,
+        };
+        for sign in [false, true] {
+            let comm = double_commutator(&op, &FermionOperator::zero(), &op, sign);
+            assert_eq!(comm, FermionOperator::zero());
+            assert_eq!(comm.boundaries, vec![0]);
+        }
     }
 }

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::operators::{CoherenceError, OperatorMacro, OperatorTrait, TermSortKey};
+use crate::operators::{CoherenceError, OperatorMacro, OperatorTrait, ScaledTerm, TermSortKey};
 use num_complex::{Complex64, ComplexFloat};
 use std::collections::{HashMap, HashSet};
 use std::ops::{
@@ -48,6 +48,13 @@ impl TermSortKey for MajoranaOperatorTermView<'_> {
     }
 }
 
+impl ScaledTerm for MajoranaOperatorTermView<'_> {
+    fn scaled(mut self, factor: Complex64) -> Self {
+        self.coeff *= factor;
+        self
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MajoranaOperatorGroupTermView<'a> {
     pub coeff: Complex64,
@@ -74,6 +81,13 @@ impl TermSortKey for MajoranaOperatorGroupTermView<'_> {
         // Match the ungrouped `TermView` key exactly (ignoring `group`), so ordering a grouped
         // operator agrees with ordering the same terms ungrouped.
         self.into_vec()
+    }
+}
+
+impl ScaledTerm for MajoranaOperatorGroupTermView<'_> {
+    fn scaled(mut self, factor: Complex64) -> Self {
+        self.coeff *= factor;
+        self
     }
 }
 

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -300,9 +300,15 @@ fn reduce_pairs(tpl: &[u32]) -> Vec<u32> {
 }
 
 fn _compose(a: &MajoranaOperator, b: &MajoranaOperator) -> (Vec<Complex64>, Vec<u32>, Vec<usize>) {
-    let mut coeffs = vec![];
-    let mut modes = vec![];
-    let mut boundaries = vec![0];
+    // The output size is known exactly: one term per (left, right) pair, each holding the factors
+    // of both inputs. Reserving up front turns the inner loop's repeated `extend_from_slice` into
+    // plain memcpy without the reallocation-and-copy rounds an unreserved vector would incur.
+    let num_terms = a.coeffs.len() * b.coeffs.len();
+    let num_factors = a.modes.len() * b.coeffs.len() + b.modes.len() * a.coeffs.len();
+    let mut coeffs = Vec::with_capacity(num_terms);
+    let mut modes = Vec::with_capacity(num_factors);
+    let mut boundaries = Vec::with_capacity(num_terms + 1);
+    boundaries.push(0);
 
     for left in a.iter() {
         for right in b.iter() {
@@ -394,14 +400,41 @@ impl OperatorTrait for MajoranaOperator {
         self.coeffs.iter_mut().for_each(|c| *c *= other);
     }
 
-    fn __iand__(&mut self, other: &Self) {
-        (self.coeffs, self.modes, self.boundaries) = _compose(self, other);
+    fn __isub__(&mut self, other: &Self) {
+        self.coeffs.extend(other.coeffs.iter().map(|c| -c));
+        self.modes.extend_from_slice(&other.modes);
+        let offset = self.boundaries[self.boundaries.len() - 1];
+        self.boundaries
+            .extend(other.boundaries[1..].iter().map(|b| b + offset));
         self.groups = None;
     }
 
+    fn composed(&self, other: &Self) -> Self {
+        let (coeffs, modes, boundaries) = _compose(self, other);
+        Self {
+            coeffs,
+            modes,
+            boundaries,
+            groups: None,
+        }
+    }
+
+    fn matmul(&self, other: &Self) -> Self {
+        let (coeffs, modes, boundaries) = _compose(other, self);
+        Self {
+            coeffs,
+            modes,
+            boundaries,
+            groups: None,
+        }
+    }
+
+    fn __iand__(&mut self, other: &Self) {
+        *self = self.composed(other);
+    }
+
     fn __imatmul__(&mut self, other: &Self) {
-        (self.coeffs, self.modes, self.boundaries) = _compose(other, self);
-        self.groups = None;
+        *self = self.matmul(other);
     }
 
     fn ichop(&mut self, atol: f64) {
@@ -1330,5 +1363,88 @@ mod tests {
         let round_trip = MajoranaOperator::from_terms_with_groups(op.iter_with_groups());
 
         assert_eq!(round_trip, op);
+    }
+
+    /// Two grouped, non-commuting operands for the allocation-free rewrites below.
+    ///
+    /// Grouped so that the tests can also assert that the out-of-place operations drop `groups`
+    /// exactly where their in-place counterparts do, and non-commuting so that an operand swap
+    /// cannot pass unnoticed.
+    fn operand_pair() -> (MajoranaOperator, MajoranaOperator) {
+        let op1 = MajoranaOperator {
+            coeffs: vec![Complex64::new(2.0, -1.0), Complex64::new(3.0, 0.5)],
+            modes: vec![0, 1],
+            boundaries: vec![0, 1, 2],
+            groups: Some(vec![0, 1]),
+        };
+        let op2 = MajoranaOperator {
+            coeffs: vec![Complex64::new(1.5, 2.0), Complex64::new(0.0, 4.0)],
+            modes: vec![1, 2],
+            boundaries: vec![0, 1, 2],
+            groups: Some(vec![0, 0]),
+        };
+        (op1, op2)
+    }
+
+    #[test]
+    fn test_and_matches_clone_then_and_assign() {
+        let (op1, op2) = operand_pair();
+
+        let mut expected = op1.clone();
+        expected.__iand__(&op2);
+
+        assert_eq!(op1.__and__(&op2), expected);
+        assert!(!op1.__and__(&op2).has_groups());
+    }
+
+    #[test]
+    fn test_matmul_matches_clone_then_matmul_assign() {
+        let (op1, op2) = operand_pair();
+
+        let mut expected = op1.clone();
+        expected.__imatmul__(&op2);
+
+        assert_eq!(op1.__matmul__(&op2), expected);
+        assert!(!op1.__matmul__(&op2).has_groups());
+    }
+
+    #[test]
+    fn test_sub_matches_add_of_negation() {
+        let (op1, op2) = operand_pair();
+
+        // The formulation `__sub__` used before it was fused, spelled out here so that the fused
+        // version is pinned to it. Complex coefficients matter: a sign error in the real part alone
+        // would survive real-only operands.
+        let mut expected = op1.clone();
+        expected.__iadd__(&op2.__neg__());
+
+        assert_eq!(op1.__sub__(&op2), expected);
+
+        let mut in_place = op1.clone();
+        in_place.__isub__(&op2);
+        assert_eq!(in_place, expected);
+    }
+
+    /// The out-of-place operations must not write through to either operand.
+    ///
+    /// `composed`/`matmul` take `&self`, so this cannot regress without a signature change, but the
+    /// in-place counterparts they now back (`*self = self.composed(other)`) make the property worth
+    /// stating outright.
+    #[test]
+    fn test_out_of_place_operations_leave_operands_untouched() {
+        let (op1, op2) = operand_pair();
+        let (op1_before, op2_before) = (op1.clone(), op2.clone());
+
+        let _ = op1.__and__(&op2);
+        let _ = op1.__matmul__(&op2);
+        let _ = op1.__sub__(&op2);
+        let _ = op1.__add__(&op2);
+        let _ = op1.__neg__();
+        let _ = op1.__pow__(2);
+        let _ = op1.adjoint();
+        let _ = op1.relabel_modes(vec![1, 0]);
+
+        assert_eq!(op1, op1_before);
+        assert_eq!(op2, op2_before);
     }
 }

--- a/crates/core/src/operators/majorana_operator.rs
+++ b/crates/core/src/operators/majorana_operator.rs
@@ -382,7 +382,7 @@ impl OperatorTrait for MajoranaOperator {
         Self {
             coeffs,
             modes,
-            boundaries: self.boundaries.to_vec(),
+            boundaries: self.boundaries.clone(),
             groups: self.groups.clone(),
         }
     }
@@ -524,26 +524,34 @@ impl OperatorTrait for MajoranaOperator {
     }
 
     fn get_support(&self) -> HashSet<u32> {
-        HashSet::from_iter(self.modes.clone())
+        self.modes.iter().copied().collect()
     }
 
     fn relabel_modes(&self, permutation: Vec<u32>) -> Result<Self, CoherenceError> {
         if permutation.iter().collect::<HashSet<_>>().len() != permutation.len() {
             return Err(CoherenceError::DuplicateIndices);
         }
-        let mut out = self.clone();
-        let new_modes: Result<Vec<u32>, CoherenceError> = self
+        // The relabelled modes are computed before anything is copied, so that the error path does
+        // not first clone the entire operator only to discard it.
+        let modes: Vec<u32> = self
             .modes
             .iter()
             .map(|&idx| {
                 permutation
                     .get(idx as usize)
-                    .cloned()
+                    .copied()
                     .ok_or(CoherenceError::IndexMapTooSmall)
             })
-            .collect();
-        out.modes = new_modes?;
-        Ok(out)
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
+            coeffs: self.coeffs.clone(),
+            modes,
+            boundaries: self.boundaries.clone(),
+            // Relabelling permutes mode indices without reordering, splitting or merging terms, so
+            // any grouping of those terms carries over unchanged. This is the one operation that
+            // preserves `groups` rather than dropping it.
+            groups: self.groups.clone(),
+        })
     }
 }
 
@@ -1446,5 +1454,27 @@ mod tests {
 
         assert_eq!(op1, op1_before);
         assert_eq!(op2, op2_before);
+    }
+
+    #[test]
+    fn test_relabel_modes_preserves_groups() {
+        let op = MajoranaOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+            modes: vec![0, 1, 2, 3],
+            boundaries: vec![0, 2, 4],
+            groups: Some(vec![0, 1]),
+        };
+
+        let relabeled = op.relabel_modes(vec![3, 2, 1, 0]).unwrap();
+
+        assert_eq!(
+            relabeled,
+            MajoranaOperator {
+                coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+                modes: vec![3, 2, 1, 0],
+                boundaries: vec![0, 2, 4],
+                groups: Some(vec![0, 1]),
+            }
+        );
     }
 }

--- a/crates/core/src/operators/mod.rs
+++ b/crates/core/src/operators/mod.rs
@@ -54,6 +54,32 @@ pub trait OperatorTrait {
     fn __imatmul__(&mut self, other: &Self);
     fn ichop(&mut self, atol: f64);
 
+    /// Subtracts `other` from `self` in place.
+    ///
+    /// Implemented per operator type rather than as `__iadd__(&other.__neg__())` because
+    /// [`__neg__`](OperatorMacro::__neg__) deep-copies *all* of `other`'s buffers - index data
+    /// included - only to scale its coefficients, which `__iadd__` then copies a second time.
+    /// Appending `other`'s terms while negating just the newly appended coefficients does the same
+    /// work in one pass and with no temporary.
+    fn __isub__(&mut self, other: &Self);
+
+    /// Returns the composition `self & other`, i.e. with `other` applied first.
+    ///
+    /// This exists as its own method rather than being expressed as a clone followed by
+    /// [`__iand__`](Self::__iand__) because composing rebuilds every buffer from scratch: cloning
+    /// first would allocate and copy buffers that are immediately overwritten and dropped unread.
+    ///
+    /// The composition of two operators tracks no groups, matching `__iand__`.
+    fn composed(&self, other: &Self) -> Self;
+
+    /// Returns the composition `self @ other`, i.e. with `self` applied first.
+    ///
+    /// The counterpart of [`composed`](Self::composed) carrying the operand order of
+    /// [`__imatmul__`](Self::__imatmul__). Both orders are spelled out once per operator type,
+    /// next to the in-place operation each mirrors, rather than being derived from one another by
+    /// swapping arguments at the call site.
+    fn matmul(&self, other: &Self) -> Self;
+
     /// The borrowed view of a single term yielded by [`OperatorTrait::iter`].
     type TermView<'a>: PartialEq + TermSortKey
     where
@@ -186,7 +212,6 @@ pub trait OperatorMacro {
     fn __pow__(&self, exponent: usize) -> Self;
 
     // more in-place operations
-    fn __isub__(&mut self, other: &Self);
     fn __idiv__(&mut self, other: Complex64);
 }
 
@@ -207,16 +232,12 @@ macro_rules! impl_operator_macro {
             where
                 Self: OperatorTrait,
             {
+                // Unlike the composing operations below, this clone is load-bearing: `__isub__`
+                // appends to the existing buffers, so the result genuinely starts out as a copy of
+                // `self`.
                 let mut result = self.clone();
-                result.__iadd__(&other.__neg__());
+                result.__isub__(other);
                 result
-            }
-
-            fn __isub__(&mut self, other: &Self)
-            where
-                Self: OperatorTrait,
-            {
-                self.__iadd__(&other.__neg__());
             }
 
             fn __mul__(&self, other: Complex64) -> Self
@@ -255,18 +276,16 @@ macro_rules! impl_operator_macro {
             where
                 Self: OperatorTrait,
             {
-                let mut result = self.clone();
-                result.__iand__(other);
-                result
+                // Composing reads both operands through borrowed term views and returns freshly
+                // built buffers, so there is nothing a clone of `self` could contribute here.
+                self.composed(other)
             }
 
             fn __matmul__(&self, other: &Self) -> Self
             where
                 Self: OperatorTrait,
             {
-                let mut result = self.clone();
-                result.__imatmul__(other);
-                result
+                self.matmul(other)
             }
 
             fn __pow__(&self, exponent: usize) -> Self

--- a/crates/core/src/operators/mod.rs
+++ b/crates/core/src/operators/mod.rs
@@ -40,6 +40,18 @@ pub trait TermSortKey {
     fn sort_key(&self) -> impl Ord;
 }
 
+/// Rescales the coefficient of a single term view.
+///
+/// Implemented by the `*TermView` structs. Because a view owns its coefficient outright and only
+/// borrows the index data, rescaling one allocates nothing - it is a field update on a `Copy`
+/// struct. This is what lets a weighted sum of operators be built in a single pass through
+/// [`OperatorTrait::from_terms`], instead of materialising a scaled copy of every summand and then
+/// concatenating those copies one at a time.
+pub trait ScaledTerm {
+    /// Returns this term with its coefficient multiplied by `factor`.
+    fn scaled(self, factor: Complex64) -> Self;
+}
+
 pub trait OperatorTrait {
     fn zero() -> Self;
     fn one() -> Self;
@@ -81,7 +93,7 @@ pub trait OperatorTrait {
     fn matmul(&self, other: &Self) -> Self;
 
     /// The borrowed view of a single term yielded by [`OperatorTrait::iter`].
-    type TermView<'a>: PartialEq + TermSortKey
+    type TermView<'a>: PartialEq + TermSortKey + ScaledTerm
     where
         Self: 'a;
 
@@ -91,7 +103,7 @@ pub trait OperatorTrait {
     /// Its [`TermSortKey`] must match that of the corresponding [`Self::TermView`] (i.e. ignore the
     /// group index), so that ordering a grouped operator agrees with ordering the same terms
     /// ungrouped.
-    type GroupTermView<'a>: PartialEq + TermSortKey
+    type GroupTermView<'a>: PartialEq + TermSortKey + ScaledTerm
     where
         Self: 'a;
 

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -268,10 +268,16 @@ fn _compose(
     a: &TransferVertexOperator,
     b: &TransferVertexOperator,
 ) -> (Vec<Complex64>, Vec<u32>, Vec<u32>, Vec<usize>) {
-    let mut coeffs = vec![];
-    let mut left_indices = vec![];
-    let mut right_indices = vec![];
-    let mut boundaries = vec![0];
+    // The output size is known exactly: one term per (left, right) pair, each holding the factors
+    // of both inputs. Reserving up front turns the inner loop's repeated `extend_from_slice` into
+    // plain memcpy without the reallocation-and-copy rounds an unreserved vector would incur.
+    let num_terms = a.coeffs.len() * b.coeffs.len();
+    let num_factors = a.left_indices.len() * b.coeffs.len() + b.left_indices.len() * a.coeffs.len();
+    let mut coeffs = Vec::with_capacity(num_terms);
+    let mut left_indices = Vec::with_capacity(num_factors);
+    let mut right_indices = Vec::with_capacity(num_factors);
+    let mut boundaries = Vec::with_capacity(num_terms + 1);
+    boundaries.push(0);
 
     for left in a.iter() {
         for right in b.iter() {
@@ -377,24 +383,44 @@ impl OperatorTrait for TransferVertexOperator {
         self.coeffs.iter_mut().for_each(|c| *c *= other);
     }
 
-    fn __iand__(&mut self, other: &Self) {
-        (
-            self.coeffs,
-            self.left_indices,
-            self.right_indices,
-            self.boundaries,
-        ) = _compose(self, other);
+    fn __isub__(&mut self, other: &Self) {
+        self.coeffs.extend(other.coeffs.iter().map(|c| -c));
+        self.left_indices.extend_from_slice(&other.left_indices);
+        self.right_indices.extend_from_slice(&other.right_indices);
+        let offset = self.boundaries[self.boundaries.len() - 1];
+        self.boundaries
+            .extend(other.boundaries[1..].iter().map(|b| b + offset));
         self.groups = None;
     }
 
+    fn composed(&self, other: &Self) -> Self {
+        let (coeffs, left_indices, right_indices, boundaries) = _compose(self, other);
+        Self {
+            coeffs,
+            left_indices,
+            right_indices,
+            boundaries,
+            groups: None,
+        }
+    }
+
+    fn matmul(&self, other: &Self) -> Self {
+        let (coeffs, left_indices, right_indices, boundaries) = _compose(other, self);
+        Self {
+            coeffs,
+            left_indices,
+            right_indices,
+            boundaries,
+            groups: None,
+        }
+    }
+
+    fn __iand__(&mut self, other: &Self) {
+        *self = self.composed(other);
+    }
+
     fn __imatmul__(&mut self, other: &Self) {
-        (
-            self.coeffs,
-            self.left_indices,
-            self.right_indices,
-            self.boundaries,
-        ) = _compose(other, self);
-        self.groups = None;
+        *self = self.matmul(other);
     }
 
     fn ichop(&mut self, atol: f64) {
@@ -1491,5 +1517,90 @@ mod tests {
         let round_trip = TransferVertexOperator::from_terms_with_groups(op.iter_with_groups());
 
         assert_eq!(round_trip, op);
+    }
+
+    /// Two grouped, non-commuting operands for the allocation-free rewrites below.
+    ///
+    /// Grouped so that the tests can also assert that the out-of-place operations drop `groups`
+    /// exactly where their in-place counterparts do, and non-commuting so that an operand swap
+    /// cannot pass unnoticed.
+    fn operand_pair() -> (TransferVertexOperator, TransferVertexOperator) {
+        let op1 = TransferVertexOperator {
+            coeffs: vec![Complex64::new(2.0, -1.0), Complex64::new(3.0, 0.5)],
+            left_indices: vec![0, 2],
+            right_indices: vec![1, 3],
+            boundaries: vec![0, 1, 2],
+            groups: Some(vec![0, 1]),
+        };
+        let op2 = TransferVertexOperator {
+            coeffs: vec![Complex64::new(1.5, 2.0), Complex64::new(0.0, 4.0)],
+            left_indices: vec![1, 3],
+            right_indices: vec![2, 0],
+            boundaries: vec![0, 1, 2],
+            groups: Some(vec![0, 0]),
+        };
+        (op1, op2)
+    }
+
+    #[test]
+    fn test_and_matches_clone_then_and_assign() {
+        let (op1, op2) = operand_pair();
+
+        let mut expected = op1.clone();
+        expected.__iand__(&op2);
+
+        assert_eq!(op1.__and__(&op2), expected);
+        assert!(!op1.__and__(&op2).has_groups());
+    }
+
+    #[test]
+    fn test_matmul_matches_clone_then_matmul_assign() {
+        let (op1, op2) = operand_pair();
+
+        let mut expected = op1.clone();
+        expected.__imatmul__(&op2);
+
+        assert_eq!(op1.__matmul__(&op2), expected);
+        assert!(!op1.__matmul__(&op2).has_groups());
+    }
+
+    #[test]
+    fn test_sub_matches_add_of_negation() {
+        let (op1, op2) = operand_pair();
+
+        // The formulation `__sub__` used before it was fused, spelled out here so that the fused
+        // version is pinned to it. Complex coefficients matter: a sign error in the real part alone
+        // would survive real-only operands.
+        let mut expected = op1.clone();
+        expected.__iadd__(&op2.__neg__());
+
+        assert_eq!(op1.__sub__(&op2), expected);
+
+        let mut in_place = op1.clone();
+        in_place.__isub__(&op2);
+        assert_eq!(in_place, expected);
+    }
+
+    /// The out-of-place operations must not write through to either operand.
+    ///
+    /// `composed`/`matmul` take `&self`, so this cannot regress without a signature change, but the
+    /// in-place counterparts they now back (`*self = self.composed(other)`) make the property worth
+    /// stating outright.
+    #[test]
+    fn test_out_of_place_operations_leave_operands_untouched() {
+        let (op1, op2) = operand_pair();
+        let (op1_before, op2_before) = (op1.clone(), op2.clone());
+
+        let _ = op1.__and__(&op2);
+        let _ = op1.__matmul__(&op2);
+        let _ = op1.__sub__(&op2);
+        let _ = op1.__add__(&op2);
+        let _ = op1.__neg__();
+        let _ = op1.__pow__(2);
+        let _ = op1.adjoint();
+        let _ = op1.relabel_modes(vec![3, 2, 1, 0]);
+
+        assert_eq!(op1, op1_before);
+        assert_eq!(op2, op2_before);
     }
 }

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -37,7 +37,11 @@ impl TransferVertexOperatorTermView<'_> {
     }
 
     pub fn into_vec(&'_ self) -> Vec<(u32, u32)> {
-        zip(self.left_indices.to_vec(), self.right_indices.to_vec()).collect()
+        zip(
+            self.left_indices.iter().copied(),
+            self.right_indices.iter().copied(),
+        )
+        .collect()
     }
 }
 
@@ -68,7 +72,11 @@ impl TransferVertexOperatorGroupTermView<'_> {
     }
 
     pub fn into_vec(&'_ self) -> Vec<(u32, u32)> {
-        zip(self.left_indices.to_vec(), self.right_indices.to_vec()).collect()
+        zip(
+            self.left_indices.iter().copied(),
+            self.right_indices.iter().copied(),
+        )
+        .collect()
     }
 }
 
@@ -515,39 +523,45 @@ impl OperatorTrait for TransferVertexOperator {
     }
 
     fn get_support(&self) -> HashSet<u32> {
-        let support_left: HashSet<u32> = HashSet::from_iter(self.left_indices.clone());
-        let support_right: HashSet<u32> = HashSet::from_iter(self.right_indices.clone());
-        support_left.union(&support_right).copied().collect()
+        // Both index buffers feed a single set, rather than each building its own set to be unioned
+        // afterwards: the union of two sets of mode indices is the set of all of them.
+        self.left_indices
+            .iter()
+            .chain(&self.right_indices)
+            .copied()
+            .collect()
     }
 
     fn relabel_modes(&self, permutation: Vec<u32>) -> Result<Self, CoherenceError> {
         if permutation.iter().collect::<HashSet<_>>().len() != permutation.len() {
             return Err(CoherenceError::DuplicateIndices);
         }
-        let mut out = self.clone();
-        let new_left: Result<Vec<u32>, CoherenceError> = self
-            .left_indices
-            .iter()
-            .map(|&idx| {
-                permutation
-                    .get(idx as usize)
-                    .cloned()
-                    .ok_or(CoherenceError::IndexMapTooSmall)
-            })
-            .collect();
-        out.left_indices = new_left?;
-        let new_right: Result<Vec<u32>, CoherenceError> = self
-            .right_indices
-            .iter()
-            .map(|&idx| {
-                permutation
-                    .get(idx as usize)
-                    .cloned()
-                    .ok_or(CoherenceError::IndexMapTooSmall)
-            })
-            .collect();
-        out.right_indices = new_right?;
-        Ok(out)
+        let relabel = |indices: &[u32]| -> Result<Vec<u32>, CoherenceError> {
+            indices
+                .iter()
+                .map(|&idx| {
+                    permutation
+                        .get(idx as usize)
+                        .copied()
+                        .ok_or(CoherenceError::IndexMapTooSmall)
+                })
+                .collect()
+        };
+        // Both index buffers are relabelled before anything is copied, so that the error path does
+        // not first clone the entire operator only to discard it. The left buffer is still mapped
+        // first, keeping the error it reports ahead of the right buffer's.
+        let left_indices = relabel(&self.left_indices)?;
+        let right_indices = relabel(&self.right_indices)?;
+        Ok(Self {
+            coeffs: self.coeffs.clone(),
+            left_indices,
+            right_indices,
+            boundaries: self.boundaries.clone(),
+            // Relabelling permutes mode indices without reordering, splitting or merging terms, so
+            // any grouping of those terms carries over unchanged. This is the one operation that
+            // preserves `groups` rather than dropping it.
+            groups: self.groups.clone(),
+        })
     }
 }
 
@@ -1602,5 +1616,65 @@ mod tests {
 
         assert_eq!(op1, op1_before);
         assert_eq!(op2, op2_before);
+    }
+
+    /// The support of both index buffers, where the two only partially overlap.
+    ///
+    /// A single set now collects both buffers instead of unioning a set per buffer; overlapping but
+    /// unequal sides are what distinguishes that from taking only one side, or their intersection.
+    #[test]
+    fn test_get_support_overlapping_sides() {
+        let op = TransferVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(1.0, 0.0)],
+            left_indices: vec![0, 2, 4],
+            right_indices: vec![2, 4, 7],
+            boundaries: vec![0, 2, 3],
+            groups: None,
+        };
+
+        assert_eq!(op.get_support(), HashSet::from([0, 2, 4, 7]));
+    }
+
+    /// A right-side index outside the permutation must still be reported.
+    ///
+    /// Both buffers are relabelled through one closure now, so the right side needs its own case to
+    /// show it is mapped at all rather than copied through.
+    #[test]
+    fn test_relabel_modes_index_too_small_err_from_right() {
+        let op = TransferVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0)],
+            left_indices: vec![0],
+            right_indices: vec![3],
+            boundaries: vec![0, 1],
+            groups: None,
+        };
+
+        let relabeled = op.relabel_modes(vec![1, 0, 2]);
+
+        assert!(matches!(relabeled, Err(CoherenceError::IndexMapTooSmall)));
+    }
+
+    #[test]
+    fn test_relabel_modes_preserves_groups() {
+        let op = TransferVertexOperator {
+            coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+            left_indices: vec![0, 2],
+            right_indices: vec![1, 3],
+            boundaries: vec![0, 1, 2],
+            groups: Some(vec![0, 1]),
+        };
+
+        let relabeled = op.relabel_modes(vec![3, 2, 1, 0]).unwrap();
+
+        assert_eq!(
+            relabeled,
+            TransferVertexOperator {
+                coeffs: vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+                left_indices: vec![3, 1],
+                right_indices: vec![2, 0],
+                boundaries: vec![0, 1, 2],
+                groups: Some(vec![0, 1]),
+            }
+        );
     }
 }

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::operators::{CoherenceError, OperatorMacro, OperatorTrait, TermSortKey};
+use crate::operators::{CoherenceError, OperatorMacro, OperatorTrait, ScaledTerm, TermSortKey};
 use num_complex::{Complex64, ComplexFloat};
 use std::collections::{HashMap, HashSet};
 use std::iter::zip;
@@ -54,6 +54,13 @@ impl TermSortKey for TransferVertexOperatorTermView<'_> {
     }
 }
 
+impl ScaledTerm for TransferVertexOperatorTermView<'_> {
+    fn scaled(mut self, factor: Complex64) -> Self {
+        self.coeff *= factor;
+        self
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TransferVertexOperatorGroupTermView<'a> {
     pub coeff: Complex64,
@@ -85,6 +92,13 @@ impl TermSortKey for TransferVertexOperatorGroupTermView<'_> {
         // Match the ungrouped `TermView` key exactly (ignoring `group`), so ordering a grouped
         // operator agrees with ordering the same terms ungrouped.
         self.into_vec()
+    }
+}
+
+impl ScaledTerm for TransferVertexOperatorGroupTermView<'_> {
+    fn scaled(mut self, factor: Complex64) -> Self {
+        self.coeff *= factor;
+        self
     }
 }
 

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -621,7 +621,7 @@ impl PyEdgeVertexOperator {
             let val_str = format!("{:12.6e}{:+12.6e}j", term.coeff.re, term.coeff.im);
             items_str.push(format!("{val_str} * {key_str}"));
         }
-        Ok(items_str.join("\n").to_string())
+        Ok(items_str.join("\n"))
     }
 
     /// Constructs the additive identity operator.

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -567,7 +567,7 @@ impl PyFermionOperator {
             let val_str = format!("{:12.6e}{:+12.6e}j", term.coeff.re, term.coeff.im);
             items_str.push(format!("{val_str} * {key_str}"));
         }
-        Ok(items_str.join("\n").to_string())
+        Ok(items_str.join("\n"))
     }
 
     /// Constructs the additive identity operator.

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -530,7 +530,7 @@ impl PyMajoranaOperator {
             let val_str = format!("{:12.6e}{:+12.6e}j", term.coeff.re, term.coeff.im);
             items_str.push(format!("{val_str} * {key_str}"));
         }
-        Ok(items_str.join("\n").to_string())
+        Ok(items_str.join("\n"))
     }
 
     /// Constructs the additive identity operator.

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -618,7 +618,7 @@ impl PyTransferVertexOperator {
             let val_str = format!("{:12.6e}{:+12.6e}j", term.coeff.re, term.coeff.im);
             items_str.push(format!("{val_str} * {key_str}"));
         }
-        Ok(items_str.join("\n").to_string())
+        Ok(items_str.join("\n"))
     }
 
     /// Constructs the additive identity operator.


### PR DESCRIPTION
Operator arithmetic allocated and filled buffers that were then thrown away.
Composition and subtraction cloned an operand only to overwrite it; term keys,
support and relabelling built owned collections to read once and drop; and the
double commutator summed nine intermediates that each copied the whole growing
result so far. Every one of those copies is now either unnecessary or done once.

  compose / matmul                  -25% to -28%
  subtract, commutator              -26% to -39%
  double commutator             1.6x to 2.1x faster

No behaviour change: same values, same order, same errors. The one structural
addition is a `ScaledTerm` trait, so a weighted sum of operators can be built in
a single pass.