### PR TITLE
Use exact FCI traces for matrix exponentials

### DIFF
--- a/crates/core/src/linalg/fci.rs
+++ b/crates/core/src/linalg/fci.rs
@@ -696,6 +696,47 @@ impl CompiledSector {
         self.dim
     }
 
+    /// The exact trace of the compiled operator on this FCI sector.
+    pub fn trace(&self) -> Complex64 {
+        match &self.kind {
+            CompiledKind::Spinless { entries } => entries
+                .iter()
+                .filter_map(|&(src, dst, weight)| (src == dst).then_some(weight))
+                .sum(),
+            CompiledKind::Spinful(spinful) => {
+                let diagonal_sum = |transitions: &ScaledTransitions| {
+                    (0..transitions.scale.len())
+                        .filter_map(|k| {
+                            (transitions.src[k] == transitions.dst[k])
+                                .then_some(transitions.scale[k])
+                        })
+                        .sum::<Complex64>()
+                };
+                let mut trace = spinful.scalar * (spinful.dim_a * spinful.dim_b) as f64;
+                trace += diagonal_sum(&spinful.alpha_only) * spinful.dim_b as f64;
+                trace += diagonal_sum(&spinful.beta_only) * spinful.dim_a as f64;
+                for (term, &coeff) in spinful.mixed_coeffs.iter().enumerate() {
+                    let alpha_trace: f64 = (spinful.mixed_alpha.indptr[term]
+                        ..spinful.mixed_alpha.indptr[term + 1])
+                        .filter_map(|k| {
+                            (spinful.mixed_alpha.src[k] == spinful.mixed_alpha.dst[k])
+                                .then_some(f64::from(spinful.mixed_alpha.phase[k]))
+                        })
+                        .sum();
+                    let beta_trace: f64 = (spinful.mixed_beta.indptr[term]
+                        ..spinful.mixed_beta.indptr[term + 1])
+                        .filter_map(|k| {
+                            (spinful.mixed_beta.src[k] == spinful.mixed_beta.dst[k])
+                                .then_some(f64::from(spinful.mixed_beta.phase[k]))
+                        })
+                        .sum();
+                    trace += coeff * alpha_trace * beta_trace;
+                }
+                trace
+            }
+        }
+    }
+
     /// Applies the compiled operator to a state vector: `out = op @ vec`.
     ///
     /// `vec` must have length [`Self::dim`]. Validated bit-for-bit in the tests against an
@@ -1569,6 +1610,70 @@ mod tests {
                 "mismatch at {i}: {x} vs {y}\n  got:      {a:?}\n  expected: {b:?}"
             );
         }
+    }
+
+    fn reference_trace(
+        norb: u32,
+        n_alpha: u32,
+        n_beta: Option<u32>,
+        terms: &[(Complex64, Vec<bool>, Vec<u32>)],
+    ) -> Complex64 {
+        let table = BinomialTable::new(norb);
+        let dim = table.num_strings(norb, n_alpha)
+            * n_beta.map_or(1, |n_beta| table.num_strings(norb, n_beta));
+        let mut trace = Complex64::new(0.0, 0.0);
+        for diagonal in 0..dim {
+            let mut basis = vec![Complex64::new(0.0, 0.0); dim];
+            basis[diagonal] = Complex64::new(1.0, 0.0);
+            trace += reference_matvec(norb, n_alpha, n_beta, terms, &basis)[diagonal];
+        }
+        trace
+    }
+
+    #[test]
+    fn compiled_trace_matches_reference() {
+        let spinless_terms = vec![
+            (Complex64::new(1.2, -0.1), vec![], vec![]),
+            (Complex64::new(0.5, 0.2), vec![true, false], vec![0, 0]),
+            (Complex64::new(0.7, 0.0), vec![true, false], vec![0, 1]),
+            (
+                Complex64::new(1.3, -0.4),
+                vec![true, false, true, false],
+                vec![0, 0, 2, 2],
+            ),
+        ];
+        let spinless = SpinlessSector::new(4, 2)
+            .compile(term_views(&spinless_terms))
+            .unwrap();
+        let expected = reference_trace(4, 2, None, &spinless_terms);
+        assert!((spinless.trace() - expected).norm() < 1e-12);
+
+        let norb = 3;
+        let spinful_terms = vec![
+            (Complex64::new(0.8, 0.1), vec![], vec![]),
+            (Complex64::new(0.4, 0.0), vec![true, false], vec![0, 0]),
+            (
+                Complex64::new(-0.2, 0.3),
+                vec![true, false],
+                vec![norb, norb],
+            ),
+            (
+                Complex64::new(1.1, -0.2),
+                vec![true, false, true, false],
+                vec![0, 0, norb, norb],
+            ),
+            (
+                Complex64::new(0.6, 0.0),
+                vec![true, true, false, false],
+                vec![0, norb + 2, norb, 2],
+            ),
+        ];
+        let spinful = SpinfulSector::new(norb, 2, 1)
+            .unwrap()
+            .compile(term_views(&spinful_terms))
+            .unwrap();
+        let expected = reference_trace(norb, 2, Some(1), &spinful_terms);
+        assert!((spinful.trace() - expected).norm() < 1e-12);
     }
 
     #[test]

--- a/crates/pyext/src/linalg/fci.rs
+++ b/crates/pyext/src/linalg/fci.rs
@@ -42,6 +42,7 @@ type Matvec = Box<dyn Fn(&[Complex64]) -> Result<Vec<Complex64>, FciMatvecError>
 #[pyclass(module = "qiskit_fermions.linalg.fci", name = "FciLinearOperator")]
 pub struct FciLinearOperator {
     dim: usize,
+    trace: Complex64,
     matvec: Matvec,
     rmatvec: Matvec,
 }
@@ -52,9 +53,10 @@ impl FciLinearOperator {
     /// `dim` is the FCI sector dimension (the length of the state vectors this operator acts on) and
     /// is exposed to Python as the square :attr:`shape` `(dim, dim)`. `matvec` applies the operator;
     /// `rmatvec` applies its adjoint (`A.H @ v`), which SciPy's `expm_multiply` requires.
-    pub fn new(dim: usize, matvec: Matvec, rmatvec: Matvec) -> Self {
+    pub fn new(dim: usize, trace: Complex64, matvec: Matvec, rmatvec: Matvec) -> Self {
         Self {
             dim,
+            trace,
             matvec,
             rmatvec,
         }
@@ -91,6 +93,12 @@ impl FciLinearOperator {
     fn dtype<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let numpy = py.import("numpy")?;
         numpy.getattr("dtype")?.call1(("complex128",))
+    }
+
+    /// The exact trace of the operator on this FCI sector.
+    #[getter]
+    fn trace(&self) -> Complex64 {
+        self.trace
     }
 
     /// Applies the operator to a state vector: returns ``op @ vec``.

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -1277,10 +1277,11 @@ impl PyFermionOperator {
                     .compile_fci_spinless(&sector)
                     .map_err(crate::value_err)?,
             );
+            let trace = compiled.trace();
             let (compiled_mv, compiled_rmv) = (Arc::clone(&compiled), compiled);
             let matvec = Box::new(move |vec: &[Complex64]| compiled_mv.apply(vec));
             let rmatvec = Box::new(move |vec: &[Complex64]| compiled_rmv.apply_conj(vec));
-            Ok(FciLinearOperator::new(dim, matvec, rmatvec))
+            Ok(FciLinearOperator::new(dim, trace, matvec, rmatvec))
         } else {
             let (n_alpha, n_beta) = nelec.extract::<(u32, u32)>()?;
             let sector = SpinfulSector::new(norb, n_alpha, n_beta).map_err(crate::value_err)?;
@@ -1290,10 +1291,11 @@ impl PyFermionOperator {
                     .compile_fci_spinful(&sector)
                     .map_err(crate::value_err)?,
             );
+            let trace = compiled.trace();
             let (compiled_mv, compiled_rmv) = (Arc::clone(&compiled), compiled);
             let matvec = Box::new(move |vec: &[Complex64]| compiled_mv.apply(vec));
             let rmatvec = Box::new(move |vec: &[Complex64]| compiled_rmv.apply_conj(vec));
-            Ok(FciLinearOperator::new(dim, matvec, rmatvec))
+            Ok(FciLinearOperator::new(dim, trace, matvec, rmatvec))
         }
     }
 }

--- a/python/qiskit_fermions/_lib/linalg/fci/__init__.pyi
+++ b/python/qiskit_fermions/_lib/linalg/fci/__init__.pyi
@@ -34,6 +34,11 @@ class FciLinearOperator:
         r"""
         The dtype of the operator, always ``numpy.dtype("complex128")``.
         """
+    @property
+    def trace(self) -> builtins.complex:
+        r"""
+        The exact trace of the operator on this FCI sector.
+        """
     def matvec(self, vec: numpy.typing.NDArray[numpy.complex128]) -> numpy.typing.NDArray[numpy.complex128]:
         r"""
         Applies the operator to a state vector: returns ``op @ vec``.

--- a/python/qiskit_fermions/circuit/library/_expm_multiply.py
+++ b/python/qiskit_fermions/circuit/library/_expm_multiply.py
@@ -1,0 +1,30 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Shared matrix-exponential helpers for fermionic circuit simulation."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+import scipy.sparse.linalg
+
+
+def _expm_multiply_with_trace(
+    operator: scipy.sparse.linalg.LinearOperator, vector: np.ndarray, trace: complex
+) -> np.ndarray:
+    """Apply a matrix exponential using the exact trace of the compiled FCI operator."""
+    return cast(
+        np.ndarray,
+        scipy.sparse.linalg.expm_multiply(operator, vector, traceA=trace),
+    )

--- a/python/qiskit_fermions/circuit/library/evolution.py
+++ b/python/qiskit_fermions/circuit/library/evolution.py
@@ -14,14 +14,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-import scipy.sparse.linalg
+from typing import TYPE_CHECKING, Any, cast
 
 from qiskit_fermions.linalg import linear_operator
 from qiskit_fermions.operators import OperatorTrait
 
 from .. import FermionicGate
+from ._expm_multiply import _expm_multiply_with_trace
 
 if TYPE_CHECKING:
     import numpy as np
@@ -179,8 +178,5 @@ class Evolution(FermionicGate):
                 + f" (norb={norb}, nelec={nelec})."
             )
         linop = linear_operator(operator, norb, nelec)
-        # ``traceA`` is only a balancing hint for scipy (it factors out ``exp(traceA / n)`` to
-        # improve conditioning), not a correctness input: an inexact value costs at most some
-        # numerical conditioning. Passing 0.0 avoids scipy estimating the trace itself and mirrors
-        # ffsim's own ``_apply_unitary_`` implementations.
-        return scipy.sparse.linalg.expm_multiply(-1j * self.params[0] * linop, vec, traceA=0.0)
+        scale = -1j * self.params[0]
+        return _expm_multiply_with_trace(scale * linop, vec, scale * cast(Any, linop)._trace)

--- a/python/qiskit_fermions/circuit/library/orbital_rotation.py
+++ b/python/qiskit_fermions/circuit/library/orbital_rotation.py
@@ -15,15 +15,15 @@
 from __future__ import annotations
 
 import numbers
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 import scipy.linalg
-import scipy.sparse.linalg
 
 from qiskit_fermions.utils.optionals import HAS_FFSIM
 
 from .. import FermionicGate
+from ._expm_multiply import _expm_multiply_with_trace
 
 
 class OrbitalRotation(FermionicGate):
@@ -228,6 +228,4 @@ class OrbitalRotation(FermionicGate):
         # ``qiskit_fermions.operators``); the stubs type ``from_dict``'s result as the compiled
         # ``_lib`` type, which does not carry the patched method, so mypy still needs the ignore.
         linop = linear_operator(generator, norb, nelec)  # type: ignore[arg-type]
-        # ``traceA=0.0`` mirrors Evolution._apply_unitary_placed_: it is only a scipy conditioning
-        # hint (it factors out ``exp(traceA / n)``), not a correctness input.
-        return cast(np.ndarray, scipy.sparse.linalg.expm_multiply(linop, vec, traceA=0.0))
+        return _expm_multiply_with_trace(linop, vec, cast(Any, linop)._trace)

--- a/python/qiskit_fermions/protocols/linear_operator.py
+++ b/python/qiskit_fermions/protocols/linear_operator.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import numpy as np
 import scipy.sparse.linalg
@@ -85,7 +85,8 @@ def scipy_linear_operator_from_fci(  # noqa: D417
     This is attached to the operator classes as ``_linear_operator_`` at import time (see
     :mod:`qiskit_fermions.operators`): the native operator classes are compiled types whose
     instances cannot themselves subclass SciPy's :class:`~scipy.sparse.linalg.LinearOperator`, so
-    the protocol method is provided in Python.
+    the protocol method is provided in Python. The wrapper carries the native kernel's exact
+    fixed-sector trace as private metadata for internal matrix-exponential callers.
 
     Args:
         norb: the number of spatial orbitals.
@@ -109,9 +110,11 @@ def scipy_linear_operator_from_fci(  # noqa: D417
     def rmatvec(vec):
         return kernel.rmatvec(ascontiguousarray(vec, complex128).reshape(-1))
 
-    return scipy.sparse.linalg.LinearOperator(
+    operator = scipy.sparse.linalg.LinearOperator(
         shape=kernel.shape,
         matvec=matvec,
         rmatvec=rmatvec,
         dtype=kernel.dtype,
     )
+    cast(Any, operator)._trace = kernel.trace
+    return operator

--- a/releasenotes/notes/exact-fci-trace-9d950da5d3abe256.yaml
+++ b/releasenotes/notes/exact-fci-trace-9d950da5d3abe256.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Improved the numerical conditioning of state-vector simulation for
+    :class:`.Evolution` and :class:`.OrbitalRotation` gates by supplying the
+    exact fixed-sector operator trace to SciPy's matrix exponential routine.

--- a/tests/python/circuit/library/test_evolution_apply_unitary.py
+++ b/tests/python/circuit/library/test_evolution_apply_unitary.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -25,6 +26,27 @@ from qiskit_fermions.operators import FermionOperator
 from qiskit_fermions.operators.library import FCIDump
 
 ffsim = pytest.importorskip("ffsim")
+
+
+def test_evolution_supplies_scaled_exact_trace():
+    """Evolution scales the exact fixed-sector trace with its generator."""
+    norb = 3
+    nelec = 1
+    time = 0.4
+    hamil = FermionOperator.from_dict(
+        {
+            (): 1.0,
+            ((True, 0), (False, 0)): 2.0,
+        }
+    )
+    vec = np.ones(3, dtype=complex)
+
+    with patch(
+        "scipy.sparse.linalg.expm_multiply", wraps=scipy.sparse.linalg.expm_multiply
+    ) as call:
+        Evolution(norb, hamil, time=time)._apply_unitary_(vec, norb, nelec, copy=True)
+
+    assert call.call_args.kwargs["traceA"] == pytest.approx(-1j * time * 5.0)
 
 
 def test_evolution_apply_unitary_matches_ffsim_oracle():

--- a/tests/python/circuit/library/test_expm_multiply.py
+++ b/tests/python/circuit/library/test_expm_multiply.py
@@ -1,0 +1,36 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for matrix-exponential helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import scipy.sparse.linalg
+from qiskit_fermions.circuit.library._expm_multiply import _expm_multiply_with_trace
+
+
+def test_expm_multiply_uses_operator_trace():
+    """The helper supplies the FCI operator trace to SciPy."""
+    diagonal = np.array([2.0, 4.0])
+    operator = scipy.sparse.linalg.aslinearoperator(np.diag(diagonal))
+    vector = np.array([1.0, 1.0])
+
+    with patch(
+        "scipy.sparse.linalg.expm_multiply", wraps=scipy.sparse.linalg.expm_multiply
+    ) as call:
+        result = _expm_multiply_with_trace(operator, vector, complex(diagonal.sum()))
+
+    assert call.call_args.kwargs["traceA"] == diagonal.sum()
+    np.testing.assert_allclose(result, np.exp(diagonal))

--- a/tests/python/circuit/library/test_orbital_rotation_apply_unitary.py
+++ b/tests/python/circuit/library/test_orbital_rotation_apply_unitary.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import itertools
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -25,6 +26,23 @@ from qiskit_fermions.circuit.library import OrbitalRotation
 from ...utils import random_unitary
 
 ffsim = pytest.importorskip("ffsim")
+
+
+def test_orbital_rotation_supplies_exact_generator_trace(monkeypatch):
+    """The general path supplies the exact fixed-sector generator trace."""
+    import qiskit_fermions.circuit.library.orbital_rotation as orbital_rotation_module
+
+    angles = np.array([0.1, 0.2, 0.3])
+    rotation = np.diag(np.exp(1j * angles))
+    vec = np.ones(3, dtype=complex)
+    monkeypatch.setattr(orbital_rotation_module, "HAS_FFSIM", False)
+
+    with patch(
+        "scipy.sparse.linalg.expm_multiply", wraps=scipy.sparse.linalg.expm_multiply
+    ) as call:
+        OrbitalRotation(rotation)._apply_unitary_(vec, 3, 1, copy=True)
+
+    assert call.call_args.kwargs["traceA"] == pytest.approx(1j * angles.sum())
 
 
 def _orbital_rotation_oracle(

--- a/tests/python/linalg/test_fci_linear_operator.py
+++ b/tests/python/linalg/test_fci_linear_operator.py
@@ -36,6 +36,38 @@ def test_fci_linear_operator_shape_spinless():
     assert linop.shape == (10, 10)
 
 
+def test_fci_linear_operator_trace_spinless():
+    """The exact trace includes scalar and diagonal terms while excluding hopping terms."""
+    op = FermionOperator.from_dict(
+        {
+            (): 1.5,
+            ((True, 0), (False, 0)): 2.0,
+            ((True, 0), (False, 1)): 7.0,
+        }
+    )
+
+    linop = op._linear_operator_(3, 2)
+
+    assert linop._trace == pytest.approx(8.5)
+
+
+def test_fci_linear_operator_trace_spinful():
+    """The exact trace accounts for scalar, single-spin, and mixed-spin terms."""
+    op = FermionOperator.from_dict(
+        {
+            (): 1.0,
+            ((True, 0), (False, 0)): 2.0,
+            ((True, 2), (False, 2)): 3.0,
+            ((True, 0), (False, 0), (True, 2), (False, 2)): 4.0,
+            ((True, 0), (False, 1)): 7.0,
+        }
+    )
+
+    linop = op._linear_operator_(2, (1, 1))
+
+    assert linop._trace == pytest.approx(18.0)
+
+
 def test_fci_linear_operator_matvec_matches_ffsim():
     """The native spinful matvec matches ffsim's linear operator applied to the same vector."""
     hamil = FermionOperator.from_dict(


### PR DESCRIPTION
## Summary

The compiled FCI representation already contains every transition in the requested particle-number sector. This change uses that representation to calculate the exact sector trace and carries it through the SciPy linear operator wrapper.

`Evolution` and the general `OrbitalRotation` path now pass the exact trace to `expm_multiply`, including the appropriate time scaling for evolution. This removes the hard-coded zero without adding the extra work or nondeterminism of SciPy's trace estimator.

Fixes #190

## Testing

- `python -m pytest -q tests/python`
- `tox -e lint`
- `cargo test -p qiskit-fermions-core --features pyext --lib linalg::fci`
- `cargo fmt --check`
- `cargo clippy -p qiskit-fermions-core --features pyext --all-targets -- -D warnings`
- `cargo clippy -p qiskit-fermions-pyext --all-targets -- -D warnings`

## AI tool disclosure

OpenAI Codex with GPT-5 was used while preparing the implementation and tests.
