### PR TITLE
Contract generators in Edge/Transfer `normal_ordered`

### DIFF
--- a/crates/core/src/operators/edge_vertex_operator.rs
+++ b/crates/core/src/operators/edge_vertex_operator.rs
@@ -203,82 +203,224 @@ impl EdgeVertexOperator {
         }
     }
 
-    // TODO: expose an optional mode to also unify E_{jk} operators into a fixed order of j,k
-    pub fn normal_ordered(&self) -> Self {
+    /// Returns an equivalent operator with normal-ordered terms.
+    ///
+    /// `ascending` fixes the orientation convention of the generalized edge operators: because
+    /// `E_kj = -E_jk`, every edge operator has two representations, and this picks `j < k`
+    /// (`ascending = true`) or `j > k` (`ascending = false`), absorbing the sign into the
+    /// coefficient. Vertex operators `V_j = E_jj` are unaffected.
+    ///
+    /// `reduce` additionally contracts adjacent generators via the identities in
+    /// [`_reduce_once`], which is what makes the result a genuine canonical form. Pass `false` to
+    /// get the reorder-only behaviour.
+    pub fn normal_ordered(&self, ascending: bool, reduce: bool) -> Self {
         let mut result = Self::zero();
         self.iter()
-            .for_each(|term| result.__iadd__(&_normal_ordered_term(term)));
+            .for_each(|term| result.__iadd__(&_normal_ordered_term(term, ascending, reduce)));
         result
     }
 
     pub fn is_hermitian(&self, atol: f64) -> bool {
-        let mut diff = (self.__sub__(&self.adjoint())).normal_ordered();
+        let mut diff = (self.__sub__(&self.adjoint())).normal_ordered(true, true);
         diff.ichop(atol);
         diff.equiv(&Self::zero(), atol)
     }
 }
 
-fn _normal_ordered_term(term_view: EdgeVertexOperatorTermView) -> EdgeVertexOperator {
-    let mut coeffs = vec![];
-    let mut left_indices = vec![];
-    let mut right_indices = vec![];
-    let mut boundaries = vec![0];
+/// Rewrites `(left, right)` into the orientation selected by `ascending`, returning the rewritten
+/// pair and the sign picked up from `E_kj = -E_jk`.
+///
+/// Vertex operators (`left == right`) are returned unchanged with a `+1` sign.
+fn _canon_orientation(pair: (u32, u32), ascending: bool) -> ((u32, u32), bool) {
+    let (left, right) = pair;
+    if left == right {
+        return (pair, false);
+    }
+    let wanted = if ascending {
+        (left.min(right), left.max(right))
+    } else {
+        (left.max(right), left.min(right))
+    };
+    (wanted, wanted != pair)
+}
 
-    let mut stack = vec![(term_view.to_vec(), term_view.coeff)];
-    while let Some((mut term, coeff)) = stack.pop() {
-        let mut parity = false;
-        for i in 1..term.len() {
-            // shift the operator at index i to the left until it's in the correct location
-            for j in (1..=i).rev() {
-                let (right_1, right_2) = term[j];
-                let (left_1, left_2) = term[j - 1];
+/// Sorts `term` into normal order in place, returning whether the reordering picked up a sign.
+///
+/// This only ever *permutes* factors; contraction is handled separately by [`_reduce_once`].
+fn _sort_term(term: &mut [(u32, u32)]) -> bool {
+    let mut parity = false;
+    for i in 1..term.len() {
+        // shift the operator at index i to the left until it's in the correct location
+        for j in (1..=i).rev() {
+            let (right_1, right_2) = term[j];
+            let (left_1, left_2) = term[j - 1];
 
-                let left_is_vertex_op = left_1 == left_2;
-                let right_is_vertex_op = right_1 == right_2;
+            let left_is_vertex_op = left_1 == left_2;
+            let right_is_vertex_op = right_1 == right_2;
 
-                match (left_is_vertex_op, right_is_vertex_op) {
-                    (true, false) => {
-                        // vertex op is left of edge op -> nothing to do
-                    }
-                    (true, true) => {
-                        // two vertex ops; must check their indices
-                        if left_1 > right_1 {
-                            // -> this is a commuting operation
-                            term.swap(j - 1, j);
-                        }
-                    }
-                    (false, true) => {
-                        // vertex op is right of edge op -> must _always_ swap
+            match (left_is_vertex_op, right_is_vertex_op) {
+                (true, false) => {
+                    // vertex op is left of edge op -> nothing to do
+                }
+                (true, true) => {
+                    // two vertex ops; must check their indices
+                    if left_1 > right_1 {
+                        // -> this is a commuting operation
                         term.swap(j - 1, j);
-                        // parity depends on whether the operator supports overlap
-                        if left_1 == right_1 || left_2 == right_1 {
-                            // -> anti-commuting operation when they do not!
-                            parity = !parity;
-                        }
                     }
-                    (false, false) => {
-                        // two edge ops
-                        // whether we swap depends on the actual indices:
-                        if left_1 > right_1 || (left_1 == right_1 && left_2 > right_2) {
-                            term.swap(j - 1, j);
-                            // Two edge operators anticommute iff they share *exactly one* mode:
-                            // `{E_jk, E_kl} = 0`. Sharing *both* modes is the commuting case, since
-                            // `E_jk` and `E_kj = -E_jk` are collinear and every operator commutes
-                            // with itself. Disjoint supports commute too.
-                            let overlap = HashSet::from([left_1, left_2])
-                                .intersection(&HashSet::from([right_1, right_2]))
-                                .count();
-                            if overlap == 1 {
-                                parity = !parity;
-                            }
+                }
+                (false, true) => {
+                    // vertex op is right of edge op -> must _always_ swap
+                    term.swap(j - 1, j);
+                    // parity depends on whether the operator supports overlap
+                    if left_1 == right_1 || left_2 == right_1 {
+                        // -> anti-commuting operation when they do not!
+                        parity = !parity;
+                    }
+                }
+                (false, false) => {
+                    // two edge ops
+                    // whether we swap depends on the actual indices:
+                    if left_1 > right_1 || (left_1 == right_1 && left_2 > right_2) {
+                        term.swap(j - 1, j);
+                        // Two edge operators anticommute iff they share *exactly one* mode:
+                        // `{E_jk, E_kl} = 0`. Sharing *both* modes is the commuting case, since
+                        // `E_jk` and `E_kj = -E_jk` are collinear and every operator commutes
+                        // with itself. Disjoint supports commute too.
+                        let overlap = HashSet::from([left_1, left_2])
+                            .intersection(&HashSet::from([right_1, right_2]))
+                            .count();
+                        if overlap == 1 {
+                            parity = !parity;
                         }
                     }
                 }
             }
         }
-        let signed_coeff = if parity { -coeff } else { coeff };
-        coeffs.push(signed_coeff);
-        term.iter().for_each(|&(&a, &i)| {
+    }
+    parity
+}
+
+/// Applies a single contraction to the first reducible adjacent pair in `term`, if any.
+///
+/// Returns the scalar factor that must be multiplied into the term's coefficient, or `None` when
+/// no rule applies. The rules, all of which strictly shorten the term:
+///
+/// - `V_j V_j = 1`, `E_jk E_jk = 1` (identical factors square to the identity),
+/// - `E_jk E_kj = -1` (anti-parallel edge operators),
+/// - `E_ab E_bc = -i E_ac` for distinct `a`, `b`, `c` (*fusion*: two edge operators sharing exactly
+///   one mode collapse into a single one).
+///
+/// Together with `E_kj = -E_jk` the fusion rule generates every product of two edge operators that
+/// share exactly one mode, so no further cases are needed.
+fn _reduce_once(term: &mut Vec<(u32, u32)>, ascending: bool) -> Option<Complex64> {
+    for j in 0..term.len().saturating_sub(1) {
+        let (a, b) = term[j];
+        let (c, d) = term[j + 1];
+
+        // Identical support: contracts to a scalar and both factors disappear.
+        if (a == c && b == d) || (a == d && b == c) {
+            // `E_jk E_jk = +1` (and `V_j V_j = 1`), whereas `E_jk E_kj = -1`.
+            let sign = if a == c && b == d { 1.0 } else { -1.0 };
+            term.drain(j..=j + 1);
+            return Some(Complex64::new(sign, 0.0));
+        }
+
+        // Vertex operators only contract against themselves, which the branch above covers.
+        if a == b || c == d {
+            continue;
+        }
+
+        // Exactly one shared mode: fuse into a single edge operator.
+        let shared = HashSet::from([a, b])
+            .intersection(&HashSet::from([c, d]))
+            .count();
+        if shared != 1 {
+            continue;
+        }
+
+        // Rewrite both factors into the `E_xy E_yz` shape that the fusion rule is stated for,
+        // tracking the sign each orientation flip contributes.
+        let mut parity = false;
+        let (mut a, mut b) = (a, b);
+        let (mut c, mut d) = (c, d);
+        if b != c {
+            if a == c {
+                (a, b) = (b, a);
+                parity = !parity;
+            } else if b == d {
+                (c, d) = (d, c);
+                parity = !parity;
+            } else {
+                // a == d: both need flipping
+                (a, b) = (b, a);
+                (c, d) = (d, c);
+            }
+        }
+        debug_assert_eq!(
+            b, c,
+            "fusion requires the shared mode in the inner position"
+        );
+
+        // `E_ab E_bc = -i E_ac`, then re-canonicalize the surviving operator's orientation.
+        let (fused, flipped) = _canon_orientation((a, d), ascending);
+        if flipped {
+            parity = !parity;
+        }
+        term[j] = fused;
+        term.remove(j + 1);
+
+        let factor = Complex64::new(0.0, -1.0);
+        return Some(if parity { -factor } else { factor });
+    }
+    None
+}
+
+fn _normal_ordered_term(
+    term_view: EdgeVertexOperatorTermView,
+    ascending: bool,
+    reduce: bool,
+) -> EdgeVertexOperator {
+    let mut coeffs = vec![];
+    let mut left_indices = vec![];
+    let mut right_indices = vec![];
+    let mut boundaries = vec![0];
+
+    let mut stack = vec![(term_view.into_vec(), term_view.coeff)];
+    while let Some((mut term, coeff)) = stack.pop() {
+        let mut coeff = coeff;
+
+        if reduce {
+            // Canonicalize orientations up front so the contraction rules can match on indices
+            // without worrying about which of `E_jk`/`E_kj` happens to be stored.
+            for factor in term.iter_mut() {
+                let (canon, flipped) = _canon_orientation(*factor, ascending);
+                *factor = canon;
+                if flipped {
+                    coeff = -coeff;
+                }
+            }
+        }
+
+        // Reorder, then contract, then reorder again: a contraction can bring two factors next to
+        // each other that were not adjacent before (and fusion introduces a brand-new operator),
+        // so this has to run to a fixed point. Every contraction removes at least one factor, so
+        // the loop terminates after at most `term.len()` iterations.
+        loop {
+            if _sort_term(&mut term) {
+                coeff = -coeff;
+            }
+            if !reduce {
+                break;
+            }
+            match _reduce_once(&mut term, ascending) {
+                Some(factor) => coeff *= factor,
+                None => break,
+            }
+        }
+
+        coeffs.push(coeff);
+        term.iter().for_each(|&(a, i)| {
             left_indices.push(a);
             right_indices.push(i);
         });
@@ -1134,7 +1276,71 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), op);
+        assert_eq!(op.normal_ordered(true, false), op);
+    }
+
+    /// Builds a single-term operator from `(left, right)` pairs.
+    fn single_term(actions: &[(u32, u32)], coeff: Complex64) -> EdgeVertexOperator {
+        EdgeVertexOperator {
+            coeffs: vec![coeff],
+            left_indices: actions.iter().map(|&(l, _)| l).collect(),
+            right_indices: actions.iter().map(|&(_, r)| r).collect(),
+            boundaries: vec![0, actions.len()],
+            groups: None,
+        }
+    }
+
+    #[test]
+    fn test_normal_ordered_reduce_scalars() {
+        let one = Complex64::new(1.0, 0.0);
+
+        // `V_0 V_0 = 1`
+        let op = single_term(&[(0, 0), (0, 0)], one);
+        assert_eq!(op.normal_ordered(true, true), single_term(&[], one));
+
+        // `E_01 E_01 = 1`
+        let op = single_term(&[(0, 1), (0, 1)], one);
+        assert_eq!(op.normal_ordered(true, true), single_term(&[], one));
+
+        // `E_01 E_10 = -1`
+        let op = single_term(&[(0, 1), (1, 0)], one);
+        assert_eq!(op.normal_ordered(true, true), single_term(&[], -one));
+    }
+
+    #[test]
+    fn test_normal_ordered_reduce_fusion() {
+        let one = Complex64::new(1.0, 0.0);
+        let minus_i = Complex64::new(0.0, -1.0);
+
+        // `E_01 E_12 = -i E_02`
+        let op = single_term(&[(0, 1), (1, 2)], one);
+        assert_eq!(
+            op.normal_ordered(true, true),
+            single_term(&[(0, 2)], minus_i)
+        );
+
+        // The same fusion has to be found when neither factor stores the shared mode in the inner
+        // position, which requires applying `E_kj = -E_jk` first.
+        let op = single_term(&[(1, 0), (2, 1)], one);
+        assert_eq!(
+            op.normal_ordered(true, true),
+            single_term(&[(0, 2)], minus_i)
+        );
+    }
+
+    #[test]
+    fn test_normal_ordered_ascending() {
+        let one = Complex64::new(1.0, 0.0);
+
+        // `E_10 = -E_01`, so the non-selected orientation is rewritten and the sign absorbed.
+        let op = single_term(&[(1, 0)], one);
+        assert_eq!(op.normal_ordered(true, true), single_term(&[(0, 1)], -one));
+        assert_eq!(op.normal_ordered(false, true), single_term(&[(1, 0)], one));
+
+        // Vertex operators have no orientation freedom.
+        let op = single_term(&[(1, 1)], one);
+        assert_eq!(op.normal_ordered(true, true), op);
+        assert_eq!(op.normal_ordered(false, true), op);
     }
 
     #[test]
@@ -1156,7 +1362,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(true, false), expected);
     }
 
     #[test]
@@ -1183,7 +1389,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(true, false), expected);
     }
 
     /// Two edge operators spanning the *same* pair of modes commute, so reordering them must not
@@ -1212,7 +1418,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(true, false), expected);
 
         // Same for two *identical* edge operators, where the sort is a no-op but the parity rule is
         // still consulted.
@@ -1224,7 +1430,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), op);
+        assert_eq!(op.normal_ordered(true, false), op);
     }
 
     #[test]
@@ -1246,7 +1452,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(true, false), expected);
     }
 
     #[test]
@@ -1268,7 +1474,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(true, false), expected);
     }
 
     #[test]
@@ -1290,7 +1496,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(true, false), expected);
     }
 
     /// Exercises the `atol` boundary of `is_hermitian`.

--- a/crates/core/src/operators/transfer_vertex_operator.rs
+++ b/crates/core/src/operators/transfer_vertex_operator.rs
@@ -203,75 +203,166 @@ impl TransferVertexOperator {
         }
     }
 
-    pub fn normal_ordered(&self) -> Self {
+    /// Returns an equivalent operator with normal-ordered terms.
+    ///
+    /// `reduce` additionally contracts adjacent generators via the identities in [`_reduce_once`].
+    /// Pass `false` to get the reorder-only behaviour.
+    ///
+    /// Note that, unlike [`EdgeVertexOperator::normal_ordered`], there is no orientation
+    /// convention to fix: `T_jk` and `T_kj` are *different* operators rather than two
+    /// representations of one, so there is no analogue of that method's `ascending` argument.
+    pub fn normal_ordered(&self, reduce: bool) -> Self {
         let mut result = Self::zero();
         self.iter()
-            .for_each(|term| result.__iadd__(&_normal_ordered_term(term)));
+            .for_each(|term| result.__iadd__(&_normal_ordered_term(term, reduce)));
         result
     }
 
     pub fn is_hermitian(&self, atol: f64) -> bool {
-        let mut diff = (self.__sub__(&self.adjoint())).normal_ordered();
+        let mut diff = (self.__sub__(&self.adjoint())).normal_ordered(true);
         diff.ichop(atol);
         diff.equiv(&Self::zero(), atol)
     }
 }
 
-fn _normal_ordered_term(term_view: TransferVertexOperatorTermView) -> TransferVertexOperator {
-    let mut coeffs = vec![];
-    let mut left_indices = vec![];
-    let mut right_indices = vec![];
-    let mut boundaries = vec![0];
+/// Sorts `term` into normal order in place, returning whether the reordering picked up a sign.
+///
+/// This only ever *permutes* factors; contraction is handled separately by [`_reduce_once`].
+fn _sort_term(term: &mut [(u32, u32)]) -> bool {
+    let mut parity = false;
+    for i in 1..term.len() {
+        // shift the operator at index i to the left until it's in the correct location
+        for j in (1..=i).rev() {
+            let (right_1, right_2) = term[j];
+            let (left_1, left_2) = term[j - 1];
 
-    let mut stack = vec![(term_view.to_vec(), term_view.coeff)];
-    while let Some((mut term, coeff)) = stack.pop() {
-        let mut parity = false;
-        for i in 1..term.len() {
-            // shift the operator at index i to the left until it's in the correct location
-            for j in (1..=i).rev() {
-                let (right_1, right_2) = term[j];
-                let (left_1, left_2) = term[j - 1];
+            let left_is_vertex_op = left_1 == left_2;
+            let right_is_vertex_op = right_1 == right_2;
 
-                let left_is_vertex_op = left_1 == left_2;
-                let right_is_vertex_op = right_1 == right_2;
-
-                match (left_is_vertex_op, right_is_vertex_op) {
-                    (true, false) => {
-                        // vertex op is left of transfer op -> nothing to do
-                    }
-                    (true, true) => {
-                        // two vertex ops; must check their indices
-                        if left_1 > right_1 {
-                            // -> this is a commuting operation
-                            term.swap(j - 1, j);
-                        }
-                    }
-                    (false, true) => {
-                        // vertex op is right of transfer op -> must _always_ swap
+            match (left_is_vertex_op, right_is_vertex_op) {
+                (true, false) => {
+                    // vertex op is left of transfer op -> nothing to do
+                }
+                (true, true) => {
+                    // two vertex ops; must check their indices
+                    if left_1 > right_1 {
+                        // -> this is a commuting operation
                         term.swap(j - 1, j);
-                        // parity depends on whether the operator supports overlap
-                        if left_1 == right_1 || left_2 == right_1 {
-                            // -> anti-commuting operation when they do not!
-                            parity = !parity;
-                        }
                     }
-                    (false, false) => {
-                        // two transfer ops
-                        // whether we swap depends on the actual indices:
-                        if left_1 > right_1 || (left_1 == right_1 && left_2 > right_2) {
-                            term.swap(j - 1, j);
-                            // swap will commute unless either sided index pairs equal
-                            if left_1 == right_1 || left_2 == right_2 {
-                                parity = !parity;
-                            }
+                }
+                (false, true) => {
+                    // vertex op is right of transfer op -> must _always_ swap
+                    term.swap(j - 1, j);
+                    // parity depends on whether the operator supports overlap
+                    if left_1 == right_1 || left_2 == right_1 {
+                        // -> anti-commuting operation when they do not!
+                        parity = !parity;
+                    }
+                }
+                (false, false) => {
+                    // two transfer ops
+                    // whether we swap depends on the actual indices:
+                    if left_1 > right_1 || (left_1 == right_1 && left_2 > right_2) {
+                        term.swap(j - 1, j);
+                        // swap will commute unless either sided index pairs equal
+                        if left_1 == right_1 || left_2 == right_2 {
+                            parity = !parity;
                         }
                     }
                 }
             }
         }
-        let signed_coeff = if parity { -coeff } else { coeff };
-        coeffs.push(signed_coeff);
-        term.iter().for_each(|&(&a, &i)| {
+    }
+    parity
+}
+
+/// Applies a single contraction to the first reducible adjacent pair in `term`, if any.
+///
+/// Returns the scalar factor that must be multiplied into the term's coefficient, or `None` when
+/// no rule applies. There are exactly two rules:
+///
+/// - `V_j V_j = 1` and `T_jk T_jk = 1/4` — two *identical* adjacent factors contract to a scalar
+///   and both disappear.
+/// - `T_jk T_kj = -1/4 V_j V_k` — two anti-parallel transfer operators turn into a pair of vertex
+///   operators. This keeps the term's length but removes both transfer operators, which is what
+///   makes the surrounding fixed-point loop terminate (see [`_num_transfer_ops`]).
+///
+/// # Why there is no fusion rule
+///
+/// Unlike the edge operators, two transfer operators sharing a single mode never collapse into one.
+/// Writing `T_jk = (i/2) γ_{2j} γ_{2k-1}`, cancelling one shared Majorana always leaves an
+/// (even, odd) Majorana pair drawn from two *different* modes, and no single `T`/`V` generator has
+/// that form. So `T_jk T_jl` can only be rewritten into another length-two product, never
+/// shortened, and rewriting it would not make the form any more canonical.
+fn _reduce_once(term: &mut Vec<(u32, u32)>) -> Option<Complex64> {
+    for j in 0..term.len().saturating_sub(1) {
+        let (a, b) = term[j];
+        let (c, d) = term[j + 1];
+
+        if a == c && b == d {
+            // `V_j V_j = 1`, whereas `T_jk T_jk = 1/4`.
+            let factor = if a == b { 1.0 } else { 0.25 };
+            term.drain(j..=j + 1);
+            return Some(Complex64::new(factor, 0.0));
+        }
+
+        if a == d && b == c && a != b {
+            // `T_jk T_kj = -1/4 V_j V_k`
+            term[j] = (a, a);
+            term[j + 1] = (b, b);
+            return Some(Complex64::new(-0.25, 0.0));
+        }
+    }
+    None
+}
+
+/// Returns the number of transfer (i.e. non-vertex) factors in `term`.
+///
+/// This is the measure that makes the reduction loop well-founded: every rule in [`_reduce_once`]
+/// strictly decreases it, so the loop cannot cycle even though `T_jk T_kj = -1/4 V_j V_k` leaves
+/// the term's length unchanged.
+fn _num_transfer_ops(term: &[(u32, u32)]) -> usize {
+    term.iter().filter(|(a, b)| a != b).count()
+}
+
+fn _normal_ordered_term(
+    term_view: TransferVertexOperatorTermView,
+    reduce: bool,
+) -> TransferVertexOperator {
+    let mut coeffs = vec![];
+    let mut left_indices = vec![];
+    let mut right_indices = vec![];
+    let mut boundaries = vec![0];
+
+    let mut stack = vec![(term_view.into_vec(), term_view.coeff)];
+    while let Some((mut term, coeff)) = stack.pop() {
+        let mut coeff = coeff;
+
+        // Reorder, then contract, then reorder again: a contraction can bring two factors next to
+        // each other that were not adjacent before, so this has to run to a fixed point.
+        loop {
+            if _sort_term(&mut term) {
+                coeff = -coeff;
+            }
+            if !reduce {
+                break;
+            }
+            let before = (_num_transfer_ops(&term), term.len());
+            match _reduce_once(&mut term) {
+                Some(factor) => {
+                    coeff *= factor;
+                    debug_assert!(
+                        (_num_transfer_ops(&term), term.len()) < before,
+                        "every reduction must strictly decrease (transfer ops, length), else this \
+                         loop may not terminate"
+                    );
+                }
+                None => break,
+            }
+        }
+
+        coeffs.push(coeff);
+        term.iter().for_each(|&(a, i)| {
             left_indices.push(a);
             right_indices.push(i);
         });
@@ -1127,7 +1218,52 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), op);
+        assert_eq!(op.normal_ordered(false), op);
+    }
+
+    /// Builds a single-term operator from `(left, right)` pairs.
+    fn single_term(actions: &[(u32, u32)], coeff: Complex64) -> TransferVertexOperator {
+        TransferVertexOperator {
+            coeffs: vec![coeff],
+            left_indices: actions.iter().map(|&(l, _)| l).collect(),
+            right_indices: actions.iter().map(|&(_, r)| r).collect(),
+            boundaries: vec![0, actions.len()],
+            groups: None,
+        }
+    }
+
+    #[test]
+    fn test_normal_ordered_reduce() {
+        let one = Complex64::new(1.0, 0.0);
+
+        // `V_0 V_0 = 1`
+        let op = single_term(&[(0, 0), (0, 0)], one);
+        assert_eq!(op.normal_ordered(true), single_term(&[], one));
+
+        // `T_01 T_01 = 1/4`
+        let op = single_term(&[(0, 1), (0, 1)], Complex64::new(4.0, 0.0));
+        assert_eq!(op.normal_ordered(true), single_term(&[], one));
+
+        // `T_01 T_10 = -1/4 V_0 V_1`
+        let op = single_term(&[(0, 1), (1, 0)], Complex64::new(4.0, 0.0));
+        assert_eq!(
+            op.normal_ordered(true),
+            single_term(&[(0, 0), (1, 1)], -one)
+        );
+    }
+
+    #[test]
+    fn test_normal_ordered_no_fusion() {
+        // Two transfer operators sharing a single mode cannot collapse into one, unlike two edge
+        // operators. Reducing must leave the length alone rather than invent a shorter form.
+        let op = single_term(&[(0, 1), (0, 2)], Complex64::new(1.0, 0.0));
+        let reduced = op.normal_ordered(true);
+        assert!(
+            reduced
+                .boundaries
+                .windows(2)
+                .all(|pair| pair[1] - pair[0] == 2)
+        );
     }
 
     #[test]
@@ -1149,7 +1285,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(false), expected);
     }
 
     #[test]
@@ -1171,7 +1307,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(false), expected);
     }
 
     #[test]
@@ -1193,7 +1329,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(false), expected);
     }
 
     #[test]
@@ -1215,7 +1351,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(false), expected);
     }
 
     #[test]
@@ -1237,7 +1373,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(false), expected);
     }
 
     #[test]
@@ -1259,7 +1395,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(false), expected);
     }
 
     #[test]
@@ -1281,7 +1417,7 @@ mod tests {
             groups: None,
         };
 
-        assert_eq!(op.normal_ordered(), expected);
+        assert_eq!(op.normal_ordered(false), expected);
     }
 
     /// Exercises the `atol` boundary of `is_hermitian`.

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -1081,27 +1081,35 @@ impl PyEdgeVertexOperator {
     ///
     ///     >>> from qiskit_fermions.operators import EdgeVertexOperator
     ///     >>> op = EdgeVertexOperator.from_dict({((0, 1), (1, 0), (1, 2), (0, 0), (2, 2)): 1})
-    ///     >>> print(format(op.normal_ordered().simplify()))
+    ///     >>> print(format(op.normal_ordered(reduce=False).simplify()))
     ///      -1.000000e0 -0.000000e0j * (V(0) V(2) E(0,1) E(1,0) E(1,2))
+    ///     >>> print(format(op.normal_ordered().simplify()))
+    ///       1.000000e0 +0.000000e0j * (V(0) V(2) E(1,2))
+    ///
+    /// Args:
+    ///     ascending: the orientation convention for edge operators. Since :math:`E_{kj} =
+    ///         -E_{jk}`, every edge operator has two representations; ``True`` selects :math:`j <
+    ///         k` and ``False`` selects :math:`j > k`, absorbing the sign into the coefficient.
+    ///         Vertex operators are unaffected. This value defaults to ``True``.
+    ///     reduce: whether to contract adjacent generators that combine into a scalar or into a
+    ///         single generator. See the example above. This value defaults to ``True``.
     ///
     /// Returns:
     ///     An equivalent but normal-ordered operator.
-    fn normal_ordered(&self) -> Self {
-        self.inner.normal_ordered().into()
+    #[pyo3(signature = (ascending=true, reduce=true))]
+    fn normal_ordered(&self, ascending: bool, reduce: bool) -> Self {
+        self.inner.normal_ordered(ascending, reduce).into()
     }
 
     /// Returns whether this operator is Hermitian.
     ///
     /// .. note::
-    ///    This check is implemented using :meth:`.equiv` on the :meth:`.normal_ordered` difference
-    ///    of ``self`` and its :meth:`.adjoint` and :meth:`.zero`.
-    ///
-    /// .. note::
-    ///    This check is *conservative*: it can return ``False`` for an operator that is in fact
-    ///    Hermitian. :meth:`.normal_ordered` does not contract repeated generators into scalars
-    ///    (for example :math:`V_j V_j = 1` and :math:`E_{jk} E_{kj} = -1`), so a term that would
-    ///    only cancel against its adjoint *after* such a contraction is not recognized as zero.
-    ///    A ``True`` result is always reliable.
+    ///    This check is implemented using :meth:`.equiv` on the fully reduced
+    ///    :meth:`.normal_ordered` difference of ``self`` and its :meth:`.adjoint` and
+    ///    :meth:`.zero`. Because that normal form contracts every reducible pair of adjacent
+    ///    generators — including *fusing* two edge operators that share a single mode via
+    ///    :math:`E_{ab} E_{bc} = -i E_{ac}` — a term that only cancels against its adjoint after
+    ///    such a contraction is still recognized as zero.
     ///
     /// Args:
     ///     atol: The numerical accuracy upto which coefficients are considered equal. This value

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -1075,31 +1075,52 @@ impl PyTransferVertexOperator {
     ///    have to be taken into account. See
     ///    :ref:`here <TransferVertexOperator-definition>` for the detailed definitions.
     ///
+    /// .. note::
+    ///    Fewer contractions are available here than for :class:`.EdgeVertexOperator`. Two edge
+    ///    operators sharing a single mode *fuse* into one, but the analogous transfer product does
+    ///    not: writing :math:`T_{jk} = \frac{i}{2} \gamma_{2j} \gamma_{2k-1}`, cancelling the
+    ///    shared Majorana always leaves an (even, odd) pair drawn from two different modes, which
+    ///    is not a single generator. Only ``V(j) V(j)``, ``T(j,k) T(j,k)`` and ``T(j,k) T(k,j)``
+    ///    contract.
+    ///
     /// .. doctest::
     ///
     ///     >>> from qiskit_fermions.operators import TransferVertexOperator
     ///     >>> op = TransferVertexOperator.from_dict({((0, 1), (1, 0), (1, 2), (0, 0), (2, 2)): 1})
-    ///     >>> print(format(op.normal_ordered().simplify()))
+    ///     >>> print(format(op.normal_ordered(reduce=False).simplify()))
     ///      -1.000000e0 -0.000000e0j * (V(0) V(2) T(0,1) T(1,0) T(1,2))
+    ///     >>> print(format(op.normal_ordered().simplify()))
+    ///      2.500000e-1 +0.000000e0j * (V(1) V(2) T(1,2))
+    ///
+    /// Args:
+    ///     reduce: whether to contract adjacent generators that combine into a scalar or into a
+    ///         pair of vertex operators. See the example above. This value defaults to ``True``.
     ///
     /// Returns:
     ///     An equivalent but normal-ordered operator.
-    fn normal_ordered(&self) -> Self {
-        self.inner.normal_ordered().into()
+    #[pyo3(signature = (reduce=true))]
+    fn normal_ordered(&self, reduce: bool) -> Self {
+        self.inner.normal_ordered(reduce).into()
     }
 
     /// Returns whether this operator is Hermitian.
     ///
     /// .. note::
-    ///    This check is implemented using :meth:`.equiv` on the :meth:`.normal_ordered` difference
-    ///    of ``self`` and its :meth:`.adjoint` and :meth:`.zero`.
+    ///    This check is implemented using :meth:`.equiv` on the fully reduced
+    ///    :meth:`.normal_ordered` difference of ``self`` and its :meth:`.adjoint` and
+    ///    :meth:`.zero`.
     ///
     /// .. note::
     ///    This check is *conservative*: it can return ``False`` for an operator that is in fact
-    ///    Hermitian. :meth:`.normal_ordered` does not contract repeated generators into scalars
-    ///    (for example :math:`V_j V_j = 1`), so a term that would only cancel against its adjoint
-    ///    *after* such a contraction is not recognized as zero. A ``True`` result is always
-    ///    reliable.
+    ///    Hermitian. A ``True`` result is always reliable.
+    ///
+    ///    :meth:`.normal_ordered` contracts every pair of adjacent generators that combines into a
+    ///    *shorter* term, but two transfer operators sharing a single mode do not: as explained
+    ///    there, :math:`T_{jk} T_{jl}` can only be rewritten into another length-two product.
+    ///    Since neither form is more canonical than the other, such products are left alone, and a
+    ///    term that would only cancel against its adjoint after rewriting one is not recognized as
+    ///    zero. :class:`.EdgeVertexOperator` has no such gap, because there the analogous product
+    ///    *fuses* into a single edge operator.
     ///
     /// Args:
     ///     atol: The numerical accuracy upto which coefficients are considered equal. This value

--- a/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
@@ -883,7 +883,7 @@ class EdgeVertexOperator:
             other: the other operator to compare with.
             atol: the absolute tolerance for the comparison. This value defaults to ``1e-8``.
         """
-    def normal_ordered(self) -> EdgeVertexOperator:
+    def normal_ordered(self, ascending: builtins.bool = True, reduce: builtins.bool = True) -> EdgeVertexOperator:
         r"""
         Returns an equivalent operator with normal ordered terms.
         
@@ -900,8 +900,18 @@ class EdgeVertexOperator:
         
             >>> from qiskit_fermions.operators import EdgeVertexOperator
             >>> op = EdgeVertexOperator.from_dict({((0, 1), (1, 0), (1, 2), (0, 0), (2, 2)): 1})
-            >>> print(format(op.normal_ordered().simplify()))
+            >>> print(format(op.normal_ordered(reduce=False).simplify()))
              -1.000000e0 -0.000000e0j * (V(0) V(2) E(0,1) E(1,0) E(1,2))
+            >>> print(format(op.normal_ordered().simplify()))
+              1.000000e0 +0.000000e0j * (V(0) V(2) E(1,2))
+        
+        Args:
+            ascending: the orientation convention for edge operators. Since :math:`E_{kj} =
+                -E_{jk}`, every edge operator has two representations; ``True`` selects :math:`j <
+                k` and ``False`` selects :math:`j > k`, absorbing the sign into the coefficient.
+                Vertex operators are unaffected. This value defaults to ``True``.
+            reduce: whether to contract adjacent generators that combine into a scalar or into a
+                single generator. See the example above. This value defaults to ``True``.
         
         Returns:
             An equivalent but normal-ordered operator.
@@ -911,15 +921,12 @@ class EdgeVertexOperator:
         Returns whether this operator is Hermitian.
         
         .. note::
-           This check is implemented using :meth:`.equiv` on the :meth:`.normal_ordered` difference
-           of ``self`` and its :meth:`.adjoint` and :meth:`.zero`.
-        
-        .. note::
-           This check is *conservative*: it can return ``False`` for an operator that is in fact
-           Hermitian. :meth:`.normal_ordered` does not contract repeated generators into scalars
-           (for example :math:`V_j V_j = 1` and :math:`E_{jk} E_{kj} = -1`), so a term that would
-           only cancel against its adjoint *after* such a contraction is not recognized as zero.
-           A ``True`` result is always reliable.
+           This check is implemented using :meth:`.equiv` on the fully reduced
+           :meth:`.normal_ordered` difference of ``self`` and its :meth:`.adjoint` and
+           :meth:`.zero`. Because that normal form contracts every reducible pair of adjacent
+           generators — including *fusing* two edge operators that share a single mode via
+           :math:`E_{ab} E_{bc} = -i E_{ac}` — a term that only cancels against its adjoint after
+           such a contraction is still recognized as zero.
         
         Args:
             atol: The numerical accuracy upto which coefficients are considered equal. This value

--- a/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
@@ -886,7 +886,7 @@ class TransferVertexOperator:
             other: the other operator to compare with.
             atol: the absolute tolerance for the comparison. This value defaults to ``1e-8``.
         """
-    def normal_ordered(self) -> TransferVertexOperator:
+    def normal_ordered(self, reduce: builtins.bool = True) -> TransferVertexOperator:
         r"""
         Returns an equivalent operator with normal ordered terms.
         
@@ -899,12 +899,26 @@ class TransferVertexOperator:
            have to be taken into account. See
            :ref:`here <TransferVertexOperator-definition>` for the detailed definitions.
         
+        .. note::
+           Fewer contractions are available here than for :class:`.EdgeVertexOperator`. Two edge
+           operators sharing a single mode *fuse* into one, but the analogous transfer product does
+           not: writing :math:`T_{jk} = \frac{i}{2} \gamma_{2j} \gamma_{2k-1}`, cancelling the
+           shared Majorana always leaves an (even, odd) pair drawn from two different modes, which
+           is not a single generator. Only ``V(j) V(j)``, ``T(j,k) T(j,k)`` and ``T(j,k) T(k,j)``
+           contract.
+        
         .. doctest::
         
             >>> from qiskit_fermions.operators import TransferVertexOperator
             >>> op = TransferVertexOperator.from_dict({((0, 1), (1, 0), (1, 2), (0, 0), (2, 2)): 1})
-            >>> print(format(op.normal_ordered().simplify()))
+            >>> print(format(op.normal_ordered(reduce=False).simplify()))
              -1.000000e0 -0.000000e0j * (V(0) V(2) T(0,1) T(1,0) T(1,2))
+            >>> print(format(op.normal_ordered().simplify()))
+             2.500000e-1 +0.000000e0j * (V(1) V(2) T(1,2))
+        
+        Args:
+            reduce: whether to contract adjacent generators that combine into a scalar or into a
+                pair of vertex operators. See the example above. This value defaults to ``True``.
         
         Returns:
             An equivalent but normal-ordered operator.
@@ -914,15 +928,21 @@ class TransferVertexOperator:
         Returns whether this operator is Hermitian.
         
         .. note::
-           This check is implemented using :meth:`.equiv` on the :meth:`.normal_ordered` difference
-           of ``self`` and its :meth:`.adjoint` and :meth:`.zero`.
+           This check is implemented using :meth:`.equiv` on the fully reduced
+           :meth:`.normal_ordered` difference of ``self`` and its :meth:`.adjoint` and
+           :meth:`.zero`.
         
         .. note::
            This check is *conservative*: it can return ``False`` for an operator that is in fact
-           Hermitian. :meth:`.normal_ordered` does not contract repeated generators into scalars
-           (for example :math:`V_j V_j = 1`), so a term that would only cancel against its adjoint
-           *after* such a contraction is not recognized as zero. A ``True`` result is always
-           reliable.
+           Hermitian. A ``True`` result is always reliable.
+        
+           :meth:`.normal_ordered` contracts every pair of adjacent generators that combines into a
+           *shorter* term, but two transfer operators sharing a single mode do not: as explained
+           there, :math:`T_{jk} T_{jl}` can only be rewritten into another length-two product.
+           Since neither form is more canonical than the other, such products are left alone, and a
+           term that would only cancel against its adjoint after rewriting one is not recognized as
+           zero. :class:`.EdgeVertexOperator` has no such gap, because there the analogous product
+           *fuses* into a single edge operator.
         
         Args:
             atol: The numerical accuracy upto which coefficients are considered equal. This value

--- a/tests/python/operators/majorana_matrix_oracle.py
+++ b/tests/python/operators/majorana_matrix_oracle.py
@@ -1,0 +1,86 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""A dense-matrix oracle for edge- and transfer-vertex operators.
+
+Both operator families are *defined* as products of Majorana operators, so building explicit
+matrices for the Majoranas and multiplying them out gives a ground truth that is independent of
+the operator implementations under test. This is deliberately naive: it never calls
+:meth:`normal_ordered`, :meth:`simplify` or any of the algebra being verified, so a sign error in
+those cannot hide here.
+
+The Majoranas are represented in the Jordan-Wigner basis on ``num_modes`` qubits,
+
+.. math::
+
+    \\gamma_{2j-1} = Z \\cdots Z X_j \\, , \\qquad \\gamma_{2j} = Z \\cdots Z Y_j \\, ,
+
+with a 1-based mode index :math:`j`.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+_I2 = np.eye(2, dtype=complex)
+_X = np.array([[0, 1], [1, 0]], dtype=complex)
+_Y = np.array([[0, -1j], [1j, 0]], dtype=complex)
+_Z = np.array([[1, 0], [0, -1]], dtype=complex)
+
+
+def _kron(mats) -> np.ndarray:
+    out = np.array([[1]], dtype=complex)
+    for mat in mats:
+        out = np.kron(out, mat)
+    return out
+
+
+def majorana(index: int, num_modes: int) -> np.ndarray:
+    """Returns the matrix of the Majorana operator ``gamma_index`` (1-based, in ``1..2*num_modes``)."""
+    mode = (index + 1) // 2  # 1-based mode index
+    local = _X if index % 2 == 1 else _Y
+    return _kron(
+        local if qubit == mode else (_Z if qubit < mode else _I2)
+        for qubit in range(1, num_modes + 1)
+    )
+
+
+def vertex_matrix(mode: int, num_modes: int) -> np.ndarray:
+    """Returns the matrix of ``V_mode = -i gamma_{2j-1} gamma_{2j}`` for a 0-based ``mode``."""
+    one_based = mode + 1
+    return -1j * majorana(2 * one_based - 1, num_modes) @ majorana(2 * one_based, num_modes)
+
+
+def edge_matrix(left: int, right: int, num_modes: int) -> np.ndarray:
+    """Returns the matrix of ``E_{left,right} = -i gamma_{2j-1} gamma_{2k-1}`` for 0-based modes."""
+    if left == right:
+        return vertex_matrix(left, num_modes)
+    return -1j * majorana(2 * (left + 1) - 1, num_modes) @ majorana(2 * (right + 1) - 1, num_modes)
+
+
+def transfer_matrix(left: int, right: int, num_modes: int) -> np.ndarray:
+    """Returns the matrix of ``T_{left,right} = (i/2) gamma_{2j} gamma_{2k-1}`` for 0-based modes."""
+    if left == right:
+        return vertex_matrix(left, num_modes)
+    return 0.5j * majorana(2 * (left + 1), num_modes) @ majorana(2 * (right + 1) - 1, num_modes)
+
+
+def operator_matrix(operator, num_modes: int, action_matrix) -> np.ndarray:
+    """Returns the dense matrix of ``operator``, mapping each action via ``action_matrix``."""
+    dim = 2**num_modes
+    total = np.zeros((dim, dim), dtype=complex)
+    for actions, coeff in operator.iter_terms():
+        term = np.eye(dim, dtype=complex)
+        for left, right in actions:
+            term = term @ action_matrix(left, right, num_modes)
+        total += complex(coeff) * term
+    return total

--- a/tests/python/operators/test_edge_vertex_operator.py
+++ b/tests/python/operators/test_edge_vertex_operator.py
@@ -10,12 +10,15 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+import itertools
 import pickle
 
 import numpy as np
 import pytest
 from qiskit_fermions.operators import EdgeVertexOperator
 from qiskit_fermions.operators.library import anti_commutator, commutator
+
+from .majorana_matrix_oracle import edge_matrix, operator_matrix
 
 
 class TestEdgeVertexOperator:
@@ -347,6 +350,21 @@ class TestEdgeVertexOperator:
         with subtests.test("symmetrized product is Hermitian"):
             assert (op + op.adjoint()).is_hermitian()
 
+        with subtests.test("Hermitian only after fusion"):
+            # This operator is Hermitian, but recognizing that requires *fusing* `E(1,0) E(2,1)`
+            # into a multiple of `E(2,0)`: the two terms of `op - op.adjoint()` cancel only once
+            # that contraction is applied. Reordering alone leaves a non-zero remainder, which is
+            # why this used to be reported as non-Hermitian.
+            op = cls.from_dict(
+                {
+                    ((2, 0), (2, 2)): 0.1 - 0.4j,
+                    ((2, 1), (2, 2), (1, 0)): 0.1 - 0.1j,
+                }
+            )
+            matrix = operator_matrix(op, 3, edge_matrix)
+            assert np.allclose(matrix, matrix.conj().T), "test premise: op must be Hermitian"
+            assert op.is_hermitian()
+
     def test_equiv(self):
         cls = self.get_class()
         op = cls.from_dict({(): 1e-7})
@@ -358,14 +376,16 @@ class TestEdgeVertexOperator:
     def test_normal_ordered(self, subtests):
         cls = self.get_class()
 
+        # These cases pin the pure *reordering* behaviour, so they opt out of the contraction that
+        # `reduce=True` (the default) would additionally apply. See `test_normal_ordered_reduce`.
         with subtests.test("no change"):
             op = cls.from_dict({((0, 0), (1, 1), (1, 1), (0, 1)): 1})
-            assert op.normal_ordered().equiv(op)
+            assert op.normal_ordered(reduce=False).equiv(op)
 
         with subtests.test("ordering of vertex and edge operators"):
             op = cls.from_dict({((0, 1), (1, 0), (1, 2), (0, 0), (2, 2)): 1})
             expected = cls.from_dict({((0, 0), (2, 2), (0, 1), (1, 0), (1, 2)): -1})
-            assert op.normal_ordered().equiv(expected)
+            assert op.normal_ordered(reduce=False).equiv(expected)
 
         with subtests.test("edge operators on the same pair of modes commute"):
             # Eq. (5) of arXiv:2512.11418v1 only covers `j != k != l != m`, so it says nothing
@@ -374,11 +394,130 @@ class TestEdgeVertexOperator:
             # introduce a sign.
             op = cls.from_dict({((1, 0), (0, 1)): 1 + 2j})
             expected = cls.from_dict({((0, 1), (1, 0)): 1 + 2j})
-            assert op.normal_ordered().equiv(expected)
+            assert op.normal_ordered(reduce=False).equiv(expected)
 
             # Two identical edge operators: the sort is a no-op, but the parity rule still runs.
             op = cls.from_dict({((1, 0), (1, 0)): 1 + 2j})
-            assert op.normal_ordered().equiv(op)
+            assert op.normal_ordered(reduce=False).equiv(op)
+
+    def test_normal_ordered_reduce(self, subtests):
+        cls = self.get_class()
+
+        with subtests.test("V_j V_j = 1"):
+            op = cls.from_dict({((0, 0), (0, 0)): 2 + 1j})
+            assert op.normal_ordered().equiv(cls.from_dict({(): 2 + 1j}))
+
+        with subtests.test("E_jk E_jk = 1"):
+            op = cls.from_dict({((0, 1), (0, 1)): 2 + 1j})
+            assert op.normal_ordered().equiv(cls.from_dict({(): 2 + 1j}))
+
+        with subtests.test("E_jk E_kj = -1"):
+            op = cls.from_dict({((0, 1), (1, 0)): 2 + 1j})
+            assert op.normal_ordered().equiv(cls.from_dict({(): -2 - 1j}))
+
+        with subtests.test("fusion: E_ab E_bc = -i E_ac"):
+            op = cls.from_dict({((0, 1), (1, 2)): 1})
+            assert op.normal_ordered().equiv(cls.from_dict({((0, 2),): -1j}))
+
+        with subtests.test("fusion is found regardless of stored orientation"):
+            # `E_{1,0} E_{2,1}` shares mode 1, but neither factor is oriented so that the shared
+            # mode sits in the inner position. Reducing it requires applying `E_{kj} = -E_{jk}`
+            # first, which is what the orientation canonicalization is for.
+            op = cls.from_dict({((1, 0), (2, 1)): 1})
+            assert op.normal_ordered().equiv(cls.from_dict({((0, 2),): -1j}))
+
+        with subtests.test("nothing left to contract"):
+            for actions in [((0, 0), (1, 1)), ((0, 0), (1, 2)), ((0, 1), (2, 3))]:
+                op = cls.from_dict({actions: 1})
+                reduced = op.normal_ordered()
+                assert reduced.equiv(op), f"{actions} should not have been reduced"
+
+    @pytest.mark.parametrize("ascending", [True, False])
+    def test_normal_ordered_ascending(self, ascending, subtests):
+        cls = self.get_class()
+
+        with subtests.test("orientation is canonicalized"):
+            # `E_{1,0} = -E_{0,1}`, so whichever orientation is *not* selected must be rewritten
+            # into the one that is, with the sign absorbed into the coefficient.
+            op = cls.from_dict({((1, 0),): 1})
+            expected_action = (0, 1) if ascending else (1, 0)
+            expected_coeff = -1 if ascending else 1
+            assert op.normal_ordered(ascending=ascending).equiv(
+                cls.from_dict({(expected_action,): expected_coeff})
+            )
+
+        with subtests.test("vertex operators are unaffected"):
+            op = cls.from_dict({((1, 1),): 1})
+            assert op.normal_ordered(ascending=ascending).equiv(op)
+
+    def test_normal_ordered_is_canonical(self):
+        """Asserts that two representations of one operator normal-order to the same terms.
+
+        Because ``E_kj = -E_jk``, the same operator can be stored in many ways. Flipping every
+        edge operator's orientation (and the coefficient's sign with it) is a no-op on the operator
+        itself, so it must be a no-op on the normal-ordered result too.
+        """
+        cls = self.get_class()
+        num_modes = 3
+        generators = [(a, b) for a in range(num_modes) for b in range(num_modes)]
+
+        for actions in itertools.product(generators, repeat=3):
+            coeff = 1 - 0.5j
+            flipped, flipped_coeff = [], coeff
+            for left, right in actions:
+                if left == right:
+                    flipped.append((left, right))
+                else:
+                    flipped.append((right, left))
+                    flipped_coeff = -flipped_coeff
+
+            original = cls.from_dict({tuple(actions): coeff}).normal_ordered().simplify()
+            equivalent = cls.from_dict({tuple(flipped): flipped_coeff}).normal_ordered().simplify()
+            assert original.equiv(equivalent), f"{actions} is not canonical"
+
+    @pytest.mark.parametrize("length", [2, 3])
+    @pytest.mark.parametrize("reduce", [False, True])
+    @pytest.mark.parametrize("ascending", [True, False])
+    def test_normal_ordered_preserves_matrix(self, length, reduce, ascending):
+        """Asserts ``normal_ordered`` never changes the operator it represents.
+
+        Reordering and contracting generators is only sound if every swap and every contraction
+        carries the right sign, and a sign error is invisible to a test that compares against a
+        hand-written expectation derived from the same (possibly wrong) rule. So this compares
+        against dense matrices built straight from the Majorana definitions instead, exhaustively
+        over every term of the given length.
+        """
+        cls = self.get_class()
+        num_modes = 3
+        generators = [(a, b) for a in range(num_modes) for b in range(num_modes)]
+
+        for actions in itertools.product(generators, repeat=length):
+            op = cls.from_dict({tuple(actions): 1 - 0.5j})
+            reordered = op.normal_ordered(ascending=ascending, reduce=reduce)
+            expected = operator_matrix(op, num_modes, edge_matrix)
+            actual = operator_matrix(reordered, num_modes, edge_matrix)
+            assert np.allclose(actual, expected), f"normal_ordered changed the operator {actions}"
+
+    @pytest.mark.parametrize("length", [2, 3])
+    def test_normal_ordered_is_fully_reduced(self, length):
+        """Asserts no reducible pair of adjacent generators survives ``normal_ordered``."""
+        cls = self.get_class()
+        num_modes = 3
+        generators = [(a, b) for a in range(num_modes) for b in range(num_modes)]
+
+        def reducible(actions) -> bool:
+            for (a, b), (c, d) in itertools.pairwise(actions):
+                if {a, b} == {c, d}:
+                    return True
+                # two edge operators sharing exactly one mode fuse into a single one
+                if a != b and c != d and len({a, b} & {c, d}) == 1:
+                    return True
+            return False
+
+        for actions in itertools.product(generators, repeat=length):
+            reduced = cls.from_dict({tuple(actions): 1}).normal_ordered()
+            for remaining, _ in reduced.iter_terms():
+                assert not reducible(tuple(remaining)), f"{actions} left {remaining} unreduced"
 
     def test_commutator(self, subtests):
         cls = self.get_class()

--- a/tests/python/operators/test_transfer_vertex_operator.py
+++ b/tests/python/operators/test_transfer_vertex_operator.py
@@ -10,12 +10,15 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+import itertools
 import pickle
 
 import numpy as np
 import pytest
 from qiskit_fermions.operators import TransferVertexOperator
 from qiskit_fermions.operators.library import anti_commutator, commutator
+
+from .majorana_matrix_oracle import operator_matrix, transfer_matrix
 
 
 class TestTransferVertexOperator:
@@ -347,6 +350,22 @@ class TestTransferVertexOperator:
         with subtests.test("symmetrized product is Hermitian"):
             assert (op + op.adjoint()).is_hermitian()
 
+        with subtests.test("conservative for shared-mode transfer products"):
+            # A documented limitation rather than a bug: this operator *is* Hermitian, but the two
+            # terms of `op - op.adjoint()` reduce to `T(1,0) T(1,2)` and `T(0,1) T(2,1)`, which
+            # share a single mode. Such products can only be rewritten into another length-two form,
+            # never shortened, so `normal_ordered` leaves them alone and the cancellation is missed.
+            # `EdgeVertexOperator` has no such gap because there the analogous product fuses.
+            op = cls.from_dict(
+                {
+                    ((1, 0), (1, 2), (0, 0)): -0.3 - 1.3j,
+                    ((2, 1), (2, 2), (0, 1)): 0.5 + 1.3j,
+                }
+            )
+            matrix = operator_matrix(op, 3, transfer_matrix)
+            assert np.allclose(matrix, matrix.conj().T), "test premise: op must be Hermitian"
+            assert not op.is_hermitian()
+
     def test_equiv(self):
         cls = self.get_class()
         op = cls.from_dict({(): 1e-7})
@@ -358,14 +377,83 @@ class TestTransferVertexOperator:
     def test_normal_ordered(self, subtests):
         cls = self.get_class()
 
+        # These cases pin the pure *reordering* behaviour, so they opt out of the contraction that
+        # `reduce=True` (the default) would additionally apply. See `test_normal_ordered_reduce`.
         with subtests.test("no change"):
             op = cls.from_dict({((0, 0), (1, 1), (1, 1), (0, 1)): 1})
-            assert op.normal_ordered().equiv(op)
+            assert op.normal_ordered(reduce=False).equiv(op)
 
         with subtests.test("ordering of vertex and edge operators"):
             op = cls.from_dict({((0, 1), (1, 0), (1, 2), (0, 0), (2, 2)): 1})
             expected = cls.from_dict({((0, 0), (2, 2), (0, 1), (1, 0), (1, 2)): -1})
-            assert op.normal_ordered().equiv(expected)
+            assert op.normal_ordered(reduce=False).equiv(expected)
+
+    def test_normal_ordered_reduce(self, subtests):
+        cls = self.get_class()
+
+        with subtests.test("V_j V_j = 1"):
+            op = cls.from_dict({((0, 0), (0, 0)): 2 + 1j})
+            assert op.normal_ordered().equiv(cls.from_dict({(): 2 + 1j}))
+
+        with subtests.test("T_jk T_jk = 1/4"):
+            op = cls.from_dict({((0, 1), (0, 1)): 4})
+            assert op.normal_ordered().equiv(cls.from_dict({(): 1}))
+
+        with subtests.test("T_jk T_kj = -1/4 V_j V_k"):
+            op = cls.from_dict({((0, 1), (1, 0)): 4})
+            assert op.normal_ordered().equiv(cls.from_dict({((0, 0), (1, 1)): -1}))
+
+        with subtests.test("transfer operators sharing one mode do not fuse"):
+            # Unlike two edge operators, `T_{0,1} T_{0,2}` cannot collapse into a single generator:
+            # cancelling the shared Majorana leaves an (even, odd) pair from two different modes.
+            # So this term keeps its length, and reducing must not invent a shorter form.
+            op = cls.from_dict({((0, 1), (0, 2)): 1})
+            reduced = op.normal_ordered()
+            assert all(len(actions) == 2 for actions, _ in reduced.iter_terms())
+
+    @pytest.mark.parametrize("length", [2, 3])
+    @pytest.mark.parametrize("reduce", [False, True])
+    def test_normal_ordered_preserves_matrix(self, length, reduce):
+        """Asserts ``normal_ordered`` never changes the operator it represents.
+
+        Reordering and contracting generators is only sound if every swap and every contraction
+        carries the right sign, and a sign error is invisible to a test that compares against a
+        hand-written expectation derived from the same (possibly wrong) rule. So this compares
+        against dense matrices built straight from the Majorana definitions instead, exhaustively
+        over every term of the given length.
+        """
+        cls = self.get_class()
+        num_modes = 3
+        generators = [(a, b) for a in range(num_modes) for b in range(num_modes)]
+
+        for actions in itertools.product(generators, repeat=length):
+            op = cls.from_dict({tuple(actions): 1 - 0.5j})
+            reordered = op.normal_ordered(reduce=reduce)
+            expected = operator_matrix(op, num_modes, transfer_matrix)
+            actual = operator_matrix(reordered, num_modes, transfer_matrix)
+            assert np.allclose(actual, expected), f"normal_ordered changed the operator {actions}"
+
+    @pytest.mark.parametrize("length", [2, 3])
+    def test_normal_ordered_is_fully_reduced(self, length):
+        """Asserts no contractible pair of adjacent generators survives ``normal_ordered``.
+
+        Only identical and anti-parallel pairs are contractible here; transfer operators sharing a
+        single mode are deliberately left alone (see :meth:`is_hermitian`).
+        """
+        cls = self.get_class()
+        num_modes = 3
+        generators = [(a, b) for a in range(num_modes) for b in range(num_modes)]
+
+        def reducible(actions) -> bool:
+            return any(
+                left == right or (left == (right[1], right[0]) and left[0] != left[1])
+                for left, right in itertools.pairwise(actions)
+            )
+
+        for actions in itertools.product(generators, repeat=length):
+            reduced = cls.from_dict({tuple(actions): 1}).normal_ordered()
+            for remaining, _ in reduced.iter_terms():
+                assert not reducible(tuple(remaining)), f"{actions} left {remaining} unreduced"
 
     def test_commutator(self, subtests):
         cls = self.get_class()


### PR DESCRIPTION
`normal_ordered` only *reordered* generators, so `V_j V_j`, `E_jk E_kj` and friends survived as-is and `is_hermitian` reported false negatives whenever cancellation needed a contraction first. Both families now contract to a fixed point behind a `reduce` flag defaulting to `True`, mirroring `MajoranaOperator.normal_ordered(reduce=True)`; `EdgeVertexOperator` also gains `ascending` to fix the `E_kj = -E_jk` orientation convention, closing the existing TODO and making fusion detectable at all. The families are deliberately asymmetric: edge operators sharing one mode *fuse* via `E_ab E_bc = -i E_ac`, while the analogous transfer product provably never shortens. So `is_hermitian` is now exact for edge operators (caveat dropped) but stays conservative for transfer ones -- pinned as a test, since a conservative `False` is safe where a `True` on a non-Hermitian operator would not be.