### PR TITLE
Re-enable sphinx warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,8 @@ style:
 doxygen: cheader
 	doxygen docs/Doxyfile
 
-# FIXME: we removed the -W argument below to accept warnings for the time being!
-# This change needs to be reverted once we can fix the broken intersphinx links
-# against the Qiskit C API docs.
 docs: doxygen
-	sphinx-build -j auto -T -E --keep-going -b html docs/ docs/_build/html
+	sphinx-build -W -j auto -T -E --keep-going -b html docs/ docs/_build/html
 
 # Build the documentation for browsing offline.  The API-reference entries in the sidebar normally
 # point at the absolute IBM Quantum Platform URLs, which is what the artifact ingested by the platform

--- a/docs/guides/circuit.rst
+++ b/docs/guides/circuit.rst
@@ -123,7 +123,7 @@ stack.
 Notice how the operator term grouping is preserved even in simple operations
 like decomposition. This demonstrates how structural information flows through the circuit
 stack. To understand the full transpilation to
-qubits, refer to the `Transpiling fermionic circuits <transpilation>`__  guide.
+qubits, refer to the :ref:`Transpiling fermionic circuits <transpilation_explanation>` guide.
 
 Transpile fermionic circuits
 ----------------------------

--- a/docs/guides/ffsim.rst
+++ b/docs/guides/ffsim.rst
@@ -1,7 +1,7 @@
 .. _ffsim_backend_explanation:
 
 The ffsim simulation backend
-=============================
+============================
 
 .. important::
 
@@ -18,7 +18,7 @@ building its own simulation API, and it does so in a way that keeps a native (sc
 simulation path available for users who cannot or do not want to install ffsim.
 
 Why couple with ffsim
-----------------------
+---------------------
 
 `ffsim`_ is a high-performance simulator for fermionic quantum circuits that exploits
 particle-number and spin-Z conservation to represent state vectors far more compactly than a
@@ -75,7 +75,7 @@ already working with ffsim mix in this package's gates and operators without lea
 simulation API.
 
 A native path when ffsim is unavailable
------------------------------------------
+---------------------------------------
 
 Coupling with ffsim's protocols does not make ffsim a hard dependency. `ffsim`_ transitively
 depends on `PySCF <https://pyscf.org/>`_, which does not support Windows, so ffsim is declared as
@@ -125,7 +125,7 @@ This is also why the two getting-started guides that use ffsim directly (:ref:`L
 code with :data:`~qiskit_fermions.utils.optionals.HAS_FFSIM` the same way this guide does.
 
 Fermionic simulation lives in a fixed particle-number sector
----------------------------------------------------------------
+------------------------------------------------------------
 
 Both ``_apply_unitary_`` and ``_linear_operator_`` take an ``nelec`` argument and represent the state
 vector over the *fixed-particle-number determinant basis* for that ``(norb, nelec)`` sector,
@@ -189,7 +189,7 @@ restriction. Any transpilation route works for this; the
 choice to reach for.
 
 The block-spin convention for spinful systems
-------------------------------------------------
+---------------------------------------------
 
 ``nelec`` is typed ``int | tuple[int, int]``, and its type, not a separate flag, is what selects
 between the two supported mode layouts:

--- a/docs/guides/lucj.rst
+++ b/docs/guides/lucj.rst
@@ -72,7 +72,7 @@ molecule in the ``6-31g`` basis, using `PySCF <https://pyscf.org/>`_ for the qua
    >>> t1, t2 = ccsd.t1, ccsd.t2
 
 2. Build the molecular Hamiltonian as a fermionic operator
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We will need the Hamiltonian later to evaluate the ansatz energy. We build it directly as a
 :class:`.FermionOperator` from the molecular-orbital integrals: the one-body integrals ``h1e``
@@ -159,7 +159,7 @@ per spin sector, so each is placed on the alpha modes ``0..norb`` and the beta m
    development.
 
 4. Simulate the ansatz and evaluate its energy
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Because every gate in the circuit implements ffsim's :class:`ffsim.SupportsApplyUnitary` protocol,
 the whole :class:`.FermionicCircuit` can be applied to a fixed particle-number state vector with
@@ -202,7 +202,7 @@ two repetitions:
 .. skip: end
 
 5. (Optional) Use ffsim's compressed double factorization
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :class:`.UCJ` gate above is initialized from an *exact* double factorization of the :math:`t_2`
 amplitudes: the number of ansatz repetitions :math:`L` is whatever that factorization yields (up to
@@ -264,7 +264,7 @@ way recovers the same correlation energy at this (small) system size:
 .. skip: end
 
 6. Transpile the ansatz to a qubit circuit
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To run the ansatz on hardware it must be lowered from fermionic modes to qubits.
 The :func:`~qiskit_fermions.transpiler.presets.generate_preset_jw_pass_manager` preset builds a

--- a/docs/guides/merge_slater_determinant.rst
+++ b/docs/guides/merge_slater_determinant.rst
@@ -78,7 +78,7 @@ sector. Slater determinant preparation is done per spin sector because each sect
 (electrons, orbitals) shape.
 
 Full-register (or spinless)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The simplest pattern: an :class:`.InitializeModes` immediately followed by an
 :class:`.OrbitalRotation` on the *same* modes. This is the spinless case (one determinant over all
@@ -116,7 +116,7 @@ per sector, each fuse on their own into a :class:`.PrepareSlaterDeterminant`:
    <Figure size ... with 2 Axes>
 
 Global initialization, per-spin rotations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A single full-register (``2 * norb``) :class:`.InitializeModes` followed by *two*
 :class:`.OrbitalRotation`\ s, one on each contiguous spin half. The pass splits the global
@@ -171,7 +171,7 @@ only when the :class:`.InitializeModes` is its *sole* predecessor across all of 
 figures below the before and after are identical: nothing fused.
 
 An operation in between
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 If any gate touches the modes between the initialization and the rotation, they no longer compose
 into a bare preparation, so nothing is merged:
@@ -193,7 +193,7 @@ into a bare preparation, so nothing is merged:
    <Figure size ... with 2 Axes>
 
 A partial rotation that is not a spin half
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A rotation covering exactly one contiguous spin half of a full-register initialization *does* fuse
 (see the previous section). But a rotation on any *other* partial mode set (fewer modes than the
@@ -213,7 +213,7 @@ role on the modes it leaves out, so the pass leaves both gates in place:
    <Figure size ... with 2 Axes>
 
 Why it matters: the synthesis payoff
--------------------------------------
+------------------------------------
 
 The merge is worthwhile because :class:`.PrepareSlaterDeterminant` synthesizes to far fewer gates
 than the :class:`.OrbitalRotation` it absorbs. An :math:`m`-electron determinant over :math:`n`

--- a/docs/guides/operators.rst
+++ b/docs/guides/operators.rst
@@ -1,7 +1,7 @@
 .. _operators_explanation:
 
 Design Principles of Operator Representations
-==============================================
+=============================================
 
 This guide explains the common design principles and core concepts shared across
 all operator representations in the :mod:`~qiskit_fermions.operators` module.

--- a/docs/guides/skqd.rst
+++ b/docs/guides/skqd.rst
@@ -42,7 +42,7 @@ following the `SKQD`_ publication.
 .. skip: start if(not HAS_FFSIM)
 
 1. Build the SIAM Hamiltonian as a fermionic operator
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The single-impurity Anderson model places one interacting impurity orbital (index :math:`0`) in
 contact with a non-interacting bath of :math:`L` sites arranged as a chain. Its Hamiltonian splits
@@ -266,7 +266,7 @@ thousands of determinants while the momentum basis concentrates it onto a couple
 the whole reason SKQD sampling works in the momentum basis and not the position basis.
 
 3. Prepare the reference state
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The SKQD reference :math:`\lvert \psi_0 \rangle` is the superposition of all excitations of the
 electrons closest to the Fermi level into the nearest empty momentum modes. The `SKQD`_ publication
@@ -401,7 +401,7 @@ state only) up to :math:`D - 1`.
    `future <https://github.com/Qiskit/qiskit-fermions/issues/219>`_.
 
 5. Transpile to qubit circuits
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Transpiling a :class:`.FermionicCircuit` maps its fermionic gates to qubit gates. We use the
 Jordan-Wigner :func:`.jordan_wigner` mapping. The :class:`.OrbitalRotation` gates synthesize into a
@@ -481,7 +481,7 @@ steps (four in this case):
    <Figure size ... with 1 Axes>
 
 6. Sample bitstrings from the Krylov circuits
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 On hardware, we would run the transpiled circuits and measure. Here we do the noiseless (statevector)
 version of that step to see the bitstrings SKQD would collect. We simulate each untranspiled
@@ -535,7 +535,7 @@ handful of configurations dominate, led by the reference determinant.
 .. skip: end
 
 7. Diagonalize in the sampled subspace
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The sampled bitstrings are the input to the classical half of SKQD: the Hamiltonian is projected onto
 the subspace the sampled configurations span and diagonalized there. We hand this off to the

--- a/docs/guides/vqe_outer_loop.rst
+++ b/docs/guides/vqe_outer_loop.rst
@@ -1,7 +1,7 @@
 .. _vqe_outer_loop_how_to:
 
 Running the outer VQE parameter optimization loop
-==================================================
+=================================================
 
 .. important::
 
@@ -95,7 +95,7 @@ The molecular Hamiltonian is built the same way as in the LUCJ guide:
    >>> hamiltonian += FermionOperator.from_2body_tril_spin_sym(h2e_tril, norb)
 
 2. Choose an unconstrained parametrization of the ansatz tensors
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The optimizer needs a flat real vector, but the ansatz tensors are constrained: each orbital
 rotation must be unitary, and each diagonal Coulomb matrix must be real symmetric.
@@ -127,7 +127,7 @@ keep the final orbital rotation from the :math:`t_1` amplitudes out of ``theta``
    >>> num_params = UCJ.num_parameters(norb, "balanced", n_reps)
 
 3. Build the ansatz and evaluate the state from a flat parameter vector
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Given ``theta``, :meth:`.UCJ.from_parameters` builds the gate directly. Rather than returning an
 energy directly, ``params_to_vec`` stops one step earlier and returns the ansatz state vector:
@@ -180,7 +180,7 @@ Each call to ``params_to_vec`` builds an entirely new :class:`.UCJ` gate: there 
 circuit carrying bound parameters, only the mapping from ``theta`` to tensors to a gate to a state.
 
 4. Run the outer loop with a generic optimizer
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Starting the optimizer from :math:`\boldsymbol{\theta} = \mathbf{0}` (the identity rotation and a
 zero diagonal Coulomb matrix, i.e. the Hartree-Fock reference itself) lands on a nearby local
@@ -234,7 +234,7 @@ Even with a generous iteration budget, each ``energy`` evaluation only reveals a
 a wasteful use of the full state vector ``params_to_vec`` already computed internally.
 
 5. Run the outer loop with ffsim's linear method
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `ffsim`_ ships :func:`ffsim.optimize.minimize_linear_method`, an optimizer purpose-built for
 wavefunction ansatzes: rather than a scalar ``energy``, it takes ``params_to_vec`` directly (the
@@ -281,7 +281,7 @@ of ``params_to_vec`` that a generic finite-difference method cannot.
 .. _vqe_outer_loop_ucc:
 
 6. Swap in a different ansatz
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Nothing above is specific to :class:`.UCJ`. Because the loop only ever calls
 ``num_parameters``/``from_parameters``/``to_parameters``, another ansatz exposing that interface

--- a/python/qiskit_fermions/linalg/__init__.py
+++ b/python/qiskit_fermions/linalg/__init__.py
@@ -12,9 +12,9 @@
 
 # ruff: noqa: D205,D212,D415
 """
-=========================
+========================
 Linear Algebra Utilities
-=========================
+========================
 
 .. currentmodule:: qiskit_fermions.linalg
 

--- a/python/qiskit_fermions/mappers/library/__init__.py
+++ b/python/qiskit_fermions/mappers/library/__init__.py
@@ -22,7 +22,7 @@ This module provides efficient implementations of commonly used operator represe
 routines.
 
 Python wrappers
-================
+===============
 
 The functions below are thin, type-agnostic convenience mappers. Each delegates to the appropriate
 library implementation below under the hood, based on the type of the object it is given. They do
@@ -36,7 +36,7 @@ not implement any conversion logic themselves.
    majorana_operator
 
 Library implementations
-========================
+=======================
 
 The functions below are the native, efficient mapper implementations backing this module.
 


### PR DESCRIPTION
#166 previously disabled Sphinx warnings because of a missing reference from the Qiskit C API `objects.inv`. This is now available again, so this PR reverts that hack. It also applies some other minor cosmetic changes.