### PR TITLE
Speed up loading a `FermionOperator` from an FCIDump file

### DIFF
--- a/crates/core/src/operators/library/electronic_integrals.rs
+++ b/crates/core/src/operators/library/electronic_integrals.rs
@@ -15,8 +15,69 @@ use crate::operators::fermion_operator::FermionOperator;
 use ndarray::ArrayView1;
 use num_complex::Complex64;
 
+/// The index tuples a single packed integral expands into.
+///
+/// An 8-fold-symmetric index expands into at most 8 tuples (4 for the 4-fold case), so the
+/// expansions are returned in a fixed-size buffer rather than a freshly heap-allocated `Vec` per
+/// integral: building a large operator calls these once per stored integral, and the allocation
+/// dominated the arithmetic.
+struct ExpandedIndices {
+    buf: [(u32, u32, u32, u32); 8],
+    len: usize,
+}
+
+impl ExpandedIndices {
+    #[inline]
+    fn new() -> Self {
+        Self {
+            buf: [(0, 0, 0, 0); 8],
+            len: 0,
+        }
+    }
+
+    #[inline]
+    fn push(&mut self, tuple: (u32, u32, u32, u32)) {
+        self.buf[self.len] = tuple;
+        self.len += 1;
+    }
+
+    /// Appends `(i, a, j, b)` together with whichever of its index-swap partners are distinct from
+    /// it, mirroring the permutational symmetry of a real two-electron integral.
+    #[inline]
+    fn push_with_swaps(&mut self, i: u32, a: u32, j: u32, b: u32) {
+        self.push((i, a, j, b));
+        if i > a {
+            self.push((a, i, j, b));
+        }
+        if j > b {
+            self.push((i, a, b, j));
+        }
+        if i > a && j > b {
+            self.push((a, i, b, j));
+        }
+    }
+
+    #[inline]
+    fn as_slice(&self) -> &[(u32, u32, u32, u32)] {
+        &self.buf[..self.len]
+    }
+}
+
+/// Splits a lower-triangular packed index into its `(row, column)` pair.
+///
+/// `index` is `p * (p + 1) / 2 + q` with `q <= p`, so `p` is the largest integer with
+/// `p * (p + 1) / 2 <= index`, i.e. `floor((sqrt(8 * index + 1) - 1) / 2)`. The closed form
+/// replaces a loop that counted `p` up from zero. `f64` has 53 bits of mantissa and `index` is a
+/// `u32`, so `8 * index + 1` is exact and the square root is correct to well under half an integer
+/// step; the neighbours are still checked so a rounding step in either direction cannot slip
+/// through.
+#[inline]
 fn _inflate_index(index: u32) -> (u32, u32) {
-    let mut p = 0;
+    let mut p = (((8.0 * f64::from(index) + 1.0).sqrt() - 1.0) / 2.0) as u32;
+    // Nudge into place if the floating-point floor landed one off.
+    while p * (p + 1) / 2 > index {
+        p -= 1;
+    }
     while (p + 1) * (p + 2) / 2 <= index {
         p += 1;
     }
@@ -24,53 +85,28 @@ fn _inflate_index(index: u32) -> (u32, u32) {
     (p, q)
 }
 
-fn _expand_s4_index(iajb: u32, npair: u32) -> Vec<(u32, u32, u32, u32)> {
+fn _expand_s4_index(iajb: u32, npair: u32) -> ExpandedIndices {
     let ia = iajb / npair;
     let jb = iajb % npair;
 
     let (i, a) = _inflate_index(ia);
     let (j, b) = _inflate_index(jb);
 
-    let mut res = vec![(i, a, j, b)];
-    if i > a {
-        res.push((a, i, j, b));
-    }
-    if j > b {
-        res.push((i, a, b, j));
-    }
-    if i > a && j > b {
-        res.push((a, i, b, j));
-    }
+    let mut res = ExpandedIndices::new();
+    res.push_with_swaps(i, a, j, b);
     res
 }
 
-fn _expand_s8_index(iajb: u32) -> Vec<(u32, u32, u32, u32)> {
+fn _expand_s8_index(iajb: u32) -> ExpandedIndices {
     let (ia, jb) = _inflate_index(iajb);
-    let (mut i, mut a) = _inflate_index(ia);
-    let (mut j, mut b) = _inflate_index(jb);
+    let (i, a) = _inflate_index(ia);
+    let (j, b) = _inflate_index(jb);
 
-    let mut res = vec![(i, a, j, b)];
-    if i > a {
-        res.push((a, i, j, b));
-    }
-    if j > b {
-        res.push((i, a, b, j));
-    }
-    if i > a && j > b {
-        res.push((a, i, b, j));
-    }
+    let mut res = ExpandedIndices::new();
+    res.push_with_swaps(i, a, j, b);
     if ia > jb {
-        (i, a, j, b) = (j, b, i, a);
-        res.push((i, a, j, b));
-        if i > a {
-            res.push((a, i, j, b));
-        }
-        if j > b {
-            res.push((i, a, b, j));
-        }
-        if i > a && j > b {
-            res.push((a, i, b, j));
-        }
+        // The bra and ket pairs are distinct, so the whole block repeats with them exchanged.
+        res.push_with_swaps(j, b, i, a);
     }
     res
 }
@@ -293,6 +329,7 @@ impl From2Body for FermionOperator {
                 let group_idx_ba = next_group_idx.map(|x| x + 2);
                 let group_idx_bb = next_group_idx.map(|x| x + 3);
                 _expand_s8_index(iajb as u32)
+                    .as_slice()
                     .iter()
                     .for_each(|&(i, a, j, b)| {
                         Self::_insert_2body_idx(self, c, i, j, b, a, next_group_idx);
@@ -335,6 +372,7 @@ impl From2Body for FermionOperator {
             .for_each(|(iajb, &coeff)| {
                 let c = Complex64::new(0.5 * coeff, 0.0);
                 _expand_s8_index(iajb as u32)
+                    .as_slice()
                     .iter()
                     .for_each(|&(i, a, j, b)| {
                         Self::_insert_2body_idx(self, c, i, j, b, a, next_group_idx);
@@ -350,6 +388,7 @@ impl From2Body for FermionOperator {
                 let c = Complex64::new(0.5 * coeff, 0.0);
                 let group_idx_b = next_group_idx.map(|x| x + 1);
                 _expand_s4_index(iajb as u32, npair)
+                    .as_slice()
                     .iter()
                     .for_each(|&(i, a, j, b)| {
                         Self::_insert_2body_idx(self, c, i, j + norb, b + norb, a, next_group_idx);
@@ -364,6 +403,7 @@ impl From2Body for FermionOperator {
             .for_each(|(iajb, &coeff)| {
                 let c = Complex64::new(0.5 * coeff, 0.0);
                 _expand_s8_index(iajb as u32)
+                    .as_slice()
                     .iter()
                     .for_each(|&(i, a, j, b)| {
                         Self::_insert_2body_idx(
@@ -401,6 +441,57 @@ mod tests {
     use num_complex::Complex64;
 
     use super::*;
+
+    #[test]
+    fn test_inflate_index_matches_linear_search() {
+        // `_inflate_index` uses a closed form with a floating-point square root, so check it
+        // exhaustively against the linear search it replaced rather than at sampled points: an
+        // off-by-one from rounding would corrupt every index built from it. The sweep covers packed
+        // indices well past any real FCIDUMP (norb = 2000 packs into ~2e6 pairs).
+        fn linear_search(index: u32) -> (u32, u32) {
+            let mut p = 0;
+            while (p + 1) * (p + 2) / 2 <= index {
+                p += 1;
+            }
+            (p, index - p * (p + 1) / 2)
+        }
+
+        for index in 0..2_000_000_u32 {
+            let (p, q) = _inflate_index(index);
+            assert_eq!((p, q), linear_search(index), "mismatch at {index}");
+            // Also pin the defining identity, so both implementations agreeing on a wrong answer
+            // would still fail.
+            assert_eq!(p * (p + 1) / 2 + q, index, "identity broken at {index}");
+            assert!(q <= p, "q > p at {index}");
+        }
+    }
+
+    #[test]
+    fn test_expand_s8_index_covers_the_symmetry_orbit() {
+        // A fully off-diagonal index expands to all 8 permutations; the fully diagonal one to 1.
+        // These bracket the fixed-size buffer, so an over-push would panic here rather than only in
+        // a large build.
+        //
+        // iajb = 7 unpacks to ia = 3, jb = 1, i.e. (i, a) = (2, 0) and (j, b) = (1, 0): both pairs
+        // off-diagonal and distinct from each other, which is the maximal orbit.
+        assert_eq!(_inflate_index(7), (3, 1));
+        assert_eq!(
+            _expand_s8_index(7).as_slice(),
+            &[
+                (2, 0, 1, 0),
+                (0, 2, 1, 0),
+                (2, 0, 0, 1),
+                (0, 2, 0, 1),
+                (1, 0, 2, 0),
+                (0, 1, 2, 0),
+                (1, 0, 0, 2),
+                (0, 1, 0, 2),
+            ]
+        );
+
+        // ia == jb == 0 -> i == a == j == b, a single tuple.
+        assert_eq!(_expand_s8_index(0).as_slice(), &[(0, 0, 0, 0)]);
+    }
 
     #[test]
     fn test_1body_tril_spin_sym() {

--- a/crates/core/src/operators/library/electronic_integrals.rs
+++ b/crates/core/src/operators/library/electronic_integrals.rs
@@ -76,13 +76,33 @@ fn _expand_s8_index(iajb: u32) -> Vec<(u32, u32, u32, u32)> {
 }
 
 pub trait From1Body {
-    fn add_1body_tril_spin_sym(&mut self, one_body_a: ArrayView1<f64>, norb: u32);
+    /// Appends the one-body terms, assigning group indices from `next_group_idx` upwards, and
+    /// returns the next free group index.
+    ///
+    /// The group index is threaded in and out rather than re-derived from the operator so that a
+    /// caller appending several blocks in sequence keeps the running index in its own scope.
+    /// Deriving it per integral instead (via
+    /// [`num_groups`](crate::operators::OperatorTrait::num_groups), which scans every group index)
+    /// makes building a large operator quadratic in its term count.
+    ///
+    /// `next_group_idx` must be `Some` iff the operator tracks groups; it is returned unchanged
+    /// (`None`) for an operator that does not.
+    fn add_1body_tril_spin_sym(
+        &mut self,
+        one_body_a: ArrayView1<f64>,
+        norb: u32,
+        next_group_idx: Option<u32>,
+    ) -> Option<u32>;
+
+    /// Appends the one-body alpha and beta terms. See
+    /// [`add_1body_tril_spin_sym`](Self::add_1body_tril_spin_sym) for the group-index contract.
     fn add_1body_tril_spin(
         &mut self,
         one_body_a: ArrayView1<f64>,
         one_body_b: ArrayView1<f64>,
         norb: u32,
-    );
+        next_group_idx: Option<u32>,
+    ) -> Option<u32>;
 
     fn from_1body_tril_spin_sym(one_body_a: ArrayView1<f64>, norb: u32) -> Self;
     fn from_1body_tril_spin(
@@ -150,24 +170,31 @@ impl FermionOperator {
 }
 
 impl From1Body for FermionOperator {
-    fn add_1body_tril_spin_sym(&mut self, one_body_a: ArrayView1<f64>, norb: u32) {
+    fn add_1body_tril_spin_sym(
+        &mut self,
+        one_body_a: ArrayView1<f64>,
+        norb: u32,
+        mut next_group_idx: Option<u32>,
+    ) -> Option<u32> {
         one_body_a
             .indexed_iter()
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
             .for_each(|(ia, &coeff)| {
                 let (i, a) = _inflate_index(ia as u32);
                 let c = Complex64::new(coeff, 0.0);
-                let mut next_group_idx = self.num_groups();
                 Self::_insert_1body_idx(self, c, i, a, next_group_idx);
-                next_group_idx = self.num_groups();
+                next_group_idx = next_group_idx.map(|x| x + 1);
                 Self::_insert_1body_idx(self, c, i + norb, a + norb, next_group_idx);
+                next_group_idx = next_group_idx.map(|x| x + 1);
             });
+
+        next_group_idx
     }
 
     fn from_1body_tril_spin_sym(one_body_a: ArrayView1<f64>, norb: u32) -> Self {
         let mut op = Self::zero();
         op.groups = Some(vec![]);
-        op.add_1body_tril_spin_sym(one_body_a, norb);
+        op.add_1body_tril_spin_sym(one_body_a, norb, Some(0));
         op
     }
 
@@ -176,15 +203,16 @@ impl From1Body for FermionOperator {
         one_body_a: ArrayView1<f64>,
         one_body_b: ArrayView1<f64>,
         norb: u32,
-    ) {
+        mut next_group_idx: Option<u32>,
+    ) -> Option<u32> {
         one_body_a
             .indexed_iter()
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
             .for_each(|(ia, &coeff)| {
                 let (i, a) = _inflate_index(ia as u32);
                 let c = Complex64::new(coeff, 0.0);
-                let next_group_idx = self.num_groups();
                 Self::_insert_1body_idx(self, c, i, a, next_group_idx);
+                next_group_idx = next_group_idx.map(|x| x + 1);
             });
 
         one_body_b
@@ -193,9 +221,11 @@ impl From1Body for FermionOperator {
             .for_each(|(ia, &coeff)| {
                 let (i, a) = _inflate_index(ia as u32);
                 let c = Complex64::new(coeff, 0.0);
-                let next_group_idx = self.num_groups();
                 Self::_insert_1body_idx(self, c, i + norb, a + norb, next_group_idx);
+                next_group_idx = next_group_idx.map(|x| x + 1);
             });
+
+        next_group_idx
     }
 
     fn from_1body_tril_spin(
@@ -205,20 +235,32 @@ impl From1Body for FermionOperator {
     ) -> Self {
         let mut op = Self::zero();
         op.groups = Some(vec![]);
-        op.add_1body_tril_spin(one_body_a, one_body_b, norb);
+        op.add_1body_tril_spin(one_body_a, one_body_b, norb, Some(0));
         op
     }
 }
 
 pub trait From2Body {
-    fn add_2body_tril_spin_sym(&mut self, two_body_aa: ArrayView1<f64>, norb: u32);
+    /// Appends the two-body terms, assigning group indices from `next_group_idx` upwards, and
+    /// returns the next free group index. See
+    /// [`add_1body_tril_spin_sym`](From1Body::add_1body_tril_spin_sym) for the group-index contract.
+    fn add_2body_tril_spin_sym(
+        &mut self,
+        two_body_aa: ArrayView1<f64>,
+        norb: u32,
+        next_group_idx: Option<u32>,
+    ) -> Option<u32>;
+
+    /// Appends the two-body alpha-alpha, alpha-beta and beta-beta terms. See
+    /// [`add_1body_tril_spin_sym`](From1Body::add_1body_tril_spin_sym) for the group-index contract.
     fn add_2body_tril_spin(
         &mut self,
         two_body_aa: ArrayView1<f64>,
         two_body_ab: ArrayView1<f64>,
         two_body_bb: ArrayView1<f64>,
         norb: u32,
-    );
+        next_group_idx: Option<u32>,
+    ) -> Option<u32>;
 
     fn from_2body_tril_spin_sym(two_body_aa: ArrayView1<f64>, norb: u32) -> Self;
     fn from_2body_tril_spin(
@@ -236,13 +278,17 @@ pub trait From2Body {
 }
 
 impl From2Body for FermionOperator {
-    fn add_2body_tril_spin_sym(&mut self, two_body_aa: ArrayView1<f64>, norb: u32) {
+    fn add_2body_tril_spin_sym(
+        &mut self,
+        two_body_aa: ArrayView1<f64>,
+        norb: u32,
+        mut next_group_idx: Option<u32>,
+    ) -> Option<u32> {
         two_body_aa
             .indexed_iter()
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
             .for_each(|(iajb, &coeff)| {
                 let c = Complex64::new(0.5 * coeff, 0.0);
-                let next_group_idx = self.num_groups();
                 let group_idx_ab = next_group_idx.map(|x| x + 1);
                 let group_idx_ba = next_group_idx.map(|x| x + 2);
                 let group_idx_bb = next_group_idx.map(|x| x + 3);
@@ -262,13 +308,16 @@ impl From2Body for FermionOperator {
                             group_idx_bb,
                         );
                     });
+                next_group_idx = next_group_idx.map(|x| x + 4);
             });
+
+        next_group_idx
     }
 
     fn from_2body_tril_spin_sym(two_body_aa: ArrayView1<f64>, norb: u32) -> Self {
         let mut op = Self::zero();
         op.groups = Some(vec![]);
-        op.add_2body_tril_spin_sym(two_body_aa, norb);
+        op.add_2body_tril_spin_sym(two_body_aa, norb, Some(0));
         op
     }
 
@@ -278,18 +327,19 @@ impl From2Body for FermionOperator {
         two_body_ab: ArrayView1<f64>,
         two_body_bb: ArrayView1<f64>,
         norb: u32,
-    ) {
+        mut next_group_idx: Option<u32>,
+    ) -> Option<u32> {
         two_body_aa
             .indexed_iter()
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
             .for_each(|(iajb, &coeff)| {
                 let c = Complex64::new(0.5 * coeff, 0.0);
-                let next_group_idx = self.num_groups();
                 _expand_s8_index(iajb as u32)
                     .iter()
                     .for_each(|&(i, a, j, b)| {
                         Self::_insert_2body_idx(self, c, i, j, b, a, next_group_idx);
                     });
+                next_group_idx = next_group_idx.map(|x| x + 1);
             });
 
         let npair = norb * (norb + 1) / 2;
@@ -298,7 +348,6 @@ impl From2Body for FermionOperator {
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
             .for_each(|(iajb, &coeff)| {
                 let c = Complex64::new(0.5 * coeff, 0.0);
-                let next_group_idx = self.num_groups();
                 let group_idx_b = next_group_idx.map(|x| x + 1);
                 _expand_s4_index(iajb as u32, npair)
                     .iter()
@@ -306,6 +355,7 @@ impl From2Body for FermionOperator {
                         Self::_insert_2body_idx(self, c, i, j + norb, b + norb, a, next_group_idx);
                         Self::_insert_2body_idx(self, c, j + norb, i, a, b + norb, group_idx_b);
                     });
+                next_group_idx = next_group_idx.map(|x| x + 2);
             });
 
         two_body_bb
@@ -313,7 +363,6 @@ impl From2Body for FermionOperator {
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
             .for_each(|(iajb, &coeff)| {
                 let c = Complex64::new(0.5 * coeff, 0.0);
-                let next_group_idx = self.num_groups();
                 _expand_s8_index(iajb as u32)
                     .iter()
                     .for_each(|&(i, a, j, b)| {
@@ -327,7 +376,10 @@ impl From2Body for FermionOperator {
                             next_group_idx,
                         );
                     });
+                next_group_idx = next_group_idx.map(|x| x + 1);
             });
+
+        next_group_idx
     }
 
     fn from_2body_tril_spin(
@@ -338,7 +390,7 @@ impl From2Body for FermionOperator {
     ) -> Self {
         let mut op = Self::zero();
         op.groups = Some(vec![]);
-        op.add_2body_tril_spin(two_body_aa, two_body_ab, two_body_bb, norb);
+        op.add_2body_tril_spin(two_body_aa, two_body_ab, two_body_bb, norb, Some(0));
         op
     }
 }

--- a/crates/core/src/operators/library/electronic_integrals.rs
+++ b/crates/core/src/operators/library/electronic_integrals.rs
@@ -111,6 +111,36 @@ fn _expand_s8_index(iajb: u32) -> ExpandedIndices {
     res
 }
 
+/// Counts the terms one spin block of a packed one-body matrix contributes.
+///
+/// A stored element yields one term, plus a second for its transpose when it is off-diagonal (see
+/// `_insert_1body_idx`). Used only to size the output buffers up front.
+fn _count_1body_terms(one_body: ArrayView1<f64>) -> usize {
+    one_body
+        .indexed_iter()
+        .filter(|&(_, coeff)| coeff.abs() > 0.0)
+        .map(|(ia, _)| {
+            let (i, a) = _inflate_index(ia as u32);
+            if i == a { 1 } else { 2 }
+        })
+        .sum()
+}
+
+/// Counts the index tuples one spin block of a packed two-body tensor expands into.
+///
+/// Each stored element contributes one term per tuple in its symmetry orbit. Used only to size the
+/// output buffers up front.
+fn _count_2body_tuples(
+    two_body: ArrayView1<f64>,
+    expand: impl Fn(u32) -> ExpandedIndices,
+) -> usize {
+    two_body
+        .indexed_iter()
+        .filter(|&(_, coeff)| coeff.abs() > 0.0)
+        .map(|(iajb, _)| expand(iajb as u32).len)
+        .sum()
+}
+
 pub trait From1Body {
     /// Appends the one-body terms, assigning group indices from `next_group_idx` upwards, and
     /// returns the next free group index.
@@ -155,6 +185,22 @@ pub trait From1Body {
 }
 
 impl FermionOperator {
+    /// Reserves room for `num_terms` further terms, each spanning `modes_per_term` modes.
+    ///
+    /// The buffers otherwise grow by repeated reallocation, which for a large FCIDUMP means copying
+    /// a `modes` vector on its way to tens of millions of entries a couple of dozen times. Callers
+    /// that know how many terms they are about to append reserve once instead.
+    #[inline]
+    fn _reserve_terms(&mut self, num_terms: usize, modes_per_term: usize) {
+        self.coeffs.reserve(num_terms);
+        self.actions.reserve(num_terms * modes_per_term);
+        self.modes.reserve(num_terms * modes_per_term);
+        self.boundaries.reserve(num_terms);
+        if let Some(groups) = self.groups.as_mut() {
+            groups.reserve(num_terms);
+        }
+    }
+
     #[inline]
     fn _insert_1body_idx(op: &mut Self, c: Complex64, i: u32, a: u32, group_idx: Option<u32>) {
         op.coeffs.push(c);
@@ -212,6 +258,7 @@ impl From1Body for FermionOperator {
         norb: u32,
         mut next_group_idx: Option<u32>,
     ) -> Option<u32> {
+        self._reserve_terms(_count_1body_terms(one_body_a) * 2, 2);
         one_body_a
             .indexed_iter()
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
@@ -241,6 +288,10 @@ impl From1Body for FermionOperator {
         norb: u32,
         mut next_group_idx: Option<u32>,
     ) -> Option<u32> {
+        self._reserve_terms(
+            _count_1body_terms(one_body_a) + _count_1body_terms(one_body_b),
+            2,
+        );
         one_body_a
             .indexed_iter()
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
@@ -320,6 +371,8 @@ impl From2Body for FermionOperator {
         norb: u32,
         mut next_group_idx: Option<u32>,
     ) -> Option<u32> {
+        // Every expanded tuple is emitted once per spin block (aa, ab, ba, bb).
+        self._reserve_terms(_count_2body_tuples(two_body_aa, _expand_s8_index) * 4, 4);
         two_body_aa
             .indexed_iter()
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
@@ -366,6 +419,14 @@ impl From2Body for FermionOperator {
         norb: u32,
         mut next_group_idx: Option<u32>,
     ) -> Option<u32> {
+        let npair = norb * (norb + 1) / 2;
+        // aa and bb emit one term per tuple; ab emits two (the block and its spin-flipped partner).
+        self._reserve_terms(
+            _count_2body_tuples(two_body_aa, _expand_s8_index)
+                + _count_2body_tuples(two_body_ab, |iajb| _expand_s4_index(iajb, npair)) * 2
+                + _count_2body_tuples(two_body_bb, _expand_s8_index),
+            4,
+        );
         two_body_aa
             .indexed_iter()
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
@@ -380,7 +441,6 @@ impl From2Body for FermionOperator {
                 next_group_idx = next_group_idx.map(|x| x + 1);
             });
 
-        let npair = norb * (norb + 1) / 2;
         two_body_ab
             .indexed_iter()
             .filter(|&(_, coeff)| coeff.abs() > 0.0)
@@ -464,6 +524,52 @@ mod tests {
             assert_eq!(p * (p + 1) / 2 + q, index, "identity broken at {index}");
             assert!(q <= p, "q > p at {index}");
         }
+    }
+
+    #[test]
+    fn test_builders_reserve_exactly_what_they_append() {
+        // The `_count_*` helpers size the output buffers up front. If one over-counts we silently
+        // over-allocate; if it under-counts we reintroduce a reallocation. Asserting
+        // `capacity == len` on a freshly built operator pins both directions. `Vec::reserve` is
+        // free to over-allocate in principle, but on an empty vector with an exact request every
+        // current implementation allocates exactly, so an inexact count is what this would catch.
+        let norb = 4;
+        let npair = norb * (norb + 1) / 2;
+        let num_s8 = npair * (npair + 1) / 2;
+        let num_s4 = npair * npair;
+
+        // Dense blocks, so every symmetry orbit is exercised (and a few explicit zeros, which the
+        // count must skip exactly as the build loop does).
+        let mut one_body = Array1::from_iter((0..npair).map(|x| f64::from(x) + 1.0));
+        one_body[2] = 0.0;
+        let mut two_body_s8 = Array1::from_iter((0..num_s8).map(|x| f64::from(x) + 1.0));
+        two_body_s8[5] = 0.0;
+        let two_body_s4 = Array1::from_iter((0..num_s4).map(|x| f64::from(x) + 1.0));
+
+        let op = FermionOperator::from_1body_tril_spin_sym(ArrayView1::from(&one_body), norb);
+        assert_eq!(op.coeffs.len(), op.coeffs.capacity(), "1body sym coeffs");
+        assert_eq!(op.modes.len(), op.modes.capacity(), "1body sym modes");
+
+        let op = FermionOperator::from_1body_tril_spin(
+            ArrayView1::from(&one_body),
+            ArrayView1::from(&one_body),
+            norb,
+        );
+        assert_eq!(op.coeffs.len(), op.coeffs.capacity(), "1body coeffs");
+        assert_eq!(op.modes.len(), op.modes.capacity(), "1body modes");
+
+        let op = FermionOperator::from_2body_tril_spin_sym(ArrayView1::from(&two_body_s8), norb);
+        assert_eq!(op.coeffs.len(), op.coeffs.capacity(), "2body sym coeffs");
+        assert_eq!(op.modes.len(), op.modes.capacity(), "2body sym modes");
+
+        let op = FermionOperator::from_2body_tril_spin(
+            ArrayView1::from(&two_body_s8),
+            ArrayView1::from(&two_body_s4),
+            ArrayView1::from(&two_body_s8),
+            norb,
+        );
+        assert_eq!(op.coeffs.len(), op.coeffs.capacity(), "2body coeffs");
+        assert_eq!(op.modes.len(), op.modes.capacity(), "2body modes");
     }
 
     #[test]

--- a/crates/core/src/operators/library/fcidump.rs
+++ b/crates/core/src/operators/library/fcidump.rs
@@ -185,29 +185,44 @@ impl From<&FCIDump> for FermionOperator {
         let mut op = Self::zero();
         op.groups = Some(vec![]);
 
+        // The running group index is owned here and threaded through each block, so that no builder
+        // has to re-derive it from the operator (see `From1Body::add_1body_tril_spin_sym`).
+        let mut next_group_idx = Some(0);
+
         if let Some(coeff) = fcidump.constant {
             op.coeffs.push(Complex64::new(coeff, 0.0));
             op.boundaries.push(op.boundaries.len() - 1);
             op.groups = Some(vec![0]);
+            next_group_idx = Some(1);
         };
 
         match &fcidump.one_body_b {
             Some(_) => {
-                op.add_1body_tril_spin(
+                let next_group_idx = op.add_1body_tril_spin(
                     ArrayView1::from(&fcidump.one_body_a),
                     ArrayView1::from(fcidump.one_body_b.as_ref().unwrap()),
                     fcidump.norb,
+                    next_group_idx,
                 );
                 op.add_2body_tril_spin(
                     ArrayView1::from(&fcidump.two_body_aa),
                     ArrayView1::from(fcidump.two_body_ab.as_ref().unwrap()),
                     ArrayView1::from(fcidump.two_body_bb.as_ref().unwrap()),
                     fcidump.norb,
+                    next_group_idx,
                 );
             }
             None => {
-                op.add_1body_tril_spin_sym(ArrayView1::from(&fcidump.one_body_a), fcidump.norb);
-                op.add_2body_tril_spin_sym(ArrayView1::from(&fcidump.two_body_aa), fcidump.norb);
+                let next_group_idx = op.add_1body_tril_spin_sym(
+                    ArrayView1::from(&fcidump.one_body_a),
+                    fcidump.norb,
+                    next_group_idx,
+                );
+                op.add_2body_tril_spin_sym(
+                    ArrayView1::from(&fcidump.two_body_aa),
+                    fcidump.norb,
+                    next_group_idx,
+                );
             }
         }
 

--- a/crates/core/src/operators/library/fcidump.rs
+++ b/crates/core/src/operators/library/fcidump.rs
@@ -19,6 +19,36 @@ use regex::{Captures, Regex};
 use std::fs::File;
 use std::io::Read;
 
+/// Splits one integral line into its coefficient and four (1-based) orbital indices, or returns
+/// `None` if the line is not an integral record and should be skipped.
+///
+/// This replaces a per-line capturing regex (`(.+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)`) whose captures
+/// each had to be copied into an owned `String` before parsing; here every field is parsed straight
+/// out of the borrowed line, so reading a large file allocates nothing per record.
+///
+/// The regex's leading group was greedy, so on a line carrying more than five fields the *last*
+/// four were taken as the indices and everything before them as the coefficient. That is preserved
+/// exactly: the indices are the final four whitespace-separated tokens. A line is skipped when it
+/// has fewer than five tokens, when any of the last four is not a non-negative integer, or when the
+/// remainder does not parse as a float — matching the cases where the regex previously found no
+/// match (and, for the coefficient, where the subsequent `parse` would have panicked).
+fn split_integral_line(line: &str) -> Option<(f64, usize, usize, usize, usize)> {
+    let line = line.trim();
+
+    // Walk back over the four index fields, remembering where the coefficient ends.
+    let mut rest = line;
+    let mut indices = [0_usize; 4];
+    for slot in indices.iter_mut().rev() {
+        let start = rest.rfind(char::is_whitespace)? + 1;
+        // `\d+` matched digits only: no sign, and a bare `-1` is not an index.
+        *slot = rest[start..].parse::<usize>().ok()?;
+        rest = rest[..start].trim_end();
+    }
+
+    let coeff = rest.parse::<f64>().ok()?;
+    Some((coeff, indices[0], indices[1], indices[2], indices[3]))
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct FCIDump {
     pub norb: u32,
@@ -83,8 +113,6 @@ impl FCIDump {
         let num_s4 = npair * npair;
         let num_s8 = npair * (npair + 1) / 2;
 
-        let integral_line = Regex::new(r"(.+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)").unwrap();
-
         let mut beta_present: bool = false;
         let mut constant: Option<f64> = None;
         let mut one_body_a = Array1::<f64>::zeros(npair);
@@ -94,14 +122,9 @@ impl FCIDump {
         let mut two_body_bb = Array1::<f64>::zeros(num_s8);
 
         for line in integrals.lines() {
-            let Some(integral) = integral_line.captures(line.trim()) else {
+            let Some((coeff, i, a, j, b)) = split_integral_line(line) else {
                 continue;
             };
-            let coeff = unwrap_cap(&integral, 1).parse::<f64>().unwrap();
-            let i = unwrap_cap(&integral, 2).parse::<usize>().unwrap();
-            let a = unwrap_cap(&integral, 3).parse::<usize>().unwrap();
-            let j = unwrap_cap(&integral, 4).parse::<usize>().unwrap();
-            let b = unwrap_cap(&integral, 5).parse::<usize>().unwrap();
 
             match (i, a, j, b) {
                 (0, 0, 0, 0) => constant = Some(coeff),
@@ -663,5 +686,47 @@ mod tests {
             "&FCI NORB=   2,NELEC=   2,MS2= 0,\n /\n 0.5   1   1   2   0\n",
         );
         FCIDump::from_file(path);
+    }
+
+    #[test]
+    fn test_split_integral_line_accepts_well_formed_records() {
+        assert_eq!(
+            split_integral_line(" 0.284 1 1 1 1"),
+            Some((0.284, 1, 1, 1, 1))
+        );
+        // Irregular internal padding, a leading sign and an exponent must all parse.
+        assert_eq!(
+            split_integral_line(" -1.67e-04    2    1    1    1"),
+            Some((-1.67e-4, 2, 1, 1, 1))
+        );
+        // The all-zero index tuple carries the constant and must not be treated as malformed.
+        assert_eq!(split_integral_line(" 0.5 0 0 0 0"), Some((0.5, 0, 0, 0, 0)));
+        // A coefficient written without a decimal point is still a valid float.
+        assert_eq!(split_integral_line("1 2 3 4 5"), Some((1.0, 2, 3, 4, 5)));
+    }
+
+    #[test]
+    fn test_split_integral_line_skips_non_records() {
+        // Blank, short and non-numeric lines are skipped rather than parsed, which is what let the
+        // previous regex-based loop walk past the namelist remnants and any trailing blank line.
+        assert_eq!(split_integral_line(""), None);
+        assert_eq!(split_integral_line("   "), None);
+        assert_eq!(split_integral_line(" 0.5 1 1 1"), None);
+        assert_eq!(split_integral_line("garbage line"), None);
+        // `\d+` matched digits only, so a signed index is not an index.
+        assert_eq!(split_integral_line(" 0.5 1 1 1 -1"), None);
+        // Commas were never stripped from integral records, so a comma-separated line did not match.
+        assert_eq!(split_integral_line(" 0.5,  1,  1,  1,  1"), None);
+    }
+
+    #[test]
+    fn test_split_integral_line_takes_the_last_four_indices() {
+        // The replaced regex opened with a greedy `(.+)`, so on a line with more than five fields
+        // the *last* four became the indices and everything before them the coefficient. That line
+        // shape is not legal FCIDUMP, but pin the behaviour so the rewrite is a faithful swap: here
+        // the coefficient text is `0.5 1`, which is not a float, so the record is skipped.
+        assert_eq!(split_integral_line(" 0.5 1 1 1 1 2"), None);
+        // With a coefficient that survives the greedy match, the last four fields are the indices.
+        assert_eq!(split_integral_line(" 0.5 1 2 3 4"), Some((0.5, 1, 2, 3, 4)));
     }
 }


### PR DESCRIPTION
Loading a large FCIDUMP was dominated by a quadratic group-index lookup. On a 36-orbital Fe4S4
file (9.6 MB, 222,782 records → 6,721,057 terms / 889,777 groups):

| stage | before | after |
|---|---|---|
| `FCIDump.from_file` | 0.34 s | 0.02 s |
| `FermionOperator.from_fcidump` | 216.39 s | 0.13 s |
| **total** | **216.73 s** | **~0.15 s** |

For reference, ffsim loads the same file in ~30 s and fulqrum in ~6 s.

## What was slow

Parsing was never the problem — it was 0.16% of the runtime. Essentially all of it was in
`from_fcidump`, where the `add_{1,2}body_tril_spin[_sym]` builders derived the next group index by
calling `num_groups()` **once per integral**:

```rust
.for_each(|(iajb, &coeff)| {
    let next_group_idx = self.num_groups();   // O(len(groups)) scan, per integral
    ...
});
```

`num_groups()` is `groups.iter().max()`, so building an *n*-term operator cost Θ(n²) — for this file
roughly 10¹² element reads. The method is not wrong (its docstring even suggests using it as the
next group index); calling a lazily-evaluated O(n) accessor from a hot loop is.