### PR TITLE
More IBM style-guide confirmance edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ available on IBM Quantum Platform.
 
 #### C
 
-Please refer to the [C installation instructions](docs/install-c.rst).
+Refer to the [C installation instructions](docs/install-c.rst).
 
 #### Python
 
-We encourage installing this package via `pip`, when possible:
+Install this package via `pip`, when possible:
 
 ```bash
 pip install 'qiskit-fermions'
@@ -56,7 +56,7 @@ For more installation information, refer to these [installation instructions](do
 
 ----------------------------------------------------------------------------------------------------
 
-### Getting started
+### Get started
 
 Several guides exist to help you get started with this package. For an overview of its breadth of
 features, visit the [1D Fermi-Hubbard guide](docs/guides/1d_fermi_hubbard.rst).
@@ -134,10 +134,10 @@ repository to cite the appropriate reference(s).
 
 ### Deprecation policy
 
-We follow [semantic versioning](https://semver.org/). We may occasionally make breaking changes in
-order to improve the user experience. When possible, we will keep old interfaces and mark them as
-deprecated, as long as they can co-exist with the new ones. Each substantial improvement, breaking
-change, or deprecation will be documented in the
+This package follows [semantic versioning](https://semver.org/). Breaking changes are made only
+occasionally, to improve the user experience. When possible, old interfaces are kept and marked as
+deprecated for as long as they can co-exist with the new ones. Each substantial improvement,
+breaking change, or deprecation is documented in the
 [release notes](https://quantum.cloud.ibm.com/docs/api/qiskit-fermions/release-notes).
 
 ----------------------------------------------------------------------------------------------------

--- a/crates/cext/src/operators/fermion_operator.rs
+++ b/crates/cext/src/operators/fermion_operator.rs
@@ -34,7 +34,7 @@ use qiskit_fermions_core::operators::{CoherenceError, OperatorMacro, OperatorTra
 ///
 /// @rst
 ///
-/// Any of the pointer arguments may be ``NULL`` if and only if their corresponding length is zero.
+/// Any of the pointer arguments can be ``NULL`` if and only if their corresponding length is zero.
 ///
 /// Example
 /// -------
@@ -701,7 +701,7 @@ pub unsafe extern "C" fn qf_ferm_op_split_out_groups(
 ///
 /// @rst
 ///
-/// Any of the pointer arguments may be ``NULL`` if and only if their corresponding length is zero.
+/// Any of the pointer arguments can be ``NULL`` if and only if their corresponding length is zero.
 ///
 /// .. caution::
 ///    This function resets the operator's ``groups`` attribute to ``NULL``.
@@ -921,7 +921,7 @@ pub unsafe extern "C" fn qf_ferm_op_adjoint(op: *const FermionOperator) -> *mut 
 /// @rst
 ///
 /// .. caution::
-///    This functions truncates coefficients greedily! If the acted upon operator may contain
+///    This functions truncates coefficients greedily! If the acted upon operator might contain
 ///    separate coefficients for duplicate terms consider calling :c:func:`qf_ferm_op_simplify`
 ///    instead!
 ///
@@ -1029,7 +1029,7 @@ pub unsafe extern "C" fn qf_ferm_op_simplify(
 ///   lexicographically descending while annihilation ones are ascending (e.g. ``+_1 +_0 -_0 -_1``)
 ///
 /// @param op A pointer to the operator.
-/// @param sandwich A pointer to a boolean value. This pointer may be ``NULL``.
+/// @param sandwich A pointer to a boolean value. This pointer can be ``NULL``.
 ///
 /// @return A pointer to the created operator.
 ///
@@ -1038,7 +1038,7 @@ pub unsafe extern "C" fn qf_ferm_op_simplify(
 /// .. note::
 ///    When a term is being reordered, the anti-commutation relations have to be taken into
 ///    account, :math:`a_i a^\dagger_j = \delta_{ij} - a^\dagger_j a^i`, implying that the
-///    number of terms may change.
+///    number of terms might change.
 ///
 /// Example
 /// -------

--- a/crates/cext/src/operators/majorana_operator.rs
+++ b/crates/cext/src/operators/majorana_operator.rs
@@ -32,7 +32,7 @@ use qiskit_fermions_core::operators::{CoherenceError, OperatorMacro, OperatorTra
 ///
 /// @rst
 ///
-/// Any of the pointer arguments may be ``NULL`` if and only if their corresponding length is zero.
+/// Any of the pointer arguments can be ``NULL`` if and only if their corresponding length is zero.
 ///
 /// Example
 /// -------
@@ -634,7 +634,7 @@ pub unsafe extern "C" fn qf_maj_op_split_out_groups(
 ///
 /// @rst
 ///
-/// Any of the pointer arguments may be ``NULL`` if and only if their corresponding length is zero.
+/// Any of the pointer arguments can be ``NULL`` if and only if their corresponding length is zero.
 ///
 /// .. caution::
 ///    This function resets the operator's ``groups`` attribute to ``NULL``.
@@ -848,7 +848,7 @@ pub unsafe extern "C" fn qf_maj_op_adjoint(op: *const MajoranaOperator) -> *mut 
 /// @rst
 ///
 /// .. caution::
-///    This functions truncates coefficients greedily! If the acted upon operator may contain
+///    This functions truncates coefficients greedily! If the acted upon operator might contain
 ///    separate coefficients for duplicate terms consider calling :c:func:`qf_maj_op_simplify`
 ///    instead!
 ///

--- a/crates/cext/src/pointers.rs
+++ b/crates/cext/src/pointers.rs
@@ -25,8 +25,8 @@ pub(crate) fn check_ptr<T>(ptr: *const T) -> Result<(), CInputError> {
 
 /// Create a slice of length `len` from a given pointer.
 ///
-/// If the length is zero, the function is infallible, though the returned slice may not be backed
-/// by the same pointer.  Otherwise, check if the pointer is non-null and aligned.
+/// If the length is zero, the function is infallible, though the returned slice might not be
+/// backed by the same pointer.  Otherwise, check if the pointer is non-null and aligned.
 ///
 /// # Safety
 ///

--- a/crates/pyext/src/operators/edge_vertex_operator.rs
+++ b/crates/pyext/src/operators/edge_vertex_operator.rs
@@ -137,12 +137,12 @@ crate::declare_operator_iters!(
 /// Fermionic modes indexed by ``left_indices`` and ``right_indices`` are considered spinless.
 ///
 /// .. note::
-///    You may access **read-only copies** of these internal arrays via their respective methods:
+///    You can access **read-only copies** of these internal arrays via their respective methods:
 ///    :meth:`.get_coeffs`, :meth:`.get_left_indices`, :meth:`.get_right_indices`, and
 ///    :meth:`.get_boundaries`.
 ///
 /// This data structure allows for very efficient construction and manipulation of operators.
-/// However, it implies that duplicate terms may be contained in an operator at any moment.
+/// However, it implies that duplicate terms might be contained in an operator at any moment.
 /// These must be resolved manually through the use of :meth:`.simplify`.
 ///
 /// Construction
@@ -222,7 +222,7 @@ crate::declare_operator_iters!(
 ///     >>> print(repr(op))
 ///     EdgeVertexOperator.from_dict({...})
 ///
-/// Finally, for large operators both of these outputs may be very long and undesirable. Then, a
+/// Finally, for large operators both of these outputs might be very long and undesirable. Then, a
 /// very simple form with minimal information can be obtained from the :py:func:`str` function:
 ///
 /// .. doctest::

--- a/crates/pyext/src/operators/fermion_operator.rs
+++ b/crates/pyext/src/operators/fermion_operator.rs
@@ -92,11 +92,11 @@ crate::declare_operator_iters!(
 /// Fermionic modes indexed by ``modes`` are considered spinless.
 ///
 /// .. note::
-///    You may access **read-only copies** of these internal arrays via their respective methods:
+///    You can access **read-only copies** of these internal arrays via their respective methods:
 ///    :meth:`.get_coeffs`, :meth:`.get_actions`, :meth:`.get_modes`, and :meth:`.get_boundaries`.
 ///
 /// This data structure allows for very efficient construction and manipulation of operators.
-/// However, it implies that duplicate terms may be contained in an operator at any moment.
+/// However, it implies that duplicate terms might be contained in an operator at any moment.
 /// These must be resolved manually through the use of :meth:`.simplify`.
 ///
 /// Construction
@@ -180,7 +180,7 @@ crate::declare_operator_iters!(
 ///     >>> print(repr(op))
 ///     FermionOperator.from_dict({...})
 ///
-/// Finally, for large operators both of these outputs may be very long and undesirable. Then, a
+/// Finally, for large operators both of these outputs might be very long and undesirable. Then, a
 /// very simple form with minimal information can be obtained from the :py:func:`str` function:
 ///
 /// .. doctest::

--- a/crates/pyext/src/operators/majorana_operator.rs
+++ b/crates/pyext/src/operators/majorana_operator.rs
@@ -93,11 +93,11 @@ crate::declare_operator_iters!(
 /// function :py:func:`.gamma`, even (odd) indices are used for :math:`\gamma` (:math:`\gamma'`).
 ///
 /// .. note::
-///    You may access **read-only copies** of these internal arrays via their respective methods:
+///    You can access **read-only copies** of these internal arrays via their respective methods:
 ///    :meth:`.get_coeffs`, :meth:`.get_modes`, and :meth:`.get_boundaries`.
 ///
 /// This data structure allows for very efficient construction and manipulation of operators.
-/// However, it implies that duplicate terms may be contained in an operator at any moment.
+/// However, it implies that duplicate terms might be contained in an operator at any moment.
 /// These must be resolved manually through the use of :meth:`.simplify`.
 ///
 /// Construction
@@ -175,7 +175,7 @@ crate::declare_operator_iters!(
 ///     >>> print(repr(op))
 ///     MajoranaOperator.from_dict({...})
 ///
-/// Finally, for large operators both of these outputs may be very long and undesirable. Then, a
+/// Finally, for large operators both of these outputs might be very long and undesirable. Then, a
 /// very simple form with minimal information can be obtained from the :py:func:`str` function:
 ///
 /// .. doctest::

--- a/crates/pyext/src/operators/transfer_vertex_operator.rs
+++ b/crates/pyext/src/operators/transfer_vertex_operator.rs
@@ -134,12 +134,12 @@ crate::declare_operator_iters!(
 /// Fermionic modes indexed by ``left_indices`` and ``right_indices`` are considered spinless.
 ///
 /// .. note::
-///    You may access **read-only copies** of these internal arrays via their respective methods:
+///    You can access **read-only copies** of these internal arrays via their respective methods:
 ///    :meth:`.get_coeffs`, :meth:`.get_left_indices`, :meth:`.get_right_indices`, and
 ///    :meth:`.get_boundaries`.
 ///
 /// This data structure allows for very efficient construction and manipulation of operators.
-/// However, it implies that duplicate terms may be contained in an operator at any moment.
+/// However, it implies that duplicate terms might be contained in an operator at any moment.
 /// These must be resolved manually through the use of :meth:`.simplify`.
 ///
 /// Construction
@@ -219,7 +219,7 @@ crate::declare_operator_iters!(
 ///     >>> print(repr(op))
 ///     TransferVertexOperator.from_dict({...})
 ///
-/// Finally, for large operators both of these outputs may be very long and undesirable. Then, a
+/// Finally, for large operators both of these outputs might be very long and undesirable. Then, a
 /// very simple form with minimal information can be obtained from the :py:func:`str` function:
 ///
 /// .. doctest::

--- a/docs/cdoc/qf-commutators.rst
+++ b/docs/cdoc/qf-commutators.rst
@@ -17,7 +17,7 @@ Commutator
     .. caution::
        The function signature here is **generic**! A real one will replace
        ``OpType`` with an actual :ref:`operator representations <qf_operators>`
-       and ``op_type`` with its matching prefix (e.g. ``ferm_op`` for
+       and ``op_type`` with its matching prefix (for example, ``ferm_op`` for
        :c:struct:`QfFermionOperator`).
 
     The commutator is defined as:
@@ -57,7 +57,7 @@ Anti-Commutator
     .. caution::
        The function signature here is **generic**! A real one will replace
        ``OpType`` with an actual :ref:`operator representations <qf_operators>`
-       and ``op_type`` with its matching prefix (e.g. ``ferm_op`` for
+       and ``op_type`` with its matching prefix (for example, ``ferm_op`` for
        :c:struct:`QfFermionOperator`).
 
     The anti-commutator is defined as:
@@ -97,7 +97,7 @@ Double-Commutator
     .. caution::
        The function signature here is **generic**! A real one will replace
        ``OpType`` with an actual :ref:`operator representations <qf_operators>`
-       and ``op_type`` with its matching prefix (e.g. ``ferm_op`` for
+       and ``op_type`` with its matching prefix (for example, ``ferm_op`` for
        :c:struct:`QfFermionOperator`).
 
     The double-commutator is defined as follows (see also Chapter 13.6, *Equation of motion

--- a/docs/cdoc/qf-commutators.rst
+++ b/docs/cdoc/qf-commutators.rst
@@ -4,8 +4,8 @@ Commutator Generators
 
 The :ref:`operator representations <qf_operators>` provide efficient functions
 for the computation of various commutators. Since these functions work with
-generic operator representations (a notion that does not exist in C) we explain
-them generically in the following three sections.
+generic operator representations (a notion that does not exist in C), they are
+explained generically in the following three sections.
 The actual functions contained in the C API for the various operator
 representations are listed at the bottom of this page.
 

--- a/docs/cdoc/qf-ferm-op.rst
+++ b/docs/cdoc/qf-ferm-op.rst
@@ -63,7 +63,7 @@ Entries in ``actions`` indicate creation (annihilation) operators by ``True`` (`
 Fermionic modes indexed by ``modes`` are considered spinless.
 
 .. note::
-   You may access **read-only copies** of these internal arrays via their respective functions:
+   You can access **read-only copies** of these internal arrays via their respective functions:
 
    - :c:func:`qf_ferm_op_get_coeffs`
    - :c:func:`qf_ferm_op_get_actions`
@@ -71,7 +71,7 @@ Fermionic modes indexed by ``modes`` are considered spinless.
    - :c:func:`qf_ferm_op_get_boundaries`
 
 This data structure allows for very efficient construction and manipulation of operators.
-However, it implies that duplicate terms may be contained in an operator at any moment.
+However, it implies that duplicate terms might be contained in an operator at any moment.
 These must be resolved manually through the use of :c:func:`qf_ferm_op_simplify`.
 
 Construction

--- a/docs/cdoc/qf-maj-op.rst
+++ b/docs/cdoc/qf-maj-op.rst
@@ -69,14 +69,14 @@ The integers in ``modes`` index the Majorana modes, :math:`j`. When using the co
 function :py:func:`.gamma`, even (odd) indices are used for :math:`\gamma` (:math:`\gamma'`).
 
 .. note::
-   You may access **read-only copies** of these internal arrays via their respective functions:
+   You can access **read-only copies** of these internal arrays via their respective functions:
 
    - :c:func:`qf_maj_op_get_coeffs`
    - :c:func:`qf_maj_op_get_modes`
    - :c:func:`qf_maj_op_get_boundaries`
 
 This data structure allows for very efficient construction and manipulation of operators.
-However, it implies that duplicate terms may be contained in an operator at any moment.
+However, it implies that duplicate terms might be contained in an operator at any moment.
 These must be resolved manually through the use of :c:func:`qf_maj_op_simplify`.
 
 Construction

--- a/docs/cdoc/qf-operators-terms.rst
+++ b/docs/cdoc/qf-operators-terms.rst
@@ -18,7 +18,7 @@ partitioning them based on their structure.
 Grouping
 --------
 
-Please refer to :ref:`grouping_explanation` for a detailed explanation of this module's
+Refer to :ref:`grouping_explanation` for a detailed explanation of this module's
 functionality.
 
 Members

--- a/docs/guides/1d_fermi_hubbard.rst
+++ b/docs/guides/1d_fermi_hubbard.rst
@@ -1022,7 +1022,7 @@ What to take away
   threw away the fact that its terms commute. Only supplying a flow-set-aware
   :class:`~qiskit.synthesis.EvolutionSynthesis` made the depth constant. Custom encodings,
   grouping and custom synthesis are complementary: all three are needed.
-- **Verify it.** An encoding that satisfies the commutation relations may still represent
+- **Verify it.** An encoding that satisfies the commutation relations might still represent
   a different Hamiltonian if a prefactor or sign is off. Checking an intertwining relation
   (or, more cheaply, the spectrum) catches this.
 

--- a/docs/guides/2d_fermi_hubbard.rst
+++ b/docs/guides/2d_fermi_hubbard.rst
@@ -6,7 +6,7 @@ Simulate 2D Fermi-Hubbard dynamics with flow sets
 .. important::
 
    The concepts in this guide are currently available only in the Python API.
-   Equivalent functionality will be made available via the C API in a future release.
+   Equivalent functionality will be made available in the C API in a future release.
 
 .. seealso::
    **Read the** :ref:`1D flow-set guide <1d_fermi_hubbard>` **first.** This guide is

--- a/docs/guides/circuit.rst
+++ b/docs/guides/circuit.rst
@@ -6,7 +6,7 @@ Work with fermionic circuits
 .. important::
 
    The concepts in this guide are currently available only in the Python API.
-   Equivalent functionality will be made available through the C API in a future
+   Equivalent functionality will be made available in the C API in a future
    release.
 
 This guide explains how to use the :class:`.FermionicCircuit` to implement

--- a/docs/guides/circuit.rst
+++ b/docs/guides/circuit.rst
@@ -64,7 +64,8 @@ modes, then adds fermionic gates from the :mod:`qiskit_fermions.circuit.library`
 to implement the time evolution.
 
 The example also demonstrates how to incorporate domain knowledge into an
-operator by using :ref:`operator term grouping <grouping_explanation>`. By assigning group indices to the Hamiltonian terms, structural information is
+operator by using :ref:`operator term grouping <grouping_explanation>`. By
+assigning group indices to the Hamiltonian terms, you preserve structural
 information that optimization passes can exploit throughout the transpilation
 stack.
 

--- a/docs/guides/ffsim.rst
+++ b/docs/guides/ffsim.rst
@@ -6,7 +6,7 @@ The ffsim simulation backend
 .. important::
 
    The concepts in this guide are currently available only in the Python API.
-   Equivalent functionality will be made available through the C API in a future
+   Equivalent functionality will be made available in the C API in a future
    release.
 
 The :ref:`getting-started guides <lucj_getting_started>` simulate fermionic circuits and
@@ -172,8 +172,8 @@ add an explicit guard before ever calling it:
    rejected: Evolution requires an operator that conserves the (norb, nelec) sector: every term must preserve the particle number of each spin species (norb=2, nelec=(1, 1)).
 
 Calling :meth:`.SupportsLinearOperator._linear_operator_` *directly* on a non-conserving operator bypasses
-this guard (it is a lower-level building block, not a validated simulation entry point) and will
-return a matrix-vector product that silently zeroes the non-conserving amplitude rather than raising.
+this guard (it is a lower-level building block, not a validated simulation entry point) and returns
+a matrix-vector product that silently zeroes the non-conserving amplitude rather than raising.
 
 The practical consequence is that non-particle-preserving simulation is not possible in fermionic
 space at all, by construction of the fixed-sector representation: not as a missing feature, but

--- a/docs/guides/grouping.rst
+++ b/docs/guides/grouping.rst
@@ -44,7 +44,7 @@ according to the *line flow sets* as shown in Figure 1c of [1]_.
    group indices accordingly.
 
 .. plot::
-   :alt: A simple directed graph on which we define our MajoranaOperator.
+   :alt: A simple directed graph on which to define a MajoranaOperator.
    :context: close-figs
    :include-source:
 
@@ -65,8 +65,8 @@ according to the *line flow sets* as shown in Figure 1c of [1]_.
     <Figure size ... with 1 Axes>
 
 This is a simple two-by-three lattice of Majorana modes connected by
-directed edges. Each edge represents a term in our operator acting on the two
-connected modes. We want to group these terms according to their edge labels
+directed edges. Each edge represents a term in the operator acting on the two
+connected modes. The goal is to group these terms according to their edge labels
 (shown on the graph): terms connected by edges with the same label are placed in
 the same group. The following code shows how that can be done:
 

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -8,7 +8,7 @@ this package.
 .. note::
    These guides might refer to specific Python modules when explaining core concepts.
    Unless otherwise stated, the C API provides matching functionality, although it is not structured
-   into modules. However, the function names will correspond naturally and should be easy to navigate.
+   into modules. However, the function names correspond naturally and should be easy to navigate.
 
 Get started
 ===========

--- a/docs/guides/lucj.rst
+++ b/docs/guides/lucj.rst
@@ -6,7 +6,7 @@ Build an LUCJ ansatz
 .. important::
 
    The concepts in this guide are currently available only in the Python API.
-   Equivalent functionality will be made available through the C API in a future
+   Equivalent functionality will be made available in the C API in a future
    release.
 
 The local unitary cluster Jastrow (`LUCJ`_) ansatz is a compact, hardware-efficient

--- a/docs/guides/lucj.rst
+++ b/docs/guides/lucj.rst
@@ -256,7 +256,7 @@ way recovers the same correlation energy at this (small) system size:
    compressed LUCJ energy: -1.14618323 Hartree
 
 .. note::
-   ``diag_coulomb_mats`` from ``optimize=True`` may carry tiny imaginary round-off; :class:`.UCJ`
+   ``diag_coulomb_mats`` from ``optimize=True`` might carry tiny imaginary round-off; :class:`.UCJ`
    takes their real part and raises only if the imaginary part is not negligible. For a better fit at
    a given ``n_reps`` (at increased classical cost) see ffsim's ``multi_stage_start`` /
    ``multi_stage_step`` options.

--- a/docs/guides/lucj.rst
+++ b/docs/guides/lucj.rst
@@ -35,7 +35,7 @@ with :math:`n_{i\sigma}` the number operator on spatial orbital :math:`i` with s
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The (L)UCJ ansatz can be initialized from the amplitudes of a coupled-cluster singles and
-doubles (CCSD) calculation. We run restricted Hartree-Fock followed by CCSD for a hydrogen
+doubles (CCSD) calculation. Run restricted Hartree-Fock followed by CCSD for a hydrogen
 molecule in the ``6-31g`` basis, using `PySCF <https://pyscf.org/>`_ for the quantum chemistry.
 
 .. invisible-code-block: python
@@ -74,7 +74,7 @@ molecule in the ``6-31g`` basis, using `PySCF <https://pyscf.org/>`_ for the qua
 2. Build the molecular Hamiltonian as a fermionic operator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We will need the Hamiltonian later to evaluate the ansatz energy. We build it directly as a
+The Hamiltonian is needed later to evaluate the ansatz energy. Build it directly as a
 :class:`.FermionOperator` from the molecular-orbital integrals: the one-body integrals ``h1e``
 (the core Hamiltonian in the MO basis), the two-body integrals ``h2e`` (from :func:`pyscf.ao2mo`),
 and the constant nuclear-repulsion energy. The electronic-integral constructors
@@ -116,7 +116,7 @@ matrices and orbital rotations, and derives an optional final orbital rotation f
 
 The number of ansatz repetitions :math:`L` equals the number of terms in the double
 factorization. Truncating it with the ``n_reps`` argument trades some accuracy for a shallower
-circuit; here we keep the two largest terms, which recovers most of the correlation energy while
+circuit; here the two largest terms are kept, which recovers most of the correlation energy while
 halving the number of layers.
 
 .. plot::
@@ -133,7 +133,7 @@ halving the number of layers.
    >>> circuit.append(InitializeModes.from_hartree_fock(norb, nelec), circuit.modes)
    >>> circuit.append(ansatz, circuit.modes)
 
-The :class:`.UCJ` gate is a pure unitary carrying no reference of its own, so we prepend an
+The :class:`.UCJ` gate is a pure unitary carrying no reference of its own, so prepend an
 :class:`.InitializeModes` gate (built with
 :meth:`~qiskit_fermions.circuit.library.InitializeModes.from_hartree_fock`) to supply the
 Hartree-Fock reference the ansatz is applied to. Decomposing the circuit reveals its anatomy: the
@@ -165,7 +165,7 @@ Because every gate in the circuit implements ffsim's :class:`ffsim.SupportsApply
 the whole :class:`.FermionicCircuit` can be applied to a fixed particle-number state vector with
 :func:`ffsim.apply_unitary`, starting from the Hartree-Fock reference. The
 :class:`.FermionOperator` likewise implements ffsim's :class:`ffsim.SupportsLinearOperator`
-protocol, so we can obtain a SciPy :class:`~scipy.sparse.linalg.LinearOperator` for it via
+protocol, so you can obtain a SciPy :class:`~scipy.sparse.linalg.LinearOperator` for it via
 :func:`ffsim.linear_operator` and evaluate the ansatz energy as the expectation value of the
 molecular Hamiltonian.
 
@@ -213,7 +213,7 @@ typically smaller, number of repetitions. This trades a classical optimization u
 shallower ansatz at a target accuracy, and has no equivalent in this package.
 
 There is no need to re-implement it: an ``ffsim`` UCJ operator exposes the same tensors that
-:class:`.UCJ` is built from, so we can construct the operator with ``optimize=True`` and hand its
+:class:`.UCJ` is built from, so you can construct the operator with ``optimize=True`` and hand its
 ``diag_coulomb_mats`` / ``orbital_rotations`` / ``final_orbital_rotation`` straight to the
 :class:`.UCJ` constructor.
 
@@ -271,7 +271,7 @@ The :func:`~qiskit_fermions.transpiler.presets.generate_preset_jw_pass_manager` 
 staged pipeline that maps the fermionic circuit through the Jordan-Wigner transformation and
 synthesizes each gate into a qubit-level circuit. The composite :class:`.UCJ` gate must first be
 decomposed into its primitive gates (:class:`.OrbitalRotation`, :class:`.Evolution`, ...) so the
-pipeline's optimization stage can act on them, so we pass ``circuit.decompose()``.
+pipeline's optimization stage can act on them, so pass ``circuit.decompose()``.
 
 .. skip: start if(not HAS_FFSIM)
 
@@ -306,8 +306,8 @@ A real device has a restricted qubit coupling map, and the LUCJ ansatz is design
 same-spin (``pairs_aa``) interactions form two linear chains and the alpha-beta (``pairs_ab``)
 interactions bridge them. ffsim's :external:func:`~ffsim.qiskit.generate_lucj_pass_manager` builds a
 device-aware qubit pipeline for this structure, and returns the subset of ``pairs_ab`` the
-hardware can actually accommodate. We can slot that pipeline into the preset's ``qubit`` stage while
-keeping our own fermion-to-qubit synthesis:
+hardware can actually accommodate. Slot that pipeline into the preset's ``qubit`` stage while
+keeping the package's own fermion-to-qubit synthesis:
 
 .. plot::
    :context:
@@ -339,7 +339,7 @@ keeping our own fermion-to-qubit synthesis:
    [(0, 0)]
 
 With ``pm.qubit`` now set to the device-aware pipeline, running the pass manager lays the circuit out
-on the backend's qubits and routes it to the coupling map. If we route the *unrestricted* ansatz from
+on the backend's qubits and routes it to the coupling map. For the *unrestricted* ansatz from
 step 3, whose diagonal Coulomb operator still contains alpha-beta terms the hardware cannot reach
 directly, the router must insert many ``SWAP`` gates to bridge them:
 
@@ -382,7 +382,7 @@ directly. The ansatz then matches the device topology and the router barely has 
 
 Drawing only the active qubits (``idle_wires=False``) shows the circuit restricted to the two spin
 chains and the alpha-beta bridge, expressed in the device basis gates. Layout and routing scatter the
-logical modes across the device's physical qubits, so we pass a ``wire_order`` taken from the
+logical modes across the device's physical qubits, so pass a ``wire_order`` taken from the
 circuit's final layout (:meth:`~qiskit.transpiler.TranspileLayout.final_index_layout` lists the
 physical qubit each input qubit ended up on, in input-qubit order) to draw the wires back in the
 original mode order:

--- a/docs/guides/mappers.rst
+++ b/docs/guides/mappers.rst
@@ -4,8 +4,8 @@ Map operator representations
 ============================
 
 **Mappers** are routines that transform operators from one representation to another
-while preserving mathematical equivalence. They enable you to work flexibly across
-different operator algebras and prepare operators for quantum circuit execution.
+while preserving mathematical equivalence. Use them to work flexibly across
+different operator algebras and to prepare operators for quantum circuit execution.
 
 Implement custom mappers
 ------------------------

--- a/docs/guides/merge_slater_determinant.rst
+++ b/docs/guides/merge_slater_determinant.rst
@@ -25,8 +25,8 @@ reduced decomposition automatically. Under simulation the rewrite is a no-op on 
 and then applies the rotation, just as the two separate gates do), so the merge only unlocks the
 cheaper synthesis without changing the prepared state.
 
-Throughout this guide we draw a circuit before and after the pass, side by side: the input on the
-left, and on the right the result of running the pass on it. Two helpers do that: ``merge``
+Throughout this guide, each circuit is drawn before and after the pass, side by side: the input
+on the left, and on the right the result of running the pass on it. Two helpers do that: ``merge``
 runs the pass on a copy of the circuit (via its :class:`.FermionicDAGCircuit`) and converts the
 result back to a drawable :class:`.FermionicCircuit`, and ``draw_merge`` draws both halves into a
 single before/after figure:
@@ -221,7 +221,7 @@ orbitals needs at most :math:`m(n-m)` two-qubit rotations and no diagonal phase 
 :math:`n(n-1)/2` rotations plus :math:`n` phases of the full square orbital rotation.
 
 The preset Jordan-Wigner pass manager runs :class:`.MergeSlaterDeterminantPreparation` in its
-optimization stage, so this reduction happens automatically. We transpile a two-electron,
+optimization stage, so this reduction happens automatically. Transpile a two-electron,
 six-orbital preparation all the way to a :class:`~qiskit.circuit.QuantumCircuit` and count its gates:
 
 .. note::

--- a/docs/guides/merge_slater_determinant.rst
+++ b/docs/guides/merge_slater_determinant.rst
@@ -12,7 +12,7 @@ An :class:`.InitializeModes` gate declares a reference mode occupation; an
 :class:`.OrbitalRotation` gate rotates the single-particle basis. Placed back to back, the two
 gates *prepare a Slater determinant*: the modes start in the reference determinant and are then
 rotated into the target orbitals. The :class:`.PrepareSlaterDeterminant` gate captures that
-composition, and because it knows the reference occupation, transpiling it can use the rectangular
+composition, and because it carries the reference occupation, transpiling it can use the rectangular
 :func:`~qiskit_fermions.linalg.givens_decomposition_slater`, which realizes only the *occupied*
 orbitals, instead of the full square decomposition an :class:`.OrbitalRotation` alone requires. That
 is a strictly cheaper synthesis (see the payoff at the end of this guide).

--- a/docs/guides/merge_slater_determinant.rst
+++ b/docs/guides/merge_slater_determinant.rst
@@ -121,7 +121,7 @@ Global initialization, per-spin rotations
 A single full-register (``2 * norb``) :class:`.InitializeModes` followed by *two*
 :class:`.OrbitalRotation`\ s, one on each contiguous spin half. The pass splits the global
 occupation at the sector boundary and emits **two** :class:`.PrepareSlaterDeterminant` gates. The
-two rotations may appear in either order.
+two rotations might appear in either order.
 
 This is the shape produced by the local unitary cluster Jastrow (LUCJ) workflow (see the
 :ref:`LUCJ guide <lucj_getting_started>`):

--- a/docs/guides/merge_slater_determinant.rst
+++ b/docs/guides/merge_slater_determinant.rst
@@ -6,7 +6,7 @@ Optimize Slater determinant preparation
 .. important::
 
    The concepts in this guide are currently available only in the Python API.
-   Equivalent functionality will be made available via the C API in a future release.
+   Equivalent functionality will be made available in the C API in a future release.
 
 An :class:`.InitializeModes` gate declares a reference mode occupation; an
 :class:`.OrbitalRotation` gate rotates the single-particle basis. Placed back to back, the two

--- a/docs/guides/operators.rst
+++ b/docs/guides/operators.rst
@@ -20,7 +20,7 @@ design principles:
 
 - |term_iteration_and_reconstruction|_:
   Irrespective of the internal sparse storage, operators provide a consistent
-  iteration interface that lets you inspect, filter, and transform terms without
+  iteration interface, so you can inspect, filter, and transform terms without
   understanding the underlying data structure, then reconstruct new operators
   from modified terms.
 
@@ -181,7 +181,7 @@ Term iteration and reconstruction
 ---------------------------------
 
 Operators provide a consistent iteration interface by using :meth:`.OperatorTrait.iter_terms`
-irrespective of their internal sparse representation. This allows you to inspect, filter,
+irrespective of their internal sparse representation. You can therefore inspect, filter,
 or transform terms without needing to understand the underlying data structure.
 You can then reconstruct a new operator from the transformed terms by using
 :meth:`.OperatorTrait.from_terms`.

--- a/docs/guides/operators.rst
+++ b/docs/guides/operators.rst
@@ -1,7 +1,7 @@
 .. _operators_explanation:
 
-Design Principles of Operator Representations
-==============================================
+Design principles of operator representations
+=============================================
 
 This guide explains the common design principles and core concepts shared across
 all operator representations in the :mod:`~qiskit_fermions.operators` module.

--- a/docs/guides/skqd.rst
+++ b/docs/guides/skqd.rst
@@ -6,7 +6,7 @@ Generate Krylov time-evolution circuits (SKQD)
 .. important::
 
    The concepts in this guide are currently available only in the Python API.
-   Equivalent functionality will be made available through the C API in a future
+   Equivalent functionality will be made available in the C API in a future
    release.
 
 Sample-based Krylov Quantum Diagonalization (`SKQD`_) is a quantum-centric variant of subspace

--- a/docs/guides/skqd.rst
+++ b/docs/guides/skqd.rst
@@ -178,7 +178,7 @@ orbitals into ``2 * norb`` fermionic modes.
 
 We keep the one-body part :math:`H_1` and the two-body part :math:`H_2` as separate operators
 rather than summing them eagerly, matching the terms :math:`H_1` and :math:`H_2` of the section-1 equations.
-Building each piece once (in both bases) lets us reuse them below: summed, they give the full
+Building each piece once (in both bases) makes them reusable below: summed, they give the full
 Hamiltonian for the exact diagonalization in either basis; individually, :math:`H_2` (momentum basis)
 is the operator the Trotter step evolves in step 4.
 

--- a/docs/guides/skqd.rst
+++ b/docs/guides/skqd.rst
@@ -31,7 +31,7 @@ following the `SKQD`_ publication.
 .. note::
    The SKQD sampling step works only if the ground state is **sparse** in the computational basis:
    the classical diagonalization must be able to reconstruct it from a manageable number of sampled
-   bitstrings. As we will see, that sparsity is not automatic; it is a property of the
+   bitstrings. As shown below, that sparsity is not automatic; it is a property of the
    single-particle basis in which the problem is expressed. Getting the basis right is the crux of
    this construction.
 
@@ -69,10 +69,10 @@ and the two-body part carrying the on-site Coulomb repulsion :math:`U` on the im
 
    H_2 = U \, a^\dagger_{0\uparrow} a_{0\uparrow} a^\dagger_{0\downarrow} a_{0\downarrow}.
 
-We work at the particle-hole-symmetric point :math:`\mu = -U/2`. These two parts map directly onto
-the one-body integrals ``h1e`` (bath hopping, impurity hybridization, impurity on-site energy) and
-the single two-body integral ``h2e`` (the impurity Coulomb term). We first assemble them in the
-position basis, where the model is naturally defined.
+This guide works at the particle-hole-symmetric point :math:`\mu = -U/2`. These two parts map
+directly onto the one-body integrals ``h1e`` (bath hopping, impurity hybridization, impurity on-site
+energy) and the single two-body integral ``h2e`` (the impurity Coulomb term). First assemble them in
+the position basis, where the model is naturally defined.
 
 .. plot::
    :context:
@@ -128,7 +128,7 @@ while leaving the impurity orbital untouched, then relocates the impurity to a c
    ...
    >>> orbital_rotation = momentum_basis(norb)
 
-Unlike a variational workflow, we rotate the Hamiltonian integrals into the momentum basis,
+Unlike a variational workflow, this rotates the Hamiltonian integrals into the momentum basis,
 so that the whole circuit (Hamiltonian and state alike) lives in the basis where the ground
 state is sparse and the sampled bitstrings are therefore informative. Rotating the one- and two-body
 integrals is a standard basis change of the electronic-structure tensors:
@@ -152,7 +152,7 @@ integrals is a standard basis change of the electronic-structure tensors:
 
 Because the rotation leaves the impurity orbital fixed (it acts only on the bath), the on-site
 interaction is unchanged: ``h2e_momentum`` remains a single number-number term, just like ``h2e``;
-the only change is that the impurity has been relocated to a central index. We can see this directly
+the only change is that the impurity has been relocated to a central index. This is visible directly
 in the integral tensors, which each carry one nonzero entry:
 
 .. plot::
@@ -167,16 +167,16 @@ in the integral tensors, which each carry one nonzero entry:
 
 This locality is what keeps the interaction cheap to synthesize later.
 
-We assemble the one-body integrals into a :class:`.FermionOperator` with the electronic-integral
+Assemble the one-body integrals into a :class:`.FermionOperator` with the electronic-integral
 constructor :meth:`~qiskit_fermions.operators.FermionOperator.from_1body_tril_spin_sym`, which expects
 them packed into lower-triangular ordering. The two-body part is a single number-number term, so
-rather than route it through the two-body integral machinery we build it directly with
+rather than routing it through the two-body integral machinery, build it directly with
 :func:`.cre`/:func:`.ann`: the on-site Coulomb operator :math:`U \, n_{p\uparrow} n_{p\downarrow}`
 for the impurity mode :math:`p` (its :math:`\uparrow` mode at index ``p``, its :math:`\downarrow` mode
 at index ``p + norb`` in the block-spin layout). Both constructors spin-double the ``norb`` spatial
 orbitals into ``2 * norb`` fermionic modes.
 
-We keep the one-body part :math:`H_1` and the two-body part :math:`H_2` as separate operators
+Keep the one-body part :math:`H_1` and the two-body part :math:`H_2` as separate operators
 rather than summing them eagerly, matching the terms :math:`H_1` and :math:`H_2` of the section-1 equations.
 Building each piece once (in both bases) makes them reusable below: summed, they give the full
 Hamiltonian for the exact diagonalization in either basis; individually, :math:`H_2` (momentum basis)
@@ -214,11 +214,11 @@ is the operator the Trotter step evolves in step 4.
    ...     (one_body_momentum + two_body_momentum).normal_ordered().simplify(atol=1e-14)
    ... )
 
-The basis change is a unitary similarity transform, so it leaves the spectrum untouched: we can
-confirm the operator is correct by comparing its lowest eigenvalue in the
+The basis change is a unitary similarity transform, so it leaves the spectrum untouched. Confirm the
+operator is correct by comparing its lowest eigenvalue in the
 :math:`(\text{norb}, \text{nelec})` sector against an exact diagonalization. The
 :class:`.FermionOperator` exposes a SciPy :class:`~scipy.sparse.linalg.LinearOperator` (backed by a
-native full configuration interaction (FCI) matrix-vector kernel), so we can hand it straight to
+native full configuration interaction (FCI) matrix-vector kernel), so it can be handed straight to
 :func:`scipy.sparse.linalg.eigsh`.
 
 .. plot::
@@ -236,7 +236,7 @@ native full configuration interaction (FCI) matrix-vector kernel), so we can han
    >>> print(f"exact ground-state energy: {reference_energy:.6f}")
    exact ground-state energy: -13.422492
 
-The payoff of the basis change is sparsity. To make it concrete, we count how many
+The payoff of the basis change is sparsity. To make it concrete, count how many
 computational-basis determinants are needed to capture 99% of the ground-state weight, and compare
 the momentum basis against the position basis. The energy is basis-independent, but the number of
 determinants is not:
@@ -274,13 +274,12 @@ builds it with a hand-written network of :external:class:`~qiskit.circuit.librar
 It looks strongly correlated (it
 has hundreds of nonzero computational-basis amplitudes), but a network of number-conserving two-mode
 rotations is a single-particle (fermionic Gaussian) operation, so the state it produces is a
-single Slater determinant. That means we can prepare it with one :class:`.PrepareSlaterDeterminant`
+single Slater determinant. That means you can prepare it with one :class:`.PrepareSlaterDeterminant`
 gate, given the single-particle rotation the network implements.
 
 Because each :external:class:`~qiskit.circuit.library.XXPlusYYGate` acts as a Givens rotation on a
-pair of modes, we can build that
-rotation directly in the single-particle picture (one Givens matrix per gate) instead of emitting
-the two-qubit gates by hand. The gates form a brickwork of nearest-neighbor rotations that fans out
+pair of modes, that rotation can be built directly in the single-particle picture (one Givens
+matrix per gate) instead of emitting the two-qubit gates by hand. The gates form a brickwork of nearest-neighbor rotations that fans out
 from the Fermi level in expanding layers, spreading each near-Fermi electron across the empty modes
 just above it:
 
@@ -336,14 +335,13 @@ same gate is applied once on the alpha modes ``0..norb`` and once on the beta mo
    >>> reference_preparation = PrepareSlaterDeterminant(occupation, reference_rotation)
 
 This declarative gate replaces the hand-coded :external:class:`~qiskit.circuit.library.XXPlusYYGate`
-network; the transpiler generates the
-Givens-rotation synthesis for us.
+network; the transpiler generates the Givens-rotation synthesis.
 
 4. Assemble the Krylov circuits
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each Krylov circuit is the reference-state preparation followed by evolution under
-:math:`e^{-i k \, \Delta t \, H}`. We split the Hamiltonian into its one-body and two-body parts,
+:math:`e^{-i k \, \Delta t \, H}`. Split the Hamiltonian into its one-body and two-body parts,
 :math:`H = H_1 + H_2`, and Trotterize the evolution over that split. This is the decisive choice for
 circuit depth. The one-body evolution :math:`e^{-i t H_1}` is a free-fermion (fermionic Gaussian)
 operation, so it is a single-particle basis rotation (an :class:`.OrbitalRotation` with
@@ -355,10 +353,10 @@ Givens rotations plus a single two-qubit interaction gate, the shallow structure
 
 The two-body part is already in hand: it is the ``two_body_momentum`` operator built in step 2 (the
 single on-site term). The one-body evolution :math:`e^{-i t H_1}` is spin-independent, so it is a
-single per-sector :class:`.OrbitalRotation` with unitary :math:`e^{-i t \, \mathbf{h}_1}` that we
-apply once to each spin sector, the same parallel structure as the reference-state preparation.
+single per-sector :class:`.OrbitalRotation` with unitary :math:`e^{-i t \, \mathbf{h}_1}` applied
+once to each spin sector, the same parallel structure as the reference-state preparation.
 
-Each Krylov circuit evolves for a total time :math:`k \, \Delta t`. We realize that with a
+Each Krylov circuit evolves for a total time :math:`k \, \Delta t`. That is realized with a
 second-order Trotter product of :math:`k` steps of size :math:`\Delta t`, so the per-step error
 stays fixed as the Krylov dimension grows. Each step sandwiches a full one-body rotation (one per
 spin sector) between two half-steps of the (cheap, single-term) two-body evolution. The Krylov
@@ -395,7 +393,7 @@ state only) up to :math:`D - 1`.
    ...     return circuit
 
 .. note::
-   The fermionic circuit carries no measurements: measurement is a qubit-level concept, so we add it
+   The fermionic circuit carries no measurements: measurement is a qubit-level concept, so add it
    after transpilation, once the fermionic gates have been synthesized onto qubits. Convenience
    ``measure`` instructions on :class:`.FermionicCircuit` might be introduced in the
    `future <https://github.com/Qiskit/qiskit-fermions/issues/219>`_.
@@ -403,16 +401,16 @@ state only) up to :math:`D - 1`.
 5. Transpile to qubit circuits
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Transpiling a :class:`.FermionicCircuit` maps its fermionic gates to qubit gates. We use the
+Transpiling a :class:`.FermionicCircuit` maps its fermionic gates to qubit gates. This uses the
 Jordan-Wigner :func:`.jordan_wigner` mapping. The :class:`.OrbitalRotation` gates synthesize into a
 brickwork of Givens rotations, and the single-term :class:`.Evolution` lowers to a single two-qubit
 interaction gate.
 
-Because every fermionic gate here has a default synthesis, we can use the ready-made
+Because every fermionic gate here has a default synthesis, you can use the ready-made
 :func:`.generate_preset_jw_pass_manager` directly rather than hand-assembling the stages. Any
-keyword arguments are forwarded to the qubit stage; we pass ``optimization_level=0`` for a faithful,
+keyword arguments are forwarded to the qubit stage; pass ``optimization_level=0`` for a faithful,
 unoptimized picture of the synthesized depth. Generating the full family of Krylov circuits is then
-a loop over the Krylov dimension. We keep the untranspiled :class:`.FermionicCircuit`\ s alongside
+a loop over the Krylov dimension. Keep the untranspiled :class:`.FermionicCircuit`\ s alongside
 the transpiled qubit circuits: the fermionic ones drive the exact (statevector) simulation in step
 6, while the transpiled ones (with measurements added) are what a backend would execute.
 
@@ -483,8 +481,8 @@ steps (four in this case):
 6. Sample bitstrings from the Krylov circuits
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On hardware, we would run the transpiled circuits and measure. Here we do the noiseless (statevector)
-version of that step to see the bitstrings SKQD would collect. We simulate each untranspiled
+On hardware, you would run the transpiled circuits and measure. This is the noiseless (statevector)
+version of that step, showing the bitstrings SKQD would collect. Simulate each untranspiled
 :class:`.FermionicCircuit` with :func:`ffsim.apply_unitary` and sample the resulting statevector with
 :func:`ffsim.sample_state_vector`.
 
@@ -538,20 +536,20 @@ handful of configurations dominate, led by the reference determinant.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The sampled bitstrings are the input to the classical half of SKQD: the Hamiltonian is projected onto
-the subspace the sampled configurations span and diagonalized there. We hand this off to the
+the subspace the sampled configurations span and diagonalized there. This is handed off to the
 `qiskit-addon-sqd <https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd>`_ package, whose
 :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` runs the full sample-based
 quantum diagonalization loop: it builds a subspace from batches of the sampled configurations,
 diagonalizes the Hamiltonian in it, and iteratively refines the subspace via configuration
 recovery: flipping occupations to repair configurations that violate the known particle-number
 symmetry. Configuration recovery is designed to undo the damage of hardware noise, which corrupts
-sampled bitstrings into the wrong particle-number sector; we sample noiselessly here, so there is
-nothing to repair on that front.
+sampled bitstrings into the wrong particle-number sector; the sampling here is noiseless, so
+there is nothing to repair on that front.
 
 .. skip: start if(not (HAS_FFSIM and HAS_QISKIT_ADDON_SQD))
 
-The solver consumes the sampled counts as a :external:class:`~qiskit.primitives.BitArray`, which we
-build directly from the pooled ``counts`` of step 6. It diagonalizes in the same momentum basis the
+The solver consumes the sampled counts as a :external:class:`~qiskit.primitives.BitArray`, built
+directly from the pooled ``counts`` of step 6. It diagonalizes in the same momentum basis the
 rest of the construction uses, so it takes the ``h1e_momentum`` and ``h2e_momentum`` integrals from
 step 2 directly, with no repacking. The recovered energy matches the exact reference to well under a
 milli-Hartree, from only a few hundred sampled configurations; because the SQD energy is a variational
@@ -586,7 +584,7 @@ from step 2):
    >>> print(f"SQD estimate: {result.energy:.4f} (exact: {reference_energy:.4f})")
    SQD estimate: -13.4224 (exact: -13.4225)
 
-We visualize the run: the energy's convergence across the iterations, and the average
+Visualize the run: the energy's convergence across the iterations, and the average
 occupancy of each spatial orbital in the recovered ground state. The per-iteration energy is the
 lowest across that iteration's batches, and the occupancy sums the ``orbital_occupancies`` over the
 two spin sectors. Even without noise to correct, the energy still decreases from iteration to

--- a/docs/guides/skqd.rst
+++ b/docs/guides/skqd.rst
@@ -397,7 +397,7 @@ state only) up to :math:`D - 1`.
 .. note::
    The fermionic circuit carries no measurements: measurement is a qubit-level concept, so we add it
    after transpilation, once the fermionic gates have been synthesized onto qubits. Convenience
-   ``measure`` instructions on :class:`.FermionicCircuit` may be introduced in the
+   ``measure`` instructions on :class:`.FermionicCircuit` might be introduced in the
    `future <https://github.com/Qiskit/qiskit-fermions/issues/219>`_.
 
 5. Transpile to qubit circuits

--- a/docs/guides/sqdrift.rst
+++ b/docs/guides/sqdrift.rst
@@ -82,8 +82,8 @@ detail in :ref:`this guide <grouping_explanation>`.
 .. hint::
 
    The full electronic structure Hamiltonian contains certain terms whose
-   inclusion in a time-evolution circuit will have no impact on the perceived
-   bitstrings and, thus, only result in an increased sampling overhead.
+   inclusion in a time-evolution circuit has no impact on the perceived
+   bitstrings and, thus, only results in an increased sampling overhead.
    Therefore, it is recommended that such terms be filtered from the
    Hamiltonian at this point, before constructing the :class:`.Evolution` gate
    in the next step.
@@ -166,7 +166,7 @@ Crucially, add the :class:`.QDriftTrotterization` transpilation pass to the
 circuit does not use the time evolution of the entire Hamiltonian, whose depth
 would exceed the capabilities of currently available quantum computing hardware.
 
-Instead, it will subsample a fixed number of ``groups`` of Hamiltonian terms for
+Instead, it subsamples a fixed number of ``groups`` of Hamiltonian terms for
 each circuit, every time the circuit is transpiled. Through this, you can generate
 multiple circuit randomizations as required by the `SqDRIFT`_ algorithm by
 repeatedly running the transpilation pipeline.

--- a/docs/guides/sqdrift.rst
+++ b/docs/guides/sqdrift.rst
@@ -89,7 +89,7 @@ detail in :ref:`this guide <grouping_explanation>`.
    in the next step.
 
    The terms that fit this description are those that are diagonal
-   in the occupation-number basis, i.e. the products of number operators
+   in the occupation-number basis, that is, the products of number operators
    (:math:`a^\dagger_i a_i`). This includes the constant energy offset, whose
    time evolution only introduces a global phase into the circuit, the
    individual number-operators whose time evolution amounts to single-qubit Z
@@ -274,7 +274,7 @@ None of the excitations sampled without filtering touch the occupied set
 occupied and an unoccupied mode; every single one is trivial and would have
 no effect on the sampled bitstrings. With ``filter_trivial=True``, all five are
 rejected and replaced by excitations that do couple an occupied mode with an
-unoccupied one, e.g. the first accepted excitation ``[0, 1, 6, 7]`` moves a
+unoccupied one. For example, the first accepted excitation ``[0, 1, 6, 7]`` moves a
 particle between occupied modes ``0``, ``1``, and ``6`` and unoccupied mode
 ``7``.
 

--- a/docs/guides/sqdrift.rst
+++ b/docs/guides/sqdrift.rst
@@ -17,8 +17,8 @@ circuits.
 1. Hamiltonian setup
 ^^^^^^^^^^^^^^^^^^^^
 
-For the purposes of this guide, we load the electronic structure Hamiltonian
-of N2 from an FCIDUMP file. Of course, there are other means of
+For the purposes of this guide, load the electronic structure Hamiltonian
+of N2 from an FCIDUMP file. There are other means of
 constructing the :class:`.FermionOperator`. Be sure to consult its
 documentation, as well as the :mod:`qiskit_fermions.operators.library`.
 
@@ -44,7 +44,7 @@ documentation, as well as the :mod:`qiskit_fermions.operators.library`.
 2. Group Hamiltonian terms
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We exploit the many symmetries that are present in the electronic
+Exploit the many symmetries that are present in the electronic
 structure Hamiltonian by grouping related terms that have identical coefficients.
 This action changes the operator coefficient distribution that the qDRIFT
 protocol samples from, but it does not affect its convergence guarantees.
@@ -119,7 +119,7 @@ detail in :ref:`this guide <grouping_explanation>`.
 3. Prepare the time evolution circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We prepare the Hamiltonian's time evolution circuit and the
+Prepare the Hamiltonian's time evolution circuit and the
 base circuit from which to draw samples. The
 :mod:`qiskit_fermions.circuit.library` contains all the required
 components to do so, in compliance with Qiskit conventions.
@@ -143,8 +143,8 @@ components to do so, in compliance with Qiskit conventions.
        // with custom gate definitions.
 
 .. note::
-   In this example, we neither initialize the fermionic modes with particles,
-   nor measure their final state.
+   This example neither initializes the fermionic modes with particles,
+   nor measures their final state.
 
 4. Transpile the circuit with QDrift Trotterization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -153,21 +153,21 @@ The :mod:`qiskit_fermions.transpiler` module integrates directly with Qiskit's
 transpilation pipeline, allowing the :class:`.FermionicCircuit` constructed above
 to be directly transpiled to a :external:class:`~qiskit.circuit.QuantumCircuit`.
 
-We use the :func:`.jordan_wigner` fermion-to-qubit mapping to
+Use the :func:`.jordan_wigner` fermion-to-qubit mapping to
 convert the Hamiltonian expressed in terms of fermions to be expressed in Pauli strings instead. This
 can be done directly as part of the transpilation process by using the
-:class:`.EvolutionSynthesis` transpilation pass plugin. We use
+:class:`.EvolutionSynthesis` transpilation pass plugin. Use
 :func:`.generate_preset_jw_pass_manager` to build
 :class:`.FermionicStagedPassManager`, which ensures that the
 Jordan-Wigner encoding is used consistently for all circuit instructions.
 
-Crucially, we add the :class:`.QDriftTrotterization` transpilation pass to the
-``optimization`` stage of the transpilation pipeline. This ensures that we do
-not use the time evolution of the entire Hamiltonian, a circuit whose depth
+Crucially, add the :class:`.QDriftTrotterization` transpilation pass to the
+``optimization`` stage of the transpilation pipeline. This ensures that the
+circuit does not use the time evolution of the entire Hamiltonian, whose depth
 would exceed the capabilities of currently available quantum computing hardware.
 
 Instead, it will subsample a fixed number of ``groups`` of Hamiltonian terms for
-each circuit, every time we transpile the circuit. Through this, we can generate
+each circuit, every time the circuit is transpiled. Through this, you can generate
 multiple circuit randomizations as required by the `SqDRIFT`_ algorithm by
 repeatedly running the transpilation pipeline.
 
@@ -203,7 +203,7 @@ ensemble of circuits to generate:
        // via this API.
 
 .. note::
-   In the example above we have fixed the ``seed`` for the random number
+   The preceding example fixes the ``seed`` for the random number
    generator used inside of the :class:`.QDriftTrotterization` transpilation
    pass.
 
@@ -223,7 +223,7 @@ non-trivial excitation.
 This filtering needs to know which modes start out occupied. It therefore
 requires an :class:`.InitializeModes` gate preceding the :class:`.Evolution`
 gate(s) in the circuit; :meth:`.InitializeModes.from_hartree_fock` is a
-convenient way to construct one. We add one here for the N2 Hartree-Fock
+convenient way to construct one. Add one here for the N2 Hartree-Fock
 reference (seven alpha and seven beta electrons in 14 spatial orbitals) and compare the
 sampled excitations with and without ``filter_trivial=True``:
 
@@ -349,7 +349,7 @@ pass:
 Next steps
 ^^^^^^^^^^
 
-Now that we have successfully generated an ensemble of circuits, we can sample
+Now that you have successfully generated an ensemble of circuits, you can sample
 bitstrings from them. To do so, the circuits must be executed on hardware.
 Refer to the `Qiskit
 documentation <https://quantum.cloud.ibm.com/docs/guides/intro-to-patterns>`_

--- a/docs/guides/transpilation.rst
+++ b/docs/guides/transpilation.rst
@@ -136,8 +136,8 @@ approaches:
    <Figure size ... with 1 Axes>
 
 Both workflows produce equivalent circuits. However, the traditional workflow
-requires you to implement optimization steps manually, whereas the
-fermionic-first approach allows you to integrate problem-aware optimizations
+requires you to implement optimization steps manually, whereas with the
+fermionic-first approach you can integrate problem-aware optimizations
 into the transpilation process.
 
 Advanced workflows

--- a/docs/guides/transpilation.rst
+++ b/docs/guides/transpilation.rst
@@ -9,7 +9,7 @@ Transpile fermionic circuits
    Equivalent functionality will be made available via the C API in a future release.
 
 This guide explains how to transpile a :class:`.FermionicCircuit` to a standard
-:class:`~qiskit.circuit.QuantumCircuit`. We continue with the same time evolution
+:class:`~qiskit.circuit.QuantumCircuit`. It continues with the same time evolution
 example from the :ref:`fermionic circuits guide <fermionic_circuit_explanation>`.
 
 Transpilation stages

--- a/docs/guides/transpilation.rst
+++ b/docs/guides/transpilation.rst
@@ -6,7 +6,7 @@ Transpile fermionic circuits
 .. important::
 
    The concepts in this guide are currently available only in the Python API.
-   Equivalent functionality will be made available via the C API in a future release.
+   Equivalent functionality will be made available in the C API in a future release.
 
 This guide explains how to transpile a :class:`.FermionicCircuit` to a standard
 :class:`~qiskit.circuit.QuantumCircuit`. It continues with the same time evolution

--- a/docs/guides/vqe_outer_loop.rst
+++ b/docs/guides/vqe_outer_loop.rst
@@ -138,7 +138,7 @@ The final orbital rotation is initialized from the :math:`t_1` amplitudes and he
 since that rotation already captures the singles, the optimization can focus on the
 :math:`t_2`-derived repetition tensors, and ``theta`` stays :math:`\mathcal{O}(N^2)` parameters
 shorter. This is a choice, not a requirement: freezing it does restrict the variational manifold,
-so for systems with significant singles character you may well want it optimized too. Passing
+so for systems with significant singles character you might well want it optimized too. Passing
 ``with_final_orbital_rotation=True`` to both :meth:`.UCJ.num_parameters` and
 :meth:`.UCJ.from_parameters` folds it into ``theta``, which then also makes the two explicit
 ``final_orbital_rotation`` assignments below unnecessary.

--- a/docs/guides/vqe_outer_loop.rst
+++ b/docs/guides/vqe_outer_loop.rst
@@ -1,7 +1,7 @@
 .. _vqe_outer_loop_how_to:
 
-Running the outer VQE parameter optimization loop
-==================================================
+Run the outer VQE parameter optimization loop
+=============================================
 
 .. important::
 

--- a/docs/guides/vqe_outer_loop.rst
+++ b/docs/guides/vqe_outer_loop.rst
@@ -183,7 +183,7 @@ circuit carrying bound parameters, only the mapping from ``theta`` to tensors to
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Starting the optimizer from :math:`\boldsymbol{\theta} = \mathbf{0}` (the identity rotation and a
-zero diagonal Coulomb matrix, i.e. the Hartree-Fock reference itself) lands on a nearby local
+zero diagonal Coulomb matrix, that is, the Hartree-Fock reference itself) lands on a nearby local
 minimum barely below Hartree-Fock. With only one repetition, the ansatz is not expressive enough
 near that point for a gradient-based search to escape it unassisted. A classically computed
 starting point is a much better choice, so we reuse the CCSD-initialized ansatz from step 1: calling

--- a/docs/guides/vqe_outer_loop.rst
+++ b/docs/guides/vqe_outer_loop.rst
@@ -40,12 +40,12 @@ ansatz gate, using :class:`.UCJ` as a concrete example.
 1. Construct the ansatz
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-As a concrete example, we use the :class:`.UCJ` ansatz for a hydrogen molecule in the ``6-31g``
-basis, following the :ref:`LUCJ guide <lucj_getting_started>`, which covers the classical
+As a concrete example, this guide uses the :class:`.UCJ` ansatz for a hydrogen molecule in the
+``6-31g`` basis, following the :ref:`LUCJ guide <lucj_getting_started>`, which covers the classical
 calculation, the Hamiltonian construction, and the ansatz gate itself in more detail; this guide
-focuses on the optimization loop around it instead. We reuse the molecule's coupled-cluster
-singles and doubles (CCSD) :math:`t_1`/
-:math:`t_2` amplitudes as the initial point for the optimization, rather than for a fixed ansatz.
+focuses on the optimization loop around it instead. The molecule's coupled-cluster singles and
+doubles (CCSD) :math:`t_1`/:math:`t_2` amplitudes serve as the initial point for the optimization,
+rather than as a fixed ansatz.
 
 .. plot::
    :context:
@@ -110,7 +110,7 @@ Coulomb matrix written directly by its upper triangle and diagonal, then symmetr
    three-method interface can be dropped in here unchanged; :ref:`step 6 <vqe_outer_loop_ucc>` does
    that with :class:`.UCC`.
 
-We fix a single repetition (``n_reps=1``) here to keep the optimization fast for this guide, and
+Fix a single repetition (``n_reps=1``) here to keep the optimization fast for this guide, and
 keep the final orbital rotation from the :math:`t_1` amplitudes out of ``theta`` (see step 3);
 :meth:`.UCJ.num_parameters` reports how many parameters this leaves.
 
@@ -186,7 +186,7 @@ Starting the optimizer from :math:`\boldsymbol{\theta} = \mathbf{0}` (the identi
 zero diagonal Coulomb matrix, that is, the Hartree-Fock reference itself) lands on a nearby local
 minimum barely below Hartree-Fock. With only one repetition, the ansatz is not expressive enough
 near that point for a gradient-based search to escape it unassisted. A classically computed
-starting point is a much better choice, so we reuse the CCSD-initialized ansatz from step 1: calling
+starting point is a much better choice, so reuse the CCSD-initialized ansatz from step 1: calling
 :meth:`~.UCJ.to_parameters` on it (with its final rotation cleared, since ``theta`` excludes it)
 gives ``theta0``, which is then handed to :func:`scipy.optimize.minimize` together with ``energy``.
 Any ``scipy`` gradient-free or finite-difference method works here since ``energy`` returns a plain
@@ -212,9 +212,9 @@ float; no gradient of the fermionic ansatz is implemented.
    Because ``energy`` relies on multi-threaded linear algebra (inside :func:`ffsim.apply_unitary`
    and :func:`ffsim.linear_operator`), and ``minimize`` here uses numeric finite-difference
    gradients, the optimization trajectory (in particular the number of iterations needed)
-   can vary slightly between runs, machines, and BLAS backends. We give the optimizer a generous
-   iteration budget and check convergence with a tolerance rather than pinning down an exact
-   iteration count.
+   can vary slightly between runs, machines, and BLAS backends. The optimizer therefore gets a
+   generous iteration budget, and convergence is checked with a tolerance rather than by pinning
+   down an exact iteration count.
 
 .. plot::
    :context:
@@ -251,8 +251,8 @@ to the :class:`.UCJ` gate and ``params_to_vec`` built above, unchanged.
    By default, each step also runs an inner search over the ``regularization``/``variation``
    hyperparameters, which can itself become numerically sensitive once the ansatz is already very
    close to the optimum, occasionally causing a step to stall. Since a good fixed ``regularization``
-   and ``variation`` are already known to work well starting this close to the CCSD solution, we
-   disable that inner search here for a reliably reproducible trajectory.
+   and ``variation`` are already known to work well starting this close to the CCSD solution, that
+   inner search is disabled here for a reliably reproducible trajectory.
 
 .. plot::
    :context:
@@ -273,8 +273,8 @@ to the :class:`.UCJ` gate and ``params_to_vec`` built above, unchanged.
    >>> print(f"linear method: {lm_result.fun:.5f} Hartree")
    linear method: -1.15167 Hartree
 
-The iteration counts of both optimizers vary between runs and machines, so we don't print
-them here; but with the same warm start, the linear method consistently needs only a small
+The iteration counts of both optimizers vary between runs and machines, so they are not printed
+here; but with the same warm start, the linear method consistently needs only a small
 fraction of L-BFGS-B's iterations to reach the same energy, since it exploits the extra structure
 of ``params_to_vec`` that a generic finite-difference method cannot.
 

--- a/docs/guides/vqe_outer_loop.rst
+++ b/docs/guides/vqe_outer_loop.rst
@@ -6,7 +6,7 @@ Run the outer VQE parameter optimization loop
 .. important::
 
    The concepts in this guide are currently available only in the Python API.
-   Equivalent functionality will be made available through the C API in a future
+   Equivalent functionality will be made available in the C API in a future
    release.
 
 The variational quantum eigensolver (VQE) minimizes the expectation value of a Hamiltonian over a

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,7 +98,7 @@ License
 Deprecation policy
 ------------------
 
-We follow `semantic versioning <https://semver.org/>`_. We may occasionally make
+We follow `semantic versioning <https://semver.org/>`_. We might occasionally make
 breaking changes in order to improve the user experience. When possible, we will
 keep old interfaces and mark them as deprecated, as long as they can co-exist
 with the new ones. Each substantial improvement, breaking change, or deprecation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,11 +98,11 @@ License
 Deprecation policy
 ------------------
 
-We follow `semantic versioning <https://semver.org/>`_. We might occasionally make
-breaking changes in order to improve the user experience. When possible, we will
-keep old interfaces and mark them as deprecated, as long as they can co-exist
+This package follows `semantic versioning <https://semver.org/>`_. Breaking changes
+are made only occasionally, to improve the user experience. When possible, old
+interfaces are kept and marked as deprecated for as long as they can co-exist
 with the new ones. Each substantial improvement, breaking change, or deprecation
-will be documented in the `release notes
+is documented in the `release notes
 <https://quantum.cloud.ibm.com/docs/api/qiskit-fermions/release-notes>`_.
 
 References

--- a/docs/install-py.rst
+++ b/docs/install-py.rst
@@ -5,7 +5,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
 First, create a minimal environment with only Python installed in it.
-We recommend using `Python virtual environments
+Use `Python virtual environments
 <https://docs.python.org/3.10/tutorial/venv.html>`__.
 
 .. code:: sh

--- a/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/edge_vertex_operator/__init__.pyi
@@ -115,12 +115,12 @@ class EdgeVertexOperator:
     Fermionic modes indexed by ``left_indices`` and ``right_indices`` are considered spinless.
     
     .. note::
-       You may access **read-only copies** of these internal arrays via their respective methods:
+       You can access **read-only copies** of these internal arrays via their respective methods:
        :meth:`.get_coeffs`, :meth:`.get_left_indices`, :meth:`.get_right_indices`, and
        :meth:`.get_boundaries`.
     
     This data structure allows for very efficient construction and manipulation of operators.
-    However, it implies that duplicate terms may be contained in an operator at any moment.
+    However, it implies that duplicate terms might be contained in an operator at any moment.
     These must be resolved manually through the use of :meth:`.simplify`.
     
     Construction
@@ -200,7 +200,7 @@ class EdgeVertexOperator:
         >>> print(repr(op))
         EdgeVertexOperator.from_dict({...})
     
-    Finally, for large operators both of these outputs may be very long and undesirable. Then, a
+    Finally, for large operators both of these outputs might be very long and undesirable. Then, a
     very simple form with minimal information can be obtained from the :py:func:`str` function:
     
     .. doctest::

--- a/python/qiskit_fermions/_lib/operators/fermion_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/fermion_operator/__init__.pyi
@@ -68,11 +68,11 @@ class FermionOperator:
     Fermionic modes indexed by ``modes`` are considered spinless.
     
     .. note::
-       You may access **read-only copies** of these internal arrays via their respective methods:
+       You can access **read-only copies** of these internal arrays via their respective methods:
        :meth:`.get_coeffs`, :meth:`.get_actions`, :meth:`.get_modes`, and :meth:`.get_boundaries`.
     
     This data structure allows for very efficient construction and manipulation of operators.
-    However, it implies that duplicate terms may be contained in an operator at any moment.
+    However, it implies that duplicate terms might be contained in an operator at any moment.
     These must be resolved manually through the use of :meth:`.simplify`.
     
     Construction
@@ -156,7 +156,7 @@ class FermionOperator:
         >>> print(repr(op))
         FermionOperator.from_dict({...})
     
-    Finally, for large operators both of these outputs may be very long and undesirable. Then, a
+    Finally, for large operators both of these outputs might be very long and undesirable. Then, a
     very simple form with minimal information can be obtained from the :py:func:`str` function:
     
     .. doctest::

--- a/python/qiskit_fermions/_lib/operators/majorana_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/majorana_operator/__init__.pyi
@@ -70,11 +70,11 @@ class MajoranaOperator:
     function :py:func:`.gamma`, even (odd) indices are used for :math:`\gamma` (:math:`\gamma'`).
     
     .. note::
-       You may access **read-only copies** of these internal arrays via their respective methods:
+       You can access **read-only copies** of these internal arrays via their respective methods:
        :meth:`.get_coeffs`, :meth:`.get_modes`, and :meth:`.get_boundaries`.
     
     This data structure allows for very efficient construction and manipulation of operators.
-    However, it implies that duplicate terms may be contained in an operator at any moment.
+    However, it implies that duplicate terms might be contained in an operator at any moment.
     These must be resolved manually through the use of :meth:`.simplify`.
     
     Construction
@@ -152,7 +152,7 @@ class MajoranaOperator:
         >>> print(repr(op))
         MajoranaOperator.from_dict({...})
     
-    Finally, for large operators both of these outputs may be very long and undesirable. Then, a
+    Finally, for large operators both of these outputs might be very long and undesirable. Then, a
     very simple form with minimal information can be obtained from the :py:func:`str` function:
     
     .. doctest::

--- a/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
+++ b/python/qiskit_fermions/_lib/operators/transfer_vertex_operator/__init__.pyi
@@ -112,12 +112,12 @@ class TransferVertexOperator:
     Fermionic modes indexed by ``left_indices`` and ``right_indices`` are considered spinless.
     
     .. note::
-       You may access **read-only copies** of these internal arrays via their respective methods:
+       You can access **read-only copies** of these internal arrays via their respective methods:
        :meth:`.get_coeffs`, :meth:`.get_left_indices`, :meth:`.get_right_indices`, and
        :meth:`.get_boundaries`.
     
     This data structure allows for very efficient construction and manipulation of operators.
-    However, it implies that duplicate terms may be contained in an operator at any moment.
+    However, it implies that duplicate terms might be contained in an operator at any moment.
     These must be resolved manually through the use of :meth:`.simplify`.
     
     Construction
@@ -197,7 +197,7 @@ class TransferVertexOperator:
         >>> print(repr(op))
         TransferVertexOperator.from_dict({...})
     
-    Finally, for large operators both of these outputs may be very long and undesirable. Then, a
+    Finally, for large operators both of these outputs might be very long and undesirable. Then, a
     very simple form with minimal information can be obtained from the :py:func:`str` function:
     
     .. doctest::


### PR DESCRIPTION
## Summary

#281 copyedited all 13 guides against the
[IBM Quantum style guide](https://github.com/Qiskit/documentation/blob/main/style-guide.md) ahead of
the docs platform migration. I used the rules set forth from both (the original copyedit PR and the style guide)
to write a Claude skill to ensure better conformance in future AI-assisted docs editing and ran a verification session
of the existing docs against that new skill.

This PR includes all findings of that session.
The commits are broken into logical chunks based on the rule that is being addressed.

## Notable decisions

Reviewers may disagree with any of these; each is isolated in its own commit.

**First person (`7894498`) is the one to look at closely.** The replacement depends on what the
sentence is doing, so this is not a mechanical substitution:

- Instructions to the reader become imperative — "We run restricted Hartree-Fock" → "Run restricted
  Hartree-Fock".
- Statements about the reader's options become second person — "so we can obtain a LinearOperator" →
  "so you can obtain a LinearOperator".
- Statements about the document become "this guide" — "we use the UCJ ansatz" → "this guide uses the
  UCJ ansatz".
- Statements about what the code does lose the actor — "we count how many determinants" → "count how
  many determinants".

Sentences were re-read and re-wrapped afterwards rather than swapped word for word; a few needed
restructuring to avoid a dangling participle or a mixed construction.

**The deprecation policy was institutional first person**, where "you" would invert the meaning
("We follow semantic versioning" is a promise the project makes). It now takes the package as its
subject, which also removes two instances of the future tense. Applied identically in
`docs/index.rst` and `README.md`.

**"Contributing" and "Citing this package" keep their gerund form** in both `docs/index.rst` and
`README.md`. #281 left both alone, they read as conventional section names rather than instructions,
and the two files should agree.

## Beyond the style rules

**`594dd7e` fixes a live regression from #281.** A GitHub review suggestion was applied verbatim,
which duplicated a word and dropped the verb. `circuit.rst` currently reads:

> By assigning group indices to the Hamiltonian terms, structural information **is / information**
> that optimization passes can exploit throughout the transpilation stack.

It also collapsed a wrapped line to 150 characters. The pre-#281 text was passive ("structural
information gets preserved that..."), so the fix uses second person instead, which the style guide
prefers anyway. A scan for repeated words across every guide found no other instance.

(The sibling bullet-indent defect from the same PR was already fixed in `bdbe624`, which kept the
capitalized bullets — so that rule is endorsed, and only the mechanical slip was reverted.)

**The C API admonition is now uniform.** Duplicated across eight guides, it had drifted into
"through the C API", "via the C API", and "in the C API". #281 fixed `1d_fermi_hubbard.rst` to "in",
which is also the plainest, so all eight now match.

**One pre-existing subject-verb disagreement** in `sqdrift.rst` became conspicuous once the tense
was corrected, and is fixed in the same commit ("has no impact ... and only result in" → "results
in").

## Deliberately out of scope

- **"above"/"below" → "preceding"/"previous"/"later"** (73 sites). The style guide prescribes this,
  but most instances point at an adjacent code block or figure rather than making the version
  comparison the rule mainly targets. A 73-site mechanical sweep carries more risk than value here;
  worth a follow-up if wanted. One clear-cut case was fixed in `7894498` ("In the example above we
  have fixed" → "The preceding example fixes").