### PR TITLE
Rework Github actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,56 @@
+---
+name: Backport metadata
+
+# Mergify manages the opening of the backport PR (see `.mergify.yml`), this workflow is just to extend
+# its behavior to do useful things like copying across the tagged labels and milestone from the base
+# PR.
+#
+# Note that this is dormant until a `stable/*` branch actually exists; it only triggers on pull
+# requests that Mergify opens against one.
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - 'stable/*'
+
+jobs:
+  copy_metadata:
+    name: Copy metadata from base PR
+    runs-on: ubuntu-latest
+    if: github.repository == 'Qiskit/qiskit-fermions' && github.actor == 'mergify[bot]'
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Copy metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -e
+          # Split Mergify's ref name (e.g. 'mergify/bp/stable/0.1/pr-123') on the final '-' to
+          # get the number of the PR that triggered Mergify.
+          IFS='-' read -ra split <<< "$BRANCH_REF"
+          base_pr=${split[-1]}
+
+          gh pr --repo "${{ github.repository }}" view "$base_pr" --json labels,milestone > base_pr.json
+
+          add_labels="$(jq --raw-output '[.labels[].name] - ["stable backport potential"] | join(",")' base_pr.json)"
+          echo "New labels: '$add_labels'"
+
+          milestone="$(jq --raw-output '.milestone.title // ""' base_pr.json )"
+          echo "Milestone: '$milestone'"
+
+          echo "Targetting current PR '${{ github.event.number }}'"
+          # The GitHub API is sometimes weird about empty values - the REST API certainly treats
+          # "add-label" with an empty input not as a no-op but as a clear of all labels.
+          if [[ -n "$add_labels" && -n "$milestone" ]]; then
+            gh pr --repo "${{ github.repository }}" edit "${{ github.event.number }}" --add-label "$add_labels" --milestone "$milestone"
+          elif [[ -n "$add_labels" ]]; then
+            gh pr --repo "${{ github.repository }}" edit "${{ github.event.number }}" --add-label "$add_labels"
+          elif [[ -n "$milestone" ]]; then
+            gh pr --repo "${{ github.repository }}" edit "${{ github.event.number }}" --milestone "$milestone"
+          fi

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -64,60 +64,66 @@ jobs:
     needs: config
     uses: ./.github/workflows/lint.yml
     with:
-      python-version: ${{ needs.config.outputs.python-old }}
       runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+      python-version: ${{ needs.config.outputs.python-old }}
 
   docs:
     name: Docs
     needs: config
     uses: ./.github/workflows/docs.yml
     with:
-      python-version: ${{ needs.config.outputs.python-coverage }}
       runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+      python-version: ${{ needs.config.outputs.python-coverage }}
 
   test-latest:
-    name: Tests / Latest / ${{ matrix.config.id }}
+    name: Tests / Latest
     needs: config
     uses: ./.github/workflows/test_latest_versions.yml
     with:
       runner: ${{ matrix.config.runner }}
-      python-version: ${{ matrix.config.python }}
+      python-version: ${{ matrix.config.python-version }}
     strategy:
       fail-fast: false
       matrix:
         config:
-          - id: Linux / oldest
-            runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
-            python: ${{ needs.config.outputs.python-old }}
-          - id: Linux / newest
-            runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
-            python: ${{ needs.config.outputs.python-new }}
-          - id: macOS / newest
-            runner: ${{ needs.config.outputs.runner-macos-arm64 }}
-            python: ${{ needs.config.outputs.python-new }}
-          - id: Windows / newest
-            runner: ${{ needs.config.outputs.runner-windows-x86_64 }}
-            python: ${{ needs.config.outputs.python-new }}
+          - runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-old }}
+          - runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-new }}
+          - runner: ${{ needs.config.outputs.runner-macos-arm64 }}
+            python-version: ${{ needs.config.outputs.python-new }}
+          - runner: ${{ needs.config.outputs.runner-windows-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-new }}
 
   test-minimum:
     name: Tests / Minimum
     needs: config
     uses: ./.github/workflows/test_minimum_versions.yml
     with:
-      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
-      python-version: ${{ needs.config.outputs.python-old }}
+      runner: ${{ matrix.config.runner }}
+      python-version: ${{ matrix.config.python-version }}
       qiskit-version: ${{ needs.config.outputs.qiskit-minimum }}
+    strategy:
+      fail-fast: false
+      # A single-entry matrix, for consistency with the other test jobs: GitHub appends the matrix
+      # values to the job name, which is what makes the legs distinguishable in the Actions summary.
+      matrix:
+        config:
+          - runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-old }}
 
   test-development:
     name: Tests / Development
     needs: config
     uses: ./.github/workflows/test_development_versions.yml
     with:
-      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
-      python-version: ${{ matrix.python-version }}
+      runner: ${{ matrix.config.runner }}
+      python-version: ${{ matrix.config.python-version }}
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - ${{ needs.config.outputs.python-old }}
-          - ${{ needs.config.outputs.python-new }}
+        config:
+          - runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-old }}
+          - runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-new }}

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,123 @@
+---
+
+# This is the shared configuration that defines all the jobs we include in branch protection.  This
+# needs to be run both by PRs and by the merge queue.
+#
+# All required branch-protection rules should be in here, and everything in here should be listed in
+# the `finalize` job.  The repository ruleset in the GitHub web interface then only needs to require
+# the single "Finalize" check, which means adding, removing or renaming any other CI job is a pure
+# code change and never needs a settings edit.
+
+name: Branch Protection
+
+on:
+  # `merge_group` is inert until a merge-queue rule is added to the repository ruleset; keeping the
+  # trigger here means enabling the queue later is a settings-only change.
+  merge_group:
+  pull_request:
+    branches:
+      - main
+      - 'stable/**'
+
+concurrency:
+  # Deliberately no `github.head_ref` component: it is empty for `merge_group` events, so including it
+  # would collapse every merge-queue entry into a single concurrency group and make them cancel each
+  # other.  `github.ref` is already unique per pull request and per queue entry.
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  config:
+    name: Configure
+    uses: ./.github/workflows/config.yml
+
+  # This 'finalize' job is a no-op; its sole purpose is to depend on all the other jobs and provide a
+  # single in-code determination of whether the branch-protection rules have been passed.  The
+  # ruleset in the GitHub web interface can then depend only on this job.
+  finalize:
+    name: Finalize
+    runs-on: 'ubuntu-latest'
+    # This list should contain every other job in this file.
+    needs:
+      - config
+      - lint
+      - docs
+      - test-latest
+      - test-minimum
+      - test-development
+    # This job needs to trigger even if its predecessors failed and return the same status.  By
+    # default, GitHub Actions will "skip" the job if a requirement failed, but that counts as a
+    # "success" state, which is not acceptable for a branch-protection rule.  We don't use `always`
+    # because we don't want `cancelled` to trigger this.
+    if: success() || failure()
+    steps:
+      - run: |
+          echo "Successful run."
+        if: ${{ !contains(needs.*.result, 'failure') }}
+      - run: |
+          echo "Predecessor jobs failed.  See GitHub Actions logs." >&2
+          exit 1
+        if: ${{ contains(needs.*.result, 'failure') }}
+
+  lint:
+    name: Lint
+    needs: config
+    uses: ./.github/workflows/lint.yml
+    with:
+      python-version: ${{ needs.config.outputs.python-old }}
+      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+
+  docs:
+    name: Docs
+    needs: config
+    uses: ./.github/workflows/docs.yml
+    with:
+      python-version: ${{ needs.config.outputs.python-coverage }}
+      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+
+  test-latest:
+    name: Tests / Latest / ${{ matrix.config.id }}
+    needs: config
+    uses: ./.github/workflows/test_latest_versions.yml
+    with:
+      runner: ${{ matrix.config.runner }}
+      python-version: ${{ matrix.config.python }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - id: Linux / oldest
+            runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python: ${{ needs.config.outputs.python-old }}
+          - id: Linux / newest
+            runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python: ${{ needs.config.outputs.python-new }}
+          - id: macOS / newest
+            runner: ${{ needs.config.outputs.runner-macos-arm64 }}
+            python: ${{ needs.config.outputs.python-new }}
+          - id: Windows / newest
+            runner: ${{ needs.config.outputs.runner-windows-x86_64 }}
+            python: ${{ needs.config.outputs.python-new }}
+
+  test-minimum:
+    name: Tests / Minimum
+    needs: config
+    uses: ./.github/workflows/test_minimum_versions.yml
+    with:
+      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+      python-version: ${{ needs.config.outputs.python-old }}
+      qiskit-version: ${{ needs.config.outputs.qiskit-minimum }}
+
+  test-development:
+    name: Tests / Development
+    needs: config
+    uses: ./.github/workflows/test_development_versions.yml
+    with:
+      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+      python-version: ${{ matrix.python-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - ${{ needs.config.outputs.python-old }}
+          - ${{ needs.config.outputs.python-new }}

--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -1,5 +1,10 @@
 name: Citation preview
 
+# Note the `paths` filter: this workflow does not report a status at all on pull requests that don't
+# touch `CITATION.bib`.  That makes it unsuitable as a required status check (a required check that is
+# never reported blocks merging forever), which is why it is deliberately not part of
+# `branch-protection.yml`.
+
 on:
   push:
     branches:
@@ -12,8 +17,14 @@ on:
       - 'stable/**'
     paths: ['CITATION.bib', '.github/workflows/citation.yml']
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-preview:
+    if: github.repository_owner == 'Qiskit'
+    name: build citation preview
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,0 +1,63 @@
+---
+
+# This is a no-op workflow whose only purpose is to centralise shared CI configuration values.  It's
+# also possible to specify these in the GitHub web interface, but that separates them from the rest
+# of the configuration logic and means that changes to the configuration do not appear in the git
+# history.
+#
+# Every value here is a literal declared directly as a `workflow_call` output, so callers can read
+# them as `needs.config.outputs.<name>` without this workflow needing any real jobs.
+#
+# Note that all values must be quoted: an unquoted `3.10` is the *number* 3.1, which would install
+# Python 3.1 rather than 3.10.
+
+name: Set CI configuration
+
+on:
+  workflow_call:
+    outputs:
+      python-old:
+        description: Oldest supported version of Python (see `requires-python` in `pyproject.toml`).
+        value: '3.10'
+
+      python-new:
+        description: Newest supported version of Python.
+        value: '3.14'
+
+      python-coverage:
+        description: >
+          Python version used for the coverage and documentation builds.  These don't need to sweep a
+          range of versions, they just need a single one that all of the tooling supports.
+        value: '3.11'
+
+      qiskit-minimum:
+        description: >
+          Oldest supported Qiskit release, used to build the Qiskit C API for the minimum-version
+          tests.  This does not *enforce* agreement with the `qiskit~=...` pins in `pyproject.toml`
+          (`build-system.requires`, `project.dependencies` and `dependency-groups.build`); it just
+          keeps the CI-side value in one greppable place.  Keep them in step by hand.
+        value: '2.5.0'
+
+      runner-linux-x86_64:
+        description: Runner image for Linux x86_64 jobs.
+        value: 'ubuntu-latest'
+
+      runner-linux-arm64:
+        description: Runner image for Linux ARM64 jobs.
+        value: 'ubuntu-24.04-arm'
+
+      runner-macos-arm64:
+        description: Runner image for macOS ARM64 jobs.
+        value: 'macos-latest'
+
+      runner-windows-x86_64:
+        description: Runner image for Windows x86_64 jobs.
+        value: 'windows-latest'
+
+jobs:
+  # We have to have _some_ job defined or the workflow isn't valid.
+  noop:
+    name: Configure
+    runs-on: 'ubuntu-latest'
+    steps:
+      - run: ':'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,9 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # Override the `rust-toolchain.toml` file because `grcov` has greater requirements than our MSRV.
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,10 +24,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  coverage:
+  # Even though this workflow isn't part of branch protection, it still reads its Python version and
+  # runner image from the shared configuration so they don't have to be kept in step by hand.
+  config:
+    name: Configure
     if: github.repository_owner == 'Qiskit'
+    uses: ./.github/workflows/config.yml
+
+  coverage:
     name: Coverage
-    runs-on: ubuntu-latest
+    needs: config
+    runs-on: ${{ needs.config.outputs.runner-linux-x86_64 }}
     timeout-minutes: 30
     env:
       # Override the `rust-toolchain.toml` file because `grcov` has greater requirements than our MSRV.
@@ -40,8 +47,7 @@ jobs:
       - uses: actions/setup-python@v7
         name: Install Python
         with:
-          # Keep in step with `python-coverage` in `config.yml`.
-          python-version: '3.11'
+          python-version: ${{ needs.config.outputs.python-coverage }}
 
       - name: Install Rust
         run:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,12 @@
 name: Coverage
 
+# This is deliberately *not* part of `branch-protection.yml`:
+#
+# * it needs the `push` trigger to give Coveralls a datapoint for every commit, which a
+#   `workflow_call`-only workflow cannot do; and
+# * coverage is a metric rather than a correctness property, so a coveralls.io outage should not be
+#   able to block merging.
+
 on:
   push:
     branches:
@@ -33,6 +40,7 @@ jobs:
       - uses: actions/setup-python@v7
         name: Install Python
         with:
+          # Keep in step with `python-coverage` in `config.yml`.
           python-version: '3.11'
 
       - name: Install Rust

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,18 @@
 ---
 name: Sphinx
 
-# This is a reusable workflow, driven by `branch-protection.yml`.  It deliberately has no `push` or
-# `pull_request` triggers of its own, and no `concurrency` block: the calling workflow owns both.
+# This is a reusable workflow and the single source of truth for building the documentation.  It
+# deliberately has no `push` or `pull_request` triggers of its own, and no `concurrency` block: the
+# calling workflow owns both.
 #
-# This builds the documentation and uploads it as an artifact; it does *not* deploy.  Publishing to
-# GitHub Pages happens post-merge in `docs_deploy.yml`, which cannot be part of branch protection
-# because it only ever runs on `main`.
+# It is called from two places:
+#
+# * `branch-protection.yml`, which only builds (`deploy: false`, the default); and
+# * `docs_deploy.yml`, which builds and then publishes to GitHub Pages (`deploy: true`).
+#
+# The deployment lives here, behind an input, rather than in `docs_deploy.yml`, so that the build
+# steps exist exactly once.  Publishing can't simply be a separate workflow that reuses the build,
+# because an `actions/upload-pages-artifact` artifact cannot be handed between workflow runs.
 
 on:
   workflow_call:
@@ -19,6 +25,13 @@ on:
         description: Runner image to use.  Expects an Ubuntu image.
         type: string
         required: true
+      deploy:
+        description: >
+          Whether to publish the built documentation to GitHub Pages.  Only ever set this for runs on
+          `main`: a Pages deployment from anywhere else would clobber the published documentation.
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build:
@@ -80,3 +93,19 @@ jobs:
         with:
           name: qiskit-fermions-htmldocs
           path: ./artifact
+
+  deploy:
+    name: deploy docs
+    if: ${{ inputs.deploy }}
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,28 +1,29 @@
+---
 name: Sphinx
 
-on:
-  workflow_dispatch:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
-    branches:
-      - main
-      - 'stable/**'
-  pull_request:
-    branches:
-      - main
-      - 'stable/**'
+# This is a reusable workflow, driven by `branch-protection.yml`.  It deliberately has no `push` or
+# `pull_request` triggers of its own, and no `concurrency` block: the calling workflow owns both.
+#
+# This builds the documentation and uploads it as an artifact; it does *not* deploy.  Publishing to
+# GitHub Pages happens post-merge in `docs_deploy.yml`, which cannot be part of branch protection
+# because it only ever runs on `main`.
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
-  # Only cancel in PR mode, otherwise we may have weird half-uploaded docs...
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version to use.
+        type: string
+        required: true
+      runner:
+        description: Runner image to use.  Expects an Ubuntu image.
+        type: string
+        required: true
 
 jobs:
   build:
-    if: github.repository_owner == 'Qiskit'
-    name: build docs
-    runs-on: ubuntu-latest
+    name: Docs
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -32,10 +33,10 @@ jobs:
       - uses: actions/setup-python@v7
         name: Install Python
         with:
-          python-version: '3.11'
+          python-version: ${{ inputs.python-version }}
 
       - name: Install Rust
-        run: rustup toolchain install stable --override --profile minimal --no-self-update
+        run: rustup toolchain install --profile minimal --no-self-update
 
       - name: Install dependencies
         run: tools/install_ubuntu_docs_dependencies.sh
@@ -79,19 +80,3 @@ jobs:
         with:
           name: qiskit-fermions-htmldocs
           path: ./artifact
-
-  deploy:
-    name: deploy docs
-    if: ${{ github.ref == 'refs/heads/main' }}
-    needs: build
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,12 +17,12 @@ name: Sphinx
 on:
   workflow_call:
     inputs:
-      python-version:
-        description: Python version to use.
-        type: string
-        required: true
       runner:
         description: Runner image to use.  Expects an Ubuntu image.
+        type: string
+        required: true
+      python-version:
+        description: Python version to use.
         type: string
         required: true
       deploy:

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -41,7 +41,7 @@ jobs:
     needs: config
     uses: ./.github/workflows/docs.yml
     with:
-      python-version: ${{ needs.config.outputs.python-coverage }}
       runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+      python-version: ${{ needs.config.outputs.python-coverage }}
       # Only publish from `main`; tag builds and manual dispatches from elsewhere just build.
       deploy: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -1,0 +1,88 @@
+---
+name: Deploy documentation
+
+# Post-merge publication of the documentation to GitHub Pages.
+#
+# This is deliberately separate from `docs.yml` (which is the reusable, branch-protected *build*).
+# Deploying is a consequence of merging rather than a precondition for it, and a Pages deployment can
+# only ever run on `main`, so it could never be a useful required status check: on a pull request the
+# job would be skipped, and GitHub counts a skipped required check as a success.
+#
+# The build steps below duplicate `docs.yml`'s because a `actions/upload-pages-artifact` artifact
+# cannot be handed across workflow runs.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
+  # Don't cancel: we may otherwise end up with weird half-uploaded docs.
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.repository_owner == 'Qiskit'
+    name: build docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v7
+        name: Install Python
+        with:
+          # Keep in step with `python-coverage` in `config.yml`.
+          python-version: '3.11'
+
+      - name: Install Rust
+        run: rustup toolchain install --profile minimal --no-self-update
+
+      - name: Install dependencies
+        run: tools/install_ubuntu_docs_dependencies.sh
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Tell reno to name the upcoming release after the branch we are on
+        shell: bash
+        run: |
+          sed -i.bak -e '/unreleased_version_title:*/d' releasenotes/config.yaml
+          echo unreleased_version_title: \"Upcoming release \(\`\`${GITHUB_REF_NAME}\`\`\)\" >> releasenotes/config.yaml
+
+      - name: Install Package
+        shell: bash
+        run: |
+          pip install --group build --group docs qiskit
+          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e ".[all]"
+
+      - name: Build docs
+        shell: bash
+        run: |
+          make docs
+
+      - name: Upload docs artifact for GitHub Pages
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs/_build/html
+
+  deploy:
+    name: deploy docs
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -3,13 +3,13 @@ name: Deploy documentation
 
 # Post-merge publication of the documentation to GitHub Pages.
 #
-# This is deliberately separate from `docs.yml` (which is the reusable, branch-protected *build*).
-# Deploying is a consequence of merging rather than a precondition for it, and a Pages deployment can
-# only ever run on `main`, so it could never be a useful required status check: on a pull request the
-# job would be skipped, and GitHub counts a skipped required check as a success.
+# This is a thin caller: the build and the deployment both live in `docs.yml`, which is the single
+# source of truth and is also what `branch-protection.yml` uses to check that the documentation still
+# builds on a pull request.  The only difference here is the `deploy: true` input.
 #
-# The build steps below duplicate `docs.yml`'s because a `actions/upload-pages-artifact` artifact
-# cannot be handed across workflow runs.
+# Deploying is deliberately not part of branch protection.  It is a consequence of merging rather than
+# a precondition for it, and it can only ever run on `main`, so as a required status check it would
+# always be skipped on a pull request -- which GitHub counts as a success.
 
 on:
   workflow_dispatch:
@@ -24,65 +24,24 @@ concurrency:
   # Don't cancel: we may otherwise end up with weird half-uploaded docs.
   cancel-in-progress: false
 
+# The called workflow's `deploy` job needs these, and permissions can only be maintained or reduced
+# down a workflow chain, never elevated, so they have to be granted here too.
+permissions:
+  pages: write
+  id-token: write
+
 jobs:
-  build:
+  config:
+    name: Configure
     if: github.repository_owner == 'Qiskit'
-    name: build docs
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
+    uses: ./.github/workflows/config.yml
 
-      - uses: actions/setup-python@v7
-        name: Install Python
-        with:
-          # Keep in step with `python-coverage` in `config.yml`.
-          python-version: '3.11'
-
-      - name: Install Rust
-        run: rustup toolchain install --profile minimal --no-self-update
-
-      - name: Install dependencies
-        run: tools/install_ubuntu_docs_dependencies.sh
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Tell reno to name the upcoming release after the branch we are on
-        shell: bash
-        run: |
-          sed -i.bak -e '/unreleased_version_title:*/d' releasenotes/config.yaml
-          echo unreleased_version_title: \"Upcoming release \(\`\`${GITHUB_REF_NAME}\`\`\)\" >> releasenotes/config.yaml
-
-      - name: Install Package
-        shell: bash
-        run: |
-          pip install --group build --group docs qiskit
-          SETUPTOOLS_RUST_CARGO_PROFILE=release pip install -e ".[all]"
-
-      - name: Build docs
-        shell: bash
-        run: |
-          make docs
-
-      - name: Upload docs artifact for GitHub Pages
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: docs/_build/html
-
-  deploy:
-    name: deploy docs
-    if: ${{ github.ref == 'refs/heads/main' }}
-    needs: build
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+  docs:
+    name: Docs
+    needs: config
+    uses: ./.github/workflows/docs.yml
+    with:
+      python-version: ${{ needs.config.outputs.python-coverage }}
+      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+      # Only publish from `main`; tag builds and manual dispatches from elsewhere just build.
+      deploy: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,12 +7,12 @@ name: Lint
 on:
   workflow_call:
     inputs:
-      python-version:
-        description: Python version to use.
-        type: string
-        required: true
       runner:
         description: Runner image to use.  Expects an Ubuntu image (we install `clang-format` via apt).
+        type: string
+        required: true
+      python-version:
+        description: Python version to use.
         type: string
         required: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,25 +1,25 @@
+---
 name: Lint
 
-on:
-  push:
-    branches:
-      - main
-      - 'stable/**'
-  pull_request:
-    branches:
-      - main
-      - 'stable/**'
+# This is a reusable workflow, driven by `branch-protection.yml`.  It deliberately has no `push` or
+# `pull_request` triggers of its own, and no `concurrency` block: the calling workflow owns both.
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
-  # Only cancel in PR mode, otherwise we may have weird half-uploaded docs...
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version to use.
+        type: string
+        required: true
+      runner:
+        description: Runner image to use.  Expects an Ubuntu image (we install `clang-format` via apt).
+        type: string
+        required: true
 
 jobs:
   lint:
-    if: github.repository_owner == 'Qiskit'
-    name: lint check
-    runs-on: ubuntu-latest
+    name: Lint
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -29,16 +29,12 @@ jobs:
       - uses: actions/setup-python@v7
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: ${{ inputs.python-version }}
 
+      # No explicit toolchain: `rust-toolchain.toml` pins the version (our declared MSRV) and lists
+      # the `rustfmt` and `clippy` components that `make lint` needs.
       - name: Install Rust
-        run:
-          rustup toolchain install stable
-            --override
-            --profile minimal
-            --component rustfmt
-            --component clippy
-            --no-self-update
+        run: rustup toolchain install --profile minimal --no-self-update
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -1,0 +1,77 @@
+---
+
+# Nightly runs of the full test matrices.
+#
+# The test workflows themselves are `workflow_call`-only (they're driven by `branch-protection.yml` for
+# pull requests and the merge queue), and a `workflow_call`-only workflow cannot carry a `schedule`
+# trigger, so the schedule has to live in a caller like this one.
+#
+# This is also the main post-merge safety net: `branch-protection.yml` only runs on pull requests and
+# the merge queue, so nothing else runs the full suites against `main`.  If this workflow starts
+# failing, that needs to be noticed.
+
+name: Nightly tests
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  # The owner guard lives here alone: every other job `needs: config`, so skipping this one skips the
+  # whole graph and forks don't burn their Actions minutes on our schedule.
+  config:
+    name: Configure
+    if: github.repository_owner == 'Qiskit'
+    uses: ./.github/workflows/config.yml
+
+  test-latest:
+    name: Tests / Latest / ${{ matrix.config.id }}
+    needs: config
+    uses: ./.github/workflows/test_latest_versions.yml
+    with:
+      runner: ${{ matrix.config.runner }}
+      python-version: ${{ matrix.config.python }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - id: Linux / oldest
+            runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python: ${{ needs.config.outputs.python-old }}
+          - id: Linux / newest
+            runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python: ${{ needs.config.outputs.python-new }}
+          - id: macOS / newest
+            runner: ${{ needs.config.outputs.runner-macos-arm64 }}
+            python: ${{ needs.config.outputs.python-new }}
+          - id: Windows / newest
+            runner: ${{ needs.config.outputs.runner-windows-x86_64 }}
+            python: ${{ needs.config.outputs.python-new }}
+
+  test-minimum:
+    name: Tests / Minimum
+    needs: config
+    uses: ./.github/workflows/test_minimum_versions.yml
+    with:
+      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+      python-version: ${{ needs.config.outputs.python-old }}
+      qiskit-version: ${{ needs.config.outputs.qiskit-minimum }}
+
+  test-development:
+    name: Tests / Development
+    needs: config
+    uses: ./.github/workflows/test_development_versions.yml
+    with:
+      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+      python-version: ${{ matrix.python-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - ${{ needs.config.outputs.python-old }}
+          - ${{ needs.config.outputs.python-new }}

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -30,48 +30,54 @@ jobs:
     uses: ./.github/workflows/config.yml
 
   test-latest:
-    name: Tests / Latest / ${{ matrix.config.id }}
+    name: Tests / Latest
     needs: config
     uses: ./.github/workflows/test_latest_versions.yml
     with:
       runner: ${{ matrix.config.runner }}
-      python-version: ${{ matrix.config.python }}
+      python-version: ${{ matrix.config.python-version }}
     strategy:
       fail-fast: false
       matrix:
         config:
-          - id: Linux / oldest
-            runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
-            python: ${{ needs.config.outputs.python-old }}
-          - id: Linux / newest
-            runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
-            python: ${{ needs.config.outputs.python-new }}
-          - id: macOS / newest
-            runner: ${{ needs.config.outputs.runner-macos-arm64 }}
-            python: ${{ needs.config.outputs.python-new }}
-          - id: Windows / newest
-            runner: ${{ needs.config.outputs.runner-windows-x86_64 }}
-            python: ${{ needs.config.outputs.python-new }}
+          - runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-old }}
+          - runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-new }}
+          - runner: ${{ needs.config.outputs.runner-macos-arm64 }}
+            python-version: ${{ needs.config.outputs.python-new }}
+          - runner: ${{ needs.config.outputs.runner-windows-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-new }}
 
   test-minimum:
     name: Tests / Minimum
     needs: config
     uses: ./.github/workflows/test_minimum_versions.yml
     with:
-      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
-      python-version: ${{ needs.config.outputs.python-old }}
+      runner: ${{ matrix.config.runner }}
+      python-version: ${{ matrix.config.python-version }}
       qiskit-version: ${{ needs.config.outputs.qiskit-minimum }}
+    strategy:
+      fail-fast: false
+      # A single-entry matrix, for consistency with the other test jobs: GitHub appends the matrix
+      # values to the job name, which is what makes the legs distinguishable in the Actions summary.
+      matrix:
+        config:
+          - runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-old }}
 
   test-development:
     name: Tests / Development
     needs: config
     uses: ./.github/workflows/test_development_versions.yml
     with:
-      runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
-      python-version: ${{ matrix.python-version }}
+      runner: ${{ matrix.config.runner }}
+      python-version: ${{ matrix.config.python-version }}
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - ${{ needs.config.outputs.python-old }}
-          - ${{ needs.config.outputs.python-new }}
+        config:
+          - runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-old }}
+          - runner: ${{ needs.config.outputs.runner-linux-x86_64 }}
+            python-version: ${{ needs.config.outputs.python-new }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    # Creating a release needs write access to repository contents.  This currently also works without
+    # the block (the repository's default workflow token is read/write), but stating it explicitly
+    # keeps the job working if that default is ever tightened to read-only.
+    permissions:
+      contents: write
     steps:
       - name: Checkout tag
         uses: actions/checkout@v7
@@ -53,6 +58,10 @@ jobs:
           pattern: deploy-*
           path: deploy
           merge-multiple: true
+      # `release/v1` is a mutable branch rather than a tag, so we silently pick up upstream changes
+      # (and Dependabot will not bump it).  That is deliberate and is what upstream recommends for
+      # this action: trusted publishing has to track PyPI's OIDC flow, and a stale pin would fail at
+      # release time rather than in CI.
       - name: Publish release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -12,18 +12,20 @@ name: Development version tests
 on:
   workflow_call:
     inputs:
-      python-version:
-        description: Python version to test.
-        type: string
-        required: true
       runner:
         description: Runner image to use.
+        type: string
+        required: true
+      python-version:
+        description: Python version to test.
         type: string
         required: true
 
 jobs:
   tests:
-    name: ${{ inputs.python-version }} / ${{ inputs.runner }}
+    # The caller's job name carries the matrix values, which GitHub appends to it, so this only needs
+    # to say which suite is running.
+    name: development
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     steps:

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -1,34 +1,31 @@
+---
 name: Development version tests
 
-on:
-  push:
-    branches:
-      - main
-      - 'stable/**'
-  pull_request:
-    branches:
-      - main
-      - 'stable/**'
-  schedule:
-    - cron: '0 1 * * *'
+# This is a reusable workflow, driven by `branch-protection.yml` (for pull requests and the merge
+# queue) and by `on-nightly.yml` (for the scheduled run).  It deliberately has no triggers of its own
+# beyond `workflow_call`, and no `concurrency` block: the calling workflow owns both.
+#
+# This builds Qiskit from `main`, so it can be broken by upstream changes with no local cause.  It is
+# still part of branch protection (as it was before this was centralised); admins can bypass the
+# ruleset on the rare days when upstream is broken.
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
-  # Only cancel in PR mode.  In push mode, don't cancel so we don't see spurious test "failures",
-  # and we get coverage reports on Coveralls for every push.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version to test.
+        type: string
+        required: true
+      runner:
+        description: Runner image to use.
+        type: string
+        required: true
 
 jobs:
   tests:
-    if: github.repository_owner == 'Qiskit'
-    name: Development version tests (${{ matrix.os }}, ${{ matrix.python-version }})
-    runs-on: ${{ matrix.os }}
+    name: ${{ inputs.python-version }} / ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
-    strategy:
-      max-parallel: 4
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.10", "3.14"]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -37,10 +34,10 @@ jobs:
       - uses: actions/setup-python@v7
         name: Install Python
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ inputs.python-version }}
 
       - name: Install Rust
-        run: rustup toolchain install stable --override --profile minimal --no-self-update
+        run: rustup toolchain install --profile minimal --no-self-update
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -1,39 +1,27 @@
+---
 name: Latest version tests
 
-on:
-  push:
-    branches:
-      - main
-      - 'stable/**'
-  pull_request:
-    branches:
-      - main
-      - 'stable/**'
-  schedule:
-    - cron: '0 1 * * *'
+# This is a reusable workflow, driven by `branch-protection.yml` (for pull requests and the merge
+# queue) and by `on-nightly.yml` (for the scheduled run).  It deliberately has no triggers of its own
+# beyond `workflow_call`, and no `concurrency` block: the calling workflow owns both.
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
-  # Only cancel in PR mode.  In push mode, don't cancel so we don't see spurious test "failures",
-  # and we get coverage reports on Coveralls for every push.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version to test.
+        type: string
+        required: true
+      runner:
+        description: Runner image to use.
+        type: string
+        required: true
 
 jobs:
   tests:
-    if: github.repository_owner == 'Qiskit'
-    name: latest version tests (${{ matrix.os }}, ${{ matrix.python-version }})
-    runs-on: ${{ matrix.os }}
+    name: ${{ inputs.python-version }} / ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
-    strategy:
-      max-parallel: 4
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.10", "3.14"]
-        include:
-          - os: macos-latest
-            python-version: "3.14"
-          - os: windows-latest
-            python-version: "3.14"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -42,10 +30,10 @@ jobs:
       - uses: actions/setup-python@v7
         name: Install Python
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ inputs.python-version }}
 
       - name: Install Rust
-        run: rustup toolchain install stable --override --profile minimal --no-self-update
+        run: rustup toolchain install --profile minimal --no-self-update
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -8,18 +8,20 @@ name: Latest version tests
 on:
   workflow_call:
     inputs:
-      python-version:
-        description: Python version to test.
-        type: string
-        required: true
       runner:
         description: Runner image to use.
+        type: string
+        required: true
+      python-version:
+        description: Python version to test.
         type: string
         required: true
 
 jobs:
   tests:
-    name: ${{ inputs.python-version }} / ${{ inputs.runner }}
+    # The caller's job name carries the matrix values, which GitHub appends to it, so this only needs
+    # to say which suite is running.
+    name: latest
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     steps:

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -1,34 +1,32 @@
+---
 name: Minimum version tests
 
-on:
-  push:
-    branches:
-      - main
-      - 'stable/**'
-  pull_request:
-    branches:
-      - main
-      - 'stable/**'
-  schedule:
-    - cron: '0 1 * * *'
+# This is a reusable workflow, driven by `branch-protection.yml` (for pull requests and the merge
+# queue) and by `on-nightly.yml` (for the scheduled run).  It deliberately has no triggers of its own
+# beyond `workflow_call`, and no `concurrency` block: the calling workflow owns both.
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
-  # Only cancel in PR mode.  In push mode, don't cancel so we don't see spurious test "failures",
-  # and we get coverage reports on Coveralls for every push.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: Python version to test.
+        type: string
+        required: true
+      runner:
+        description: Runner image to use.
+        type: string
+        required: true
+      qiskit-version:
+        description: >
+          Git ref of the oldest supported Qiskit release, used to build the Qiskit C API against.
+        type: string
+        required: true
 
 jobs:
   tests:
-    if: github.repository_owner == 'Qiskit'
-    name: minimum version tests (${{ matrix.os }}, ${{ matrix.python-version }})
-    runs-on: ${{ matrix.os }}
+    name: ${{ inputs.python-version }} / ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
-    strategy:
-      max-parallel: 4
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -37,10 +35,10 @@ jobs:
       - uses: actions/setup-python@v7
         name: Install Python
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ inputs.python-version }}
 
       - name: Install Rust
-        run: rustup toolchain install stable --override --profile minimal --no-self-update
+        run: rustup toolchain install --profile minimal --no-self-update
 
       - name: Install dependencies
         run: |
@@ -50,11 +48,13 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          # Passed through the environment rather than interpolated directly into the script below.
+          QISKIT_VERSION: ${{ inputs.qiskit-version }}
         run: |
           git clone https://github.com/Qiskit/qiskit build/qiskit
           cd build/qiskit
           # checkout the minimum release tag
-          git checkout 2.5.0
+          git checkout "$QISKIT_VERSION"
           make c
 
       - name: Rust tests

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -8,12 +8,12 @@ name: Minimum version tests
 on:
   workflow_call:
     inputs:
-      python-version:
-        description: Python version to test.
-        type: string
-        required: true
       runner:
         description: Runner image to use.
+        type: string
+        required: true
+      python-version:
+        description: Python version to test.
         type: string
         required: true
       qiskit-version:
@@ -24,7 +24,9 @@ on:
 
 jobs:
   tests:
-    name: ${{ inputs.python-version }} / ${{ inputs.runner }}
+    # The caller's job name carries the matrix values, which GitHub appends to it, so this only needs
+    # to say which suite is running.
+    name: minimum
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     steps:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+[toolchain]
+# Keep in sync with Cargo.toml's `rust-version`.
+channel = "1.95"
+components = [
+  "cargo",
+  "clippy",
+  "rust-std",
+  "rustc",
+  "rustfmt",
+]


### PR DESCRIPTION
This reworks the Github actions to:

- unify the branch protection logic inside a single workflow orchestrator rather than a hard-coded list of required actions inside the repo settings (see also https://github.com/Qiskit/qiskit/pull/15794)
- introduces nightly CI runs on `main`
- generally refactors the jobs to be reusable across workflows
- aligns some inconsistencies to follow the Qiskit SDK