### PR TITLE
BD - close reading

### DIFF
--- a/docs/guides/1d_fermi_hubbard.rst
+++ b/docs/guides/1d_fermi_hubbard.rst
@@ -5,7 +5,7 @@ Simulate 1D Fermi-Hubbard dynamics with flow sets
 
 .. important::
 
-   The concepts in this guide are currently available only in the Python API.
+   The functions described in this guide are currently available only in the Python API.
    Equivalent functionality will be made available in the C API in a future release.
 
 This guide builds a circuit for the **time dynamics of the one-dimensional Fermi-Hubbard
@@ -18,14 +18,18 @@ in this package:
    them *before* it, into **flow sets**, one-dimensional subsets of the directed
    fermionic interaction graph whose transfer operators mutually commute.
 
-That choice drives everything below. It calls for a **custom fermion-to-qubit encoding**
-tailored to the flow sets, which here spends one **ancilla qubit** so that the qubit count
+That choice drives everything below. It calls for the following:
+
+* A **custom fermion-to-qubit encoding** tailored to the flow sets, which here spends one **ancilla qubit** so the qubit count
 associated with the implementation of a given Hamiltonian term no longer grows with the
-number of fermionic modes (as is the case for Jordan-Wigner (JW)), and for a **custom synthesis** that
+number of fermionic modes (as is the case for Jordan-Wigner (JW)).
+* A **custom synthesis** that 
 exploits the commutativity within each set. The payoff is a circuit whose two-qubit depth
 is **constant in the system size**, against the linear growth of a JW-based term-by-term
-Trotterization. The machinery that gets an encoding of your own into the transpiler
-(:class:`.CustomF2QLayout` and :class:`.MapperFnEvolutionSynthesis`) is the part that
+Trotterization. 
+
+The machinery that gets an encoding of your own into the transpiler
+(:class:`.CustomF2QLayout` and :class:`.MapperFnEvolutionSynthesis`) 
 carries over to any model.
 
 .. seealso::
@@ -49,7 +53,7 @@ operators,
 so :math:`V_j` measures the occupation of mode :math:`j` (it is :math:`+1` when empty
 and :math:`-1` when filled), while :math:`T_{jk}` transfers a fermion along the
 *directed* edge :math:`j \to k`. Note that the two indices of :math:`T_{jk}` are *not*
-interchangeable: the **first** index carries the minus combination and the second the
+interchangeable: the first index carries the minus combination and the second carries the
 plus, which is what makes :math:`T_{jk}` distinct from :math:`T_{kj}` and gives the edge
 its orientation.
 
@@ -93,7 +97,7 @@ the two operators commute. Take instead :math:`T_{1,2}` and :math:`T_{3,2}`: bot
 *point into* site 2: they clash, and those two anticommute.
 
 This is what makes flow sets possible. Pick a set of arrows forming a directed path and
-every pair either meets head-to-tail or does not meet at all, so the whole set commutes
+every pair either meets head-to-tail or does not meet at all, so the whole set commutes, 
 even though the individual operators overlap on shared sites. Evolving under a single flow
 set therefore incurs **no Trotter error**, and as :ref:`step 7 <flowsets_synthesis>`
 shows, it can also be done at constant circuit depth.
@@ -168,12 +172,12 @@ terms its nodes.
 ---------------------------
 
 Next, label each term with the flow set it belongs to. The
-:attr:`~.TransferVertexOperator.groups` attribute exists for this purpose: an
+:attr:`~.TransferVertexOperator.groups` attribute exists for this purpose. An
 :class:`.Evolution` gate over a grouped operator decomposes into one :class:`.Evolution`
 per group (:ref:`step 6 <flowsets_transpile>` puts this to work), so the grouping decided
 here at the *fermionic* level survives into the circuit.
 
-For the 1D chain the two hopping flow sets are the east-oriented arrows
+For the 1D chain, the two hopping flow sets are the east-oriented arrows
 (:math:`T_{j,j+1}`) and the west-oriented arrows (:math:`T_{j+1,j}`). The diagonal
 interaction terms commute with everything diagonal and form a third group:
 
@@ -207,11 +211,11 @@ Groups 0 and 1 are the two flow sets: each is a directed path along the chain, s
 flow property all terms within a group commute.
 
 .. note::
-   The east/west labels used throughout this guide are **geometric**: with the chain drawn
-   left to right and mode indices increasing in that direction, :math:`T_{j,j+1}` points
+   The east/west labels used throughout this guide are **geometric**, with the chain drawn
+   left to right and mode indices increasing in that direction; :math:`T_{j,j+1}` points
    east and :math:`T_{j+1,j}` points west. Ref. [1]_ is internally inconsistent on this
    naming (its prose and its figures disagree) so this guide deliberately does *not*
-   follow the prose, and instead keeps the labels tied to the picture. When cross-reading
+   follow the prose, and instead keeps the labels from the picture. When cross-reading
    with the paper, match the flow sets by their Pauli weights (1 and 3 below), not by the
    compass words.
 
@@ -225,8 +229,8 @@ Pauli. The classification shows that **spending extra qubits buys structure** in
 encoded operators.
 
 The encoding implemented here is the parity-delocalized construction of Appendix B 2
-(Eqs. B4 and B5), which uses one **ancilla qubit**, so :math:`N_q = N_f + 1`. The
-fermionic parity is delocalized across a *pair* of qubits:
+(equations B4 and B5), which uses one **ancilla qubit**, so :math:`N_q = N_f + 1`. The
+fermionic parity is delocalized across a pair of qubits:
 
 .. math::
 
@@ -234,24 +238,24 @@ fermionic parity is delocalized across a *pair* of qubits:
    T_{j,j+1} = -\tfrac{1}{2} X_{j+1} \, , \qquad
    T_{j+1,j} = +\tfrac{1}{2} Z_j X_{j+1} Z_{j+2} \, .
 
-The index :math:`j+2` in the last expression is what forces the extra qubit. The final bond
-of the chain has :math:`j = N_f - 2`, so its :math:`Z_{j+2}` lands on qubit :math:`N_f`,
+The index :math:`j+2` in the last expression forces the extra qubit. The chain's final bond
+has :math:`j = N_f - 2`, so its :math:`Z_{j+2}` lands on qubit :math:`N_f`,
 one past the last fermionic mode :math:`N_f - 1`. That trailing qubit is the ancilla, and it
 is why :math:`N_q = N_f + 1` rather than :math:`N_f`. The same reach shows up in
-:math:`V_j`, whose :math:`Z_{j+1}` sits on the ancilla for :math:`j = N_f - 1`.
+:math:`V_j`, whose :math:`Z_{j+1}` is on the ancilla for :math:`j = N_f - 1`.
 
-The payoff is visible immediately: one whole flow set is mapped to a sum of **weight-1**
+The payoff is visible immediately: one whole flow set is mapped to a sum of weight-1
 Paulis.
 
 .. note::
-   The :math:`\tfrac{1}{2}` prefactors are fixed by the normalization :math:`T_{jk}^2 =
-   \tfrac{1}{4}`, and the *relative* minus sign between the two orientations is fixed by
+   The :math:`\tfrac{1}{2}` prefactors are fixed by the normalization :math:`T_{jk}^2 = \tfrac{1}{4}`, 
+   and the relative minus sign between the two orientations is fixed by
    the product identity :math:`T_{j,j+1} = -V_j V_{j+1} T_{j+1,j}`, which the Paulis above
-   satisfy. Getting either wrong yields an operator that still obeys the commutation
-   relations but no longer represents the same Hamiltonian, so it is worth verifying the
-   encoding numerically; this happens in :ref:`step 4 <flowsets_verify>`.
+   satisfy. Getting either wrong yields an operator that obeys the commutation
+   relations but no longer represents the same Hamiltonian, so you should verify the
+   encoding numerically, as shown in :ref:`step 4 <flowsets_verify>`.
 
-Writing the encoding means writing a function that maps a **single** generalized transfer
+Writing the encoding means writing a function that maps a single generalized transfer
 operator to a Pauli string; :func:`.map_transfer_vertex_generators` handles the iteration
 over terms and their composition:
 
@@ -292,10 +296,9 @@ over terms and their composition:
    ...     ).simplify()
 
 .. important::
-   The signature ``(operator, num_qubits)`` is what :attr:`.MapperFnEvolutionSynthesis.mapper_fn`
-   expects, and the return type must be a
+   The :attr:`.MapperFnEvolutionSynthesis.mapper_fn` expects the signature ``(operator, num_qubits)``, and the return type must be a
    :class:`~qiskit.quantum_info.SparseObservable`, which makes
-   the function directly usable as a transpiler plugin in :ref:`step 6 <flowsets_transpile>`.
+   the function directly usable as a transpiler plugin in. See :ref:`step 6 <flowsets_transpile>`.
 
 Applying it to the Hamiltonian from step 1 gives the encoded operator on
 :math:`N_f + 1 = 5` qubits:
@@ -324,13 +327,13 @@ Applying it to the Hamiltonian from step 1 gives the encoded operator on
    ZZ  [2, 4]       +0.50
    ZZ  [3, 4]       -0.50
 
-Fourteen terms, in exactly three shapes: the hopping has become ``X`` and ``ZXZ``, the
-interaction ``ZZ``, and the leading ``[]`` is the identity contributing only a global
-phase. Note that the ``ZZ`` terms reach both nearest *and* next-nearest neighbors;
-:math:`V_jV_{j+1}` spans qubits :math:`j` through :math:`j+2`, which is the cost side of
+Fourteen terms, in three shapes: the hopping has become ``X`` and ``ZXZ``, the
+interaction ``ZZ``, and the leading ``[]`` is the identity, contributing only a global
+phase. Note that the ``ZZ`` terms reach nearest *and* next-nearest neighbors;
+:math:`V_jV_{j+1}` spans qubits :math:`j` through :math:`j+2`, which is the cost of
 delocalizing the parity.
 
-Grouping by flow set exposes the asymmetry the construction buys. Listing the Pauli
+Grouping by flow set exposes the asymmetry the construction buys. List the Pauli
 weights present in each group:
 
 .. plot::
@@ -346,13 +349,12 @@ weights present in each group:
    2 [0, 2]
 
 The east-oriented flow set (group 0) consists **entirely of weight-1 Paulis**. Its time
-evolution is therefore a layer of single-qubit rotations and needs *no entangling gates at
-all*, whereas under Jordan-Wigner every hopping term is weight-2 and requires them. This
+evolution is therefore a layer of single-qubit rotations and needs *no entangling gates*, whereas under Jordan-Wigner every hopping term is weight-2 and requires them. This
 is the space-time trade-off of Ref. [1]_ in its simplest form: one extra qubit converts
 half of the hopping Hamiltonian into single-qubit rotations.
 
 The west-oriented flow set (group 1) pays for it at weight 3, and the interaction (group 2)
-sits at weight 2, with the weight-0 entry being the identity. Nothing here is yet a
+sits at weight 2, where the weight-0 entry is the identity. None of this is yet a
 *circuit* claim; what a synthesis makes of these weights is the subject of steps 5
 and 6.
 
@@ -361,13 +363,13 @@ and 6.
 4. Verify the encoding
 ----------------------
 
-A custom encoding is only useful if it is *faithful*, and a hand-written one deserves to
-be checked rather than trusted. Because this encoding uses :math:`N_f + 1` qubits, the
+A custom encoding is only useful if it is *faithful*, and a hand-written one should
+be checked. Because this encoding uses :math:`N_f + 1` qubits, the
 qubit Hilbert space is twice as large as the fermionic one, so the encoded Hamiltonian
 cannot equal the Jordan-Wigner one term by term. The two are related by an isometry
 instead.
 
-**Where the isometry comes from.** Under Jordan-Wigner a basis state simply *is* the
+**Where the isometry comes from:** Under Jordan-Wigner a basis state is the
 occupation string: qubit :math:`j` holds :math:`n_j`. This encoding instead stores
 *cumulative parities*. Define
 
@@ -384,7 +386,7 @@ Kramers-Wannier) encoding. That is also why :math:`V_j = Z_j Z_{j+1}`: the
 product of two neighboring :math:`Z`\ s reads off that difference.
 
 Writing this map out for a few states makes the structure concrete (note that
-:math:`b_0 = 0` is fixed, so only *half* of the :math:`2^{N_f+1}` qubit states are in the
+:math:`b_0 = 0` is fixed, so only half of the :math:`2^{N_f+1}` qubit states are in the
 image, and hence an isometry rather than a unitary):
 
 .. plot::
@@ -409,17 +411,17 @@ image, and hence an isometry rather than a unitary):
    1100 -> 00010
    1010 -> 00110
 
-A single fermion on site 0 flips *every* cumulative parity above it, which is the
+A single fermion on site 0 flips every cumulative parity above it, which is the
 delocalization at work. Collecting these columns into a matrix gives the isometry
-:math:`W`, and the encoding is faithful precisely when it *intertwines* the two
+:math:`W`, and the encoding is faithful when it *intertwines* the two
 Hamiltonians:
 
 .. math::
 
    \hat{H}_{\text{flow set}} \, W = W \, \hat{H}_{\text{JW}} \, .
 
-In words: mapping a fermionic state into the qubit space and then evolving it there must
-give the same result as evolving it in the fermionic space first and mapping afterwards.
+That is, mapping a fermionic state into the qubit space and then evolving it there must
+give the same result as evolving it in the fermionic space first and mapping afterward.
 
 .. plot::
    :context:
@@ -495,12 +497,12 @@ A :class:`.FermionicCircuit` acts on fermionic modes rather than qubits, and an
    >>> circuit.draw("mpl")
    <Figure size ... with 1 Axes>
 
-One opaque box over all four modes. The interesting part is what it decomposes into:
+There is one opaque box over all four modes. The interesting part is what it decomposes into:
 :class:`.Evolution` splits itself group-by-group whenever its operator has
 :attr:`~qiskit_fermions.operators.TransferVertexOperator.groups` assigned, so a single
 :meth:`~qiskit.circuit.QuantumCircuit.decompose` turns it into **one** :class:`.Evolution`
 **per flow set**, ordered by group index: east, west, then the diagonal interaction,
-carrying 3, 3, and 8 terms respectively, the groups from step 2:
+carrying 3, 3, and 8 terms respectively. The groups from step 2 are shown in the following plot:
 
 .. plot::
    :context: close-figs
@@ -512,8 +514,7 @@ carrying 3, 3, and 8 terms respectively, the groups from step 2:
    <Figure size ... with 1 Axes>
 
 This is the step that makes the grouping matter. Each of the three gates is mapped and
-synthesized independently, so the partitioning decided at the fermionic level in step 2 is
-what the transpiler ends up acting on. Skip the decomposition and the grouping is simply
+synthesized independently, so the transpiler ends up acting on the partitioning decided at the fermionic level in step 2. If you skip the decomposition,  the grouping is 
 ignored.
 
 .. _flowsets_transpile:
@@ -523,18 +524,17 @@ ignored.
 
 The encoding is now ready to be used by the transpiler. Two more pieces are needed:
 
-**A layout.** The default :class:`.TrivialF2QLayout` assumes one qubit per mode, which is
-wrong here. :class:`.CustomF2QLayout` associates the fermionic register with a
+* **A layout.** The default :class:`.TrivialF2QLayout` assumes one qubit per mode, which is
+wrong in this situation. :class:`.CustomF2QLayout` associates the fermionic register with a
 :class:`~qiskit.circuit.QuantumRegister` of a different size, which is how ancilla
 qubits enter the pipeline.
-
-**A synthesis plugin.** :class:`.MapperFnEvolutionSynthesis` takes the mapper function
+* **A synthesis plugin.** :class:`.MapperFnEvolutionSynthesis` takes the mapper function
 directly, maps the :class:`.Evolution` gate's Hamiltonian with it, and emits a
-:class:`~qiskit.circuit.library.PauliEvolutionGate` preserving the :math:`e^{-itH}`
+:class:`~qiskit.circuit.library.PauliEvolutionGate`, preserving the :math:`e^{-itH}`
 convention. Its :attr:`~.MapperFnEvolutionSynthesis.product_formula` is left at its default
-for now; step 7 is where a custom one gets slotted in.
+for now.  A custom one is added in step 7.
 
-Since every comparison below re-runs this same pipeline, it is worth wrapping once:
+Since every comparison below reruns this pipeline, it is worth wrapping once:
 
 .. plot::
    :context:
@@ -603,41 +603,40 @@ the circuit shows why:
    <Figure size ... with 1 Axes>
 
 Every term has been compiled in isolation: a basis change, a ``CX`` ladder down to a single
-rotation, then the ladder undone. The weight-1 flow set really is free; its terms are
+rotation, then the ladder is undone. The weight-1 flow set is free; its terms are
 lone rotations with no ladder around them, but each weight-3 term pays for four
-``CX``\ s, and because the ladders are emitted one term after another, nothing overlaps.
+``CX``\ gates, and because the ladders are emitted sequentially, nothing overlaps.
 
-The grouping *has* been honored at the level of the pipeline (three flow sets, three
+The grouping has been honored at the level of the pipeline (three flow sets, three
 mapped :class:`~qiskit.circuit.library.PauliEvolutionGate`\ s) but it buys almost
-nothing, because :class:`~qiskit.synthesis.LieTrotter` synthesizes each one **term by
-term**. It does not know that the terms handed to it mutually commute, so it still compiles
-them one after another. The structural advantage is present in the *operator* and preserved by
-the *decomposition*, then discarded by the *synthesis*. That last step is what the next
-section replaces.
+nothing, because :class:`~qiskit.synthesis.LieTrotter` synthesizes each one term by
+term. It does not know that the terms handed to it mutually commute, so it still compiles
+them sequentially. The structural advantage is present in the operator and preserved by
+the decomposition, then discarded by the *synthesis*. The next step replaces that synthesis.
 
 .. _flowsets_synthesis:
 
 7. A flow-set-aware synthesis
 -----------------------------
 
-Recovering the advantage requires telling the synthesis about the structure. This is
+To recover the advantage, we need to tell the synthesis about the structure. This is
 Section IV C of Ref. [1]_: because all terms of a flow set commute, they can be
-**simultaneously diagonalized** by a single Clifford circuit, rotated in one shared basis
+simultaneously diagonalized by a single Clifford circuit, rotated in one shared basis
 and rotated back, instead of once per term.
 
-For this encoding the Clifford is remarkably simple. Conjugating by a chain of ``CZ``
+For this encoding, the Clifford is simple. Conjugating by a chain of ``CZ``
 gates on nearest neighbors maps
 
 .. math::
 
    X_{j+1} \; \longmapsto \; Z_j X_{j+1} Z_{j+2}
 
-simultaneously for **every** :math:`j`. One ``CZ`` chain turns the entire weight-3
-(west) flow set into a layer of independent single-qubit :math:`X` rotations. All the
-:class:`~qiskit.synthesis.EvolutionSynthesis` interface asks for is a
+simultaneously for every :math:`j`. One ``CZ`` chain turns the entire weight-3
+(west) flow set into a layer of independent single-qubit :math:`X` rotations. The
+:class:`~qiskit.synthesis.EvolutionSynthesis` interface only requests a
 :meth:`~qiskit.synthesis.EvolutionSynthesis.synthesize` method; ``reps`` is here because a
 product formula is also where the number of Trotter steps belongs, as in Qiskit's
-own :class:`~qiskit.synthesis.LieTrotter`:
+ :class:`~qiskit.synthesis.LieTrotter`:
 
 .. plot::
    :context:
@@ -722,16 +721,16 @@ own :class:`~qiskit.synthesis.LieTrotter`:
    attribute, which the high-level-synthesis pass reads.
 
    Both helpers emit their gates in explicit layers rather than in term order, because
-   :meth:`~qiskit.circuit.QuantumCircuit.depth` schedules gates *as soon as possible in the
-   order they were added*. Since all the gates within one of these sets commute, that order
-   is ours to choose, and choosing it badly is what a term-by-term synthesis does: emitting
-   the overlapping ``CZ`` chain sequentially reports a depth growing with the qubit count
-   rather than the constant 2 the hardware could achieve.
+   :meth:`~qiskit.circuit.QuantumCircuit.depth` schedules gates *as soon as possible, in the
+   order they were added*. Since all the gates within one of these sets commute, we can choose the order.
+   A term-by-term synthesis chooses the order badly: emitting
+   the overlapping ``CZ`` chain sequentially reports a depth that grows with the qubit count
+   rather than the constant ``2`` the hardware could achieve.
 
-Selecting it requires nothing more than handing it to
+To select the order, pass it to 
 :attr:`.MapperFnEvolutionSynthesis.product_formula`, which is the argument
-``flow_set_pass_manager`` takes. Nothing else about the pipeline, or the fermionic circuit
-it runs on, changes:
+``flow_set_pass_manager`` takes. Nothing else about the pipeline (or the fermionic circuit
+it runs on) changes:
 
 .. plot::
    :context:
@@ -754,18 +753,18 @@ it runs on, changes:
    >>> flow_circuit.draw("mpl", fold=-1)
    <Figure size ... with 1 Axes>
 
-From depth 23 with 26 ``CX`` gates down to depth 12 with 22: fewer entangling gates *and*
+From depth 23 with 26 ``CX`` gates down to depth 12 with 22 ``CX`` gates.  Note that this is fewer entangling gates and
 nearly half the depth. Comparing the two pictures, the difference is not that the gates are
 cheaper but that they *stack*. The serial ladders are gone; entangling gates now sit above
-one another in shared layers, because the whole west flow set is rotated in a single shared
+one another in shared layers because the whole west flow set is rotated in a single shared
 basis and the interaction is emitted in layers of disjoint pairs.
 
 .. note::
    Both drawings show the circuit after ``decompose(reps=6)``, which rewrites everything
-   into the ``U`` and ``CX`` basis, so the ``CZ``, ``Rx`` and ``Rzz`` gates emitted by
+   into the ``U`` and ``CX`` basis, so the ``CZ``, ``Rx``, and ``Rzz`` gates emitted by
    ``FlowSetSynthesis`` are not visible as such. That is deliberate: it puts both circuits
    in the same basis, which is the only way the two-qubit counts and depths above are
-   comparable. It is the *layer structure* that is worth reading off these figures, not the
+   comparable. It is the *layer structure* that is notable in these figures, not the
    gate labels.
 
 8. Constant depth at scale
@@ -825,20 +824,19 @@ each set is still Trotterized term by term, so the growth is only slowed, not re
    >>> figure
    <Figure size ... with 2 Axes>
 
-The gate *count* grows linearly under both (there are :math:`O(N)` terms to apply, and
-that is unavoidable) but the flow-set synthesis applies them in a constant number of
+The gate count grows linearly under both (there are :math:`O(N)` terms to apply, and
+that is unavoidable), but the flow-set synthesis applies them in a constant number of
 parallel layers. This is the constant-depth result of Ref. [1]_.
 
 .. plot::
    :context:
    :nofigs:
 
-   Guard the claim the prose above rests on, but which none of the visible doctests pin
-   down: that ``FlowSetSynthesis`` reproduces each flow set's evolution *exactly*, not
+   Guard the claim the prose above rests on, but which none of the visible doctests illustrate: that ``FlowSetSynthesis`` reproduces each flow set's evolution *exactly*, not
    just to some Trotter order. The published numbers only fix behavior at the sizes and
-   step counts they were written with, so a change that silently broke exactness (a
-   dropped ``CZ`` layer, a conjugation applied in the wrong order) could leave every
-   visible output intact. Checked here across two chain lengths, group by group, against
+   step counts they were written with, so a change that silently breaks exactness (such as a
+   dropped ``CZ`` layer or a conjugation applied in the wrong order) could leave every
+   visible output intact. This is checked here across two chain lengths, group by group, against
    ``expm``.
 
    >>> from qiskit.quantum_info import Operator
@@ -871,25 +869,25 @@ parallel layers. This is the constant-depth result of Ref. [1]_.
    The depth 12 splits across the three flow sets as 0 + 4 + 8, at every chain length. The
    east flow set contributes **zero**: it is bare ``Rx`` rotations. The west flow set costs 4,
    from the two ``CZ`` brickwork layers going in and the two coming out; dropping the
-   interaction leaves that, a two-qubit depth of 4 at any chain length. The remaining
-   8 is the interaction, whose ``Rzz`` terms act on both nearest and next-nearest neighbors
-   and so need four disjoint layers, each costing two ``CX``\ s. Four is optimal here: every
+   interaction leaves a two-qubit depth of **four** at any chain length. The remaining
+   **eight** is the interaction whose ``Rzz`` terms act on both nearest and next-nearest neighbors
+   and so need four disjoint layers, each costing two ``CX``\ gates. Four is optimal here: every
    interior qubit carries four ``Rzz`` gates (two to each neighbor and two to each
    next-nearest one) and can only take part in one at a time, so no schedule can do
    better.
 
-   That two thirds of the depth is the interaction shows where this encoding really excels:
-   at the hopping, and so at the dynamics of a free-fermion chain. Do note, though, that the
-   interaction does not commute with the hopping: leaving it out is not an approximation to
+   Two thirds of the depth is the interaction, which shows that this encoding excels at
+   the hopping, and thus at the dynamics of a free-fermion chain. However, note that the
+   interaction does not commute with the hopping: leaving it out is *not* an approximation to
    Fermi-Hubbard but a different model. Where the balance falls for a given problem is worth
    exploring.
 
 9. Check the dynamics
 ---------------------
 
-Under the domain-wall map an occupation pattern becomes a
+Under the domain-wall map, an occupation pattern becomes a
 cumulative-parity string, so the initial state is prepared differently than under
-Jordan-Wigner, an easily overlooked practical consequence of delocalizing the parity. The
+Jordan-Wigner.  This is an easily overlooked practical consequence of delocalizing the parity. The
 helper from step 4 gives the right label:
 
 .. plot::
@@ -904,8 +902,8 @@ helper from step 4 gives the right label:
 
 Now compare ``FlowSetSynthesis`` against :class:`~qiskit.synthesis.LieTrotter` at increasing
 numbers of Trotter steps, measuring the fidelity of the evolved state against exact matrix
-exponentiation. The step count is a property of the *product formula*, so both columns run
-the very same fermionic circuit (``circuit`` from step 5, a single :class:`.Evolution`
+exponentiation. The step count is a property of the product formula, so both columns run
+the same fermionic circuit (``circuit`` from step 5, a single :class:`.Evolution`
 gate at the full time) and let the synthesis subdivide it:
 
 .. plot::
@@ -942,39 +940,38 @@ gate at the full time) and let the synthesis subdivide it:
    8 step(s):  flow set 0.995395 (176 CX, depth  96)   Lie 0.925807 (208 CX, depth 180)
 
 The flow-set synthesis wins on **all three** axes at once: higher fidelity, fewer entangling
-gates *and* roughly half the two-qubit depth at every step count. This is not a
+gates, and roughly half the two-qubit depth at every step count. This is not a
 depth-versus-accuracy trade; the Trotter error is genuinely smaller because each flow set
 is evolved *exactly*, so the only error left comes from splitting the three groups against
 each other, rather than from splitting all fourteen terms.
 
 .. note::
-   Which circuit goes in matters: the *undecomposed* one from step 5, holding a single
-   :class:`.Evolution` gate over all fourteen terms, not the group-wise
-   :meth:`~qiskit.circuit.QuantumCircuit.decompose` of :ref:`step 6 <flowsets_transpile>`.
-   That is what keeps the default column an honest baseline. Handing it the decomposed
+   The circuit used matters. The *undecomposed* one from step 5, holding a single
+   :class:`.Evolution` gate over all fourteen terms is used - not the group-wise
+   :meth:`~qiskit.circuit.QuantumCircuit.decompose` from :ref:`step 6 <flowsets_transpile>`.
+   That is what keeps the default column an honest baseline. Passing it the decomposed
    circuit would let it inherit the flow-set partitioning for free, and since Trotterizing a
-   set of *commuting* terms is exact, its fidelities would become identical to the flow-set
+   set of commuting terms is exact, its fidelities would become identical to the flow-set
    column's.
 
-   The flip side is that ``FlowSetSynthesis`` has to recover the flow sets itself, from the
+   The flip side is that ``FlowSetSynthesis`` has to recover the flow sets from the
    Pauli labels it is handed. That works here because the encoding gives each set a
    recognizable shape, but it is the less general route; the group-wise
-   :meth:`~qiskit.circuit.QuantumCircuit.decompose` works for *any* grouping, not just one a
-   synthesis plugin happens to be able to reverse-engineer.
+   :meth:`~qiskit.circuit.QuantumCircuit.decompose` works for *any* grouping, not just one that a 
+   synthesis plugin can reverse-engineer.
 
 .. warning::
    The :meth:`~qiskit.circuit.QuantumCircuit.decompose` call above is essential.
    :meth:`~qiskit.quantum_info.Statevector.evolve` and
    :class:`~qiskit.quantum_info.Operator` use a
    :class:`~qiskit.circuit.library.PauliEvolutionGate`'s *exact* definition and bypass a
-   custom synthesis entirely. Verifying against an un-decomposed circuit reports perfect
+   custom synthesis. Verifying against an un-decomposed circuit reports perfect
    fidelity even for a deliberately wrong synthesis.
 
 As a final cross-check, the site densities :math:`\langle n_j(t) \rangle = (1 - \langle
 V_j \rangle)/2` computed in the encoded space must reproduce the Jordan-Wigner result. This
-check is about the *encoding*, not the circuit, so no Trotter approximation enters it at
-all: both time evolutions are computed exactly, by matrix exponentiation of the respective
-Hamiltonians. Any discrepancy would therefore point at the encoding itself rather than at a
+check is about the *encoding*, not the circuit, so no Trotter approximation enters it: both time evolutions are computed exactly, by matrix exponentiation of the respective
+Hamiltonians. Any discrepancy would therefore point at the encoding rather than a
 product formula:
 
 .. plot::
@@ -1011,7 +1008,7 @@ What to take away
   :attr:`~.TransferVertexOperator.groups` attribute carries it into the circuit, where a
   single :meth:`~qiskit.circuit.QuantumCircuit.decompose` turns it into one
   :class:`.Evolution` gate per flow set.
-- **Ancillas buy structure.** Spending one extra qubit turned an entire flow set into
+- **Ancillas buy structure.** Spending one extra qubit turns an entire flow set into
   weight-1 Paulis, whose evolution needs no entangling gates. Ref. [1]_ observes this
   trade-off generally: larger qubit-to-fermion ratios admit shallower evolution circuits.
 - **A custom encoding is one function.** Map a single generalized transfer operator to a
@@ -1021,9 +1018,9 @@ What to take away
   set only slowed the linear growth in depth; a term-by-term synthesis of each set still
   threw away the fact that its terms commute. Only supplying a flow-set-aware
   :class:`~qiskit.synthesis.EvolutionSynthesis` made the depth constant. Custom encodings,
-  grouping and custom synthesis are complementary: all three are needed.
-- **Verify it.** An encoding that satisfies the commutation relations may still represent
-  a different Hamiltonian if a prefactor or sign is off. Checking an intertwining relation
+  grouping, and custom synthesis are complementary: all three are needed.
+- **Verify it.** An encoding that satisfies the commutation relations might still represent
+  a different Hamiltonian if a prefactor or sign is incorrect. Checking an intertwining relation
   (or, more cheaply, the spectrum) catches this.
 
 .. note::
@@ -1034,7 +1031,7 @@ What to take away
    :attr:`~.TransferVertexOperator.groups` and derive the diagonalizing Clifford from the
    stabilizer group, as described in Section IV C of Ref. [1]_.
 
-   Note also that delocalizing the parity makes the interaction term :math:`n_j n_{j+1}`
+   Also, delocalizing the parity makes the interaction term :math:`n_j n_{j+1}`
    weight-2 rather than diagonal in single qubits, which is the counterpart cost to the
    cheaper hopping terms.
 
@@ -1043,20 +1040,19 @@ What to take away
 Next: two dimensions
 --------------------
 
-Everything above is one-dimensional, and deliberately so: on a chain the flow sets are
+Everything above is one-dimensional, and deliberately so. On a chain, the flow sets are
 just the two arrow orientations, and the encoding needs a single ancilla. Neither
-simplification survives in two dimensions, which is where local encodings earn their
-keep.
+simplification survives in two dimensions, which is where local encodings are needed.
 
 On a planar lattice, a flow set is a directed path (or a union of vertex-disjoint directed
 paths) through the interaction graph, and finding a small set of such paths that covers
-every edge becomes a combinatorial problem in its own right rather than a two-line
-classification. The encodings also change character: instead of a single ancilla for the
+every edge becomes a combinatorial problem in its own right, rather than a two-line
+classification. The encodings also change character; instead of a single ancilla for the
 whole chain, they add one per lattice site or cell. Verstraete-Cirac pairs every fermionic
 site with its own auxiliary qubit, a qubit-to-mode ratio of :math:`2`, while Derby-Klassen places
-one at the center of each odd plaquette for a ratio of :math:`3/2`. The register layout then
+one at the center of each odd plaquette, for a ratio of :math:`3/2`. The register layout then
 has genuine two-dimensional structure, and the stabilizer group that must be projected onto
-is no longer trivial; the encoded Hamiltonian is only faithful on a *subspace*, which
+is no longer trivial. The encoded Hamiltonian is only faithful on a *subspace*, which
 changes both state preparation and the verification recipe from
 :ref:`step 4 <flowsets_verify>`.
 

--- a/docs/guides/2d_fermi_hubbard.rst
+++ b/docs/guides/2d_fermi_hubbard.rst
@@ -5,51 +5,49 @@ Simulate 2D Fermi-Hubbard dynamics with flow sets
 
 .. important::
 
-   The concepts in this guide are currently available only in the Python API.
+   The functionality described in this guide are currently available only in the Python API.
    Equivalent functionality will be made available via the C API in a future release.
 
 .. seealso::
    **Read the** :ref:`1D flow-set guide <1d_fermi_hubbard>` **first.** This guide is
-   its two-dimensional sequel and does not repeat the material developed there: transfer
+   its two-dimensional sequel and does not repeat the information developed there: transfer
    and vertex operators, what a flow set is, how :attr:`~.TransferVertexOperator.groups`
    survives into the circuit, and how a custom encoding is wired into the transpiler
-   through :class:`.MapperFnEvolutionSynthesis`. Only what *changes* in two dimensions is
-   spelled out below.
+   through :class:`.MapperFnEvolutionSynthesis`.
 
-   See also the :ref:`transpilation guide <transpilation_explanation>` for the transpiler
+   See the :ref:`transpilation guide <transpilation_explanation>` for the transpiler
    stages referenced throughout, and the :ref:`mappers guide <mappers_explanation>` for the
    general recipe for writing a custom mapper.
 
-The 1D guide closed by pointing at two dimensions as the place where local encodings earn
-their keep. This guide takes that step, for the **two-dimensional Fermi-Hubbard model on a
+The 1D guide ended by mentioning that local encodings are needed when working with two dimensions. This guide takes that step, for the **two-dimensional Fermi-Hubbard model on a
 square lattice**, using the **Verstraete-Cirac (VC) encoding** [2]_.
 
-Three things change, and they are the whole story:
+There are three differences from the 1D problem, forming the basis of this work:
 
-1. **The flow sets multiply.** A chain has two arrow orientations; a square lattice has
-   four (east, west, north, south), and each is a *union* of vertex-disjoint directed
+* **The flow sets multiply.** A chain has two arrow orientations; a square lattice has
+   four (east, west, north, south), and each is a union of vertex-disjoint directed
    paths (one per lattice row or column) rather than a single path.
-2. **The encoding gains an ancilla per site**, not one for the whole system, giving a
+* **The encoding gains an ancilla per site**, not one for the whole system, giving a
    qubit-to-mode ratio of :math:`2`. Transfer operators become weight-3 (horizontal) and
-   weight-4 (vertical) Paulis, and each of the four flow sets maps to its *own* Pauli
-   shape, so each needs its *own* diagonalizing Clifford.
-3. **The encoded Hamiltonian is only faithful on a subspace**: the joint :math:`+1`
+   weight-4 (vertical) Paulis, and each of the four flow sets maps to its own Pauli
+   shape, so each needs its own diagonalizing Clifford.
+* **The encoded Hamiltonian is only faithful on a subspace**: the joint :math:`+1`
    eigenspace of the plaquette constraints that every 2D local encoding carries [2]_ [3]_.
-   In 1D the encoding was a plain isometry and the verification was a spectrum check; here
-   the comparison has to be projected, as :ref:`step 9 <flowsets_2d_stabilizers>` works out.
+   In 1D the encoding was a plain isometry and the verification was a spectrum check. Here,
+   the comparison has to be projected, as :ref:`step 9 <flowsets_2d_stabilizers>` illustrates.
 
 The payoff is the same shape as in 1D: the two-qubit depth of one Trotter step becomes
 constant in the lattice size, at :math:`24` (:math:`16` for the hopping, matching
 Ref. [1]_, plus :math:`8` for the interaction), while a term-by-term Trotterization of the
-very same encoded Hamiltonian grows linearly. The gate count still grows with the number
+ same encoded Hamiltonian grows linearly. The gate count still grows with the number
 of bonds, of course; what becomes size-independent is how many layers those gates occupy.
 Depths throughout are counted on an abstract, fully connected register; mapping the encoding
-onto a device's restricted coupling map is its own problem, discussed at the end.
+onto a device's restricted coupling map is its own problem, which is discussed at the end.
 
 The lattice and its four orientations
 -------------------------------------
 
-The directed interaction graph is where the first of those three changes is visible. Sites
+The first change is visible on the directed interaction graph. Sites
 are numbered in row-major order, ``site(r, c) = r * cols + c``, and every bond carries both
 orientations, as the chain did in 1D, but now the bonds run along two axes:
 
@@ -102,18 +100,17 @@ orientations, as the chain did in 1D, but now the bonds run along two axes:
    <Figure size ... with 1 Axes>
 
 The commutation rule is the 1D one, unchanged: two transfer operators sharing a site
-**commute** when the arrows flow through it and **anticommute** when they clash. What the
-picture adds is that a site now has up to four incident bonds rather than two, so the
+**commute** when the arrows flow through it and **anticommute** when they clash. However, a site now has up to four incident bonds rather than two, so the
 arrows through it can clash in more ways, and a set of arrows that never clashes is no
 longer a single path. Reading the horizontal arrows left-to-right gives one such set, the
-vertical arrows top-to-bottom another, and reversing each gives two more: the east, west,
-north and south flow sets that organize everything below.
+vertical arrows from top-to-bottom gives another, and reversing each gives two more.  These are the east, west,
+north, and south flow sets that organize everything that follows.
 
 The Verstraete-Cirac encoding
 -----------------------------
 
-VC pairs every fermionic mode :math:`j` with its own auxiliary qubit. With :math:`N`
-lattice sites, mode :math:`j` lives on qubit :math:`j` and its ancilla on qubit
+Verstraete-Cirac (VC) pairs every fermionic mode :math:`j` with its own auxiliary qubit. With :math:`N`
+lattice sites, mode :math:`j` lives on qubit :math:`j` and its ancilla is on qubit
 :math:`N + j`, so the register holds :math:`2N` qubits. Vertex operators stay as simple as
 they can be,
 
@@ -130,34 +127,34 @@ site, and a vertical edge with :math:`j` the northern site,
    T_{jk}^{\text{horizontal}} = \tfrac{1}{2} X_j X_k Z_{N+j} \, , \qquad
    T_{jk}^{\text{vertical}}   = \tfrac{1}{2} X_j Y_k X_{N+j} Y_{N+k} \, ,
 
-a weight-3 "triangle" and a weight-4 "square". Which arrow each one is matters: with
-:math:`j` the western site, :math:`j \to k` points east, and with :math:`j` the northern
-site it points south. The reverse orientations follow from the identity
-:math:`T_{kj} = -V_j V_k T_{jk}`, which turns the ``XXZ`` triangle into a ``YYZ`` one and
+a weight-3 "triangle" and a weight-4 "square". Identifying each arrow matters: with
+:math:`j` as the western site, :math:`j \to k` points east, but with :math:`j` as the northern
+site, it points south. The reverse orientations follow from the identity
+:math:`T_{kj} = -V_j V_k T_{jk}`, which turns the ``XXZ`` triangle into ``YYZ``, and
 the ``XYXY`` square into ``YXXY``. Those four distinct labels are the four flow
-sets, and tracking them is what the rest of this guide does.
+sets, and the rest of this guide tracks them.
 
 .. note::
-   **These are not quite Eq. (A1) of Ref.** [1]_, which is stated "up to single-qubit
+   **These are not quite Eq. (A1) of Ref.** [1]_, which states "up to single-qubit
    rotations" and differs in three ways worth naming, since a reader checking the paper
    will notice:
 
-   * **The prefactor.** Eq. (A1) carries none. The :math:`\tfrac12` here is what makes
+   * **The prefactor:** Eq. (A1) carries none. The :math:`\tfrac12` here is what makes
      :math:`T_{jk}^2 = \tfrac14`, matching the normalization
      :math:`T_{jk} = -\tfrac12 (a^\dagger_j - a_j)(a^\dagger_k + a_k)` that
      :class:`.TransferVertexOperator` uses. The paper only ever needs its transfer
      operators inside :math:`\exp(-i\,dt\,H)`, where a scale factor is absorbed into the
      rotation angle; here they have to be *operators* that satisfy an identity.
-   * **Orientation.** Eq. (A1) selects letters by the row parity of :math:`j`, which for a
+   * **Orientation:** Eq. (A1) selects letters by the row parity of :math:`j`, which for a
      horizontal edge is the same for both endpoints, so it does not distinguish
      :math:`T_{jk}` from :math:`T_{kj}`. The paper recovers the orientation separately, by
      conjugating with a layer of :math:`R^Z(\pi/2)`. This guide instead folds it into the
      encoding, deriving the reverse from :math:`T_{kj} = -V_j V_k T_{jk}`, which is what
-     makes the two orientations land on visibly different Paulis in step 3.
-   * **The vertical shape.** Eq. (A1) alternates ``XXXX`` and ``YYYY`` by row parity, where
-     this guide uses a single ``XYXY``. These are two ways of getting the *same* thing: a
+     makes the two orientations land on different Paulis in step 3.
+   * **The vertical shape:** Eq. (A1) alternates ``XXXX`` and ``YYYY`` by row parity, where
+     this guide uses a single ``XYXY``. These are two ways of getting the same thing: a
      letter asymmetry that makes a vertical edge clash correctly with the horizontal edges
-     meeting it. Do not read the difference as a free basis choice: dropping the parity
+     meeting it. Do not read the difference as a free basis choice. Dropping the parity
      alternation and using a single ``XXXX`` breaks the algebra outright, which is why the
      distinct letters are checked rather than assumed.
 
@@ -170,9 +167,9 @@ sets, and tracking them is what the rest of this guide does.
 1. The Hamiltonian on a square lattice
 --------------------------------------
 
-The construction is the 1D one with a two-dimensional edge list. Sites keep the row-major
+The construction is the same as in 1D, but with a two-dimensional edge list. Sites keep the row-major
 numbering used for the figure above, ``site(r, c) = r * cols + c``, so that horizontal bonds
-connect consecutive indices and vertical bonds connect indices differing by ``cols``:
+connect consecutive indices, and vertical bonds connect indices differing by ``cols``:
 
 .. plot::
    :context:
@@ -217,7 +214,7 @@ vertical edges, and the sign of the difference picks the orientation. Everything
    **east** or **west** as it points right or left along a row, and **north** or **south** as
    it points up or down a column. Since the numbering runs row-major, east and south are the
    index-increasing directions. Nothing downstream depends on the names (they only label
-   groups), but four of them are easy to confuse, so it is worth fixing them against the
+   groups), but they are easy to confuse, so it is worth fixing them against the
    picture. Ref. [1]_ names its square-lattice flow sets the same way.
 
 .. plot::
@@ -265,13 +262,13 @@ disconnection is a gift rather than a complication, as step 6 shows.
 3. Encode the operator
 ----------------------
 
-The encoding is one function mapping a single generalized transfer operator to a Pauli
-string, handed to :func:`.map_transfer_vertex_generators`. Compared with the 1D version the
-body just has more cases: diagonal, horizontal, vertical, and the reverse orientations via
+The encoding is one function that maps a single generalized transfer operator to a Pauli
+string, which is handed to :func:`.map_transfer_vertex_generators`. Compared with the 1D version, the
+body has more cases: diagonal, horizontal, vertical, and the reverse orientations through 
 :math:`T_{kj} = -V_j V_k T_{jk}`.
 
-There is one wrinkle. :func:`.map_transfer_vertex_generators` calls back with a generator and
-nothing else, while deciding a bond's Pauli string also needs ``cols`` to recover row/column
+There is one problem. :func:`.map_transfer_vertex_generators` calls back with a generator and
+nothing else, while deciding a bond's Pauli string also needs ``cols`` to recover row and column
 coordinates from a mode index. Rather than nest the functions to close over it,
 :func:`functools.partial` binds it, which keeps both functions at the top level and
 independently callable.
@@ -333,7 +330,7 @@ independently callable.
    >>> num_qubits
    18
 
-The point of grouping before mapping shows up immediately: each flow set encodes to a
+The point of grouping before mapping can be seen immediately: each flow set encodes to a
 single Pauli shape, uniform across the whole set.
 
 .. plot::
@@ -352,24 +349,24 @@ single Pauli shape, uniform across the whole set.
    diagonal  ['', 'Z', 'ZZ']
 
 The four hopping shapes are distinct, so each flow set gets its own Clifford in
-:ref:`step 5 <flowsets_2d_synthesis>`. The reverse orientations are genuinely different
-Paulis, not the same ones relabeled; this is the concrete reason a 2D flow-set synthesis
-needs four circuits where the 1D one needed one.
+:ref:`step 5 <flowsets_2d_synthesis>`. The reverse orientations are different
+Paulis, not the same ones relabeled; this is the why a 2D flow-set synthesis
+needs four circuits, where the 1D synthesis needs one.
 
 .. plot::
    :context:
    :nofigs:
 
-   Guard the property the encoding actually has to satisfy, and which none of the visible
-   output pins down: the **mixed commutation relations**. Two transfer operators sharing a
+   Note the property the encoding actually has to satisfy, and which none of the visible
+   output illustrates: the **mixed commutation relations**. Two transfer operators sharing a
    site must commute when the arrows flow through it and anticommute when they clash, and
    :math:`T_{jk}^2 = \tfrac14` must hold for the normalization to be right. Every printed
    Pauli shape above can stay correct while these are violated (the shapes only say which
    letters appear, not whether the parities work out), so a plausible-looking edit to the
-   encoding can silently produce an operator algebra that is not the fermionic one.
+   encoding can silently produce a non-fermionic operator.
 
-   Checked on :math:`3 \times 3`, which has an interior site of degree 4 and vertically
-   stacked edges, over both orientations of every bond. This is what makes the distinct
+   Checked on :math:`3 \times 3`, which has an interior site of degree four and vertically
+   stacked edges, over both orientations of every bond. This makes the distinct
    letters in ``XYXY`` load-bearing rather than cosmetic: replacing it with ``XXXX`` keeps
    all four printed shapes plausible but fails 32 of these 88 pairs.
 
@@ -470,7 +467,7 @@ single ancilla.
    >>> flow_set_circuit.count_ops()["Evolution"]
    5
 
-Five gates, carrying the 6, 6, 6, 6 and 22 terms counted in step 2. Each is mapped and
+Five gates, carrying the 6, 6, 6, 6, and 22 terms counted in step 2. Each is mapped and
 synthesized independently, so the partition decided at the fermionic level survives all the
 way into the circuit:
 
@@ -501,23 +498,23 @@ depth grows with the lattice.
 5. A depth-2 Clifford per flow set
 ----------------------------------
 
-The mechanism is the 1D one: conjugate a whole commuting flow set by a Clifford that maps
-every one of its terms to a distinct weight-1 Pauli, so that the evolution of the entire
-set costs only single-qubit rotations. In 1D one brickwork of ``CZ`` gates did this.
+The mechanism is the same as in 1D: conjugate a whole commuting flow set by a Clifford that maps
+each of its terms to a distinct weight-1 Pauli, so that the evolution of the entire
+set costs only single-qubit rotations. In 1D, one brickwork of ``CZ`` gates did this.
 
-In 2D each flow set needs its own circuit, following Section IV C and Fig. 7 of Ref. [1]_.
+In 2D, each flow set needs its own circuit, following Section IV C and Fig. 7 of Ref. [1]_.
 All four act on one line of the lattice at a time (a row for east/west, a column for
 north/south) together with that line's ancillas, and all four have the same three-part
 shape:
 
-1. a layer of single-qubit rotations, putting each qubit in the basis its flow set needs;
-2. a first ``CX`` layer, always site-to-ancilla on the same site;
-3. a second ``CX`` layer, coupling neighbors along the line.
+1. A layer of single-qubit rotations, putting each qubit in the basis its flow set needs.
+2. A first ``CX`` layer, always site-to-ancilla on the same site.
+3. A second ``CX`` layer, coupling neighbors along the line.
 
-Steps 2 and 3 are the only two-qubit layers, so the two-qubit depth is :math:`2` regardless
+Steps 2 and 3 are the only two-qubit layers, so the two-qubit depth is :math:`2`, regardless
 of how long the line is. They are written out one function per flow set below. The
 rotations are what they are because they were found, by conjugating each flow set's
-terms and requiring distinct weight-1 images, so treat them as given and lean on the
+terms and requiring distinct weight-1 images, so treat them as given and rely on the
 check that follows.
 
 The two horizontal sets are the simplest. Their terms are weight-3, ``XXZ`` and ``YYZ``, and
@@ -597,9 +594,9 @@ alternates too, coupling sites on even positions and ancillas on odd ones (or th
    ...             circuit.cx(ancilla(j), ancilla(k))
 
 Drawn on a single three-site line (its sites first, then their ancillas) the whole
-mechanism fits in one picture. The triangle shape is the plainer of the two: a basis change
-on the ancillas, then two ``CX`` layers, the first pairing each site with its own ancilla
-and the second reaching to the next site along the line.
+mechanism fits in one picture. The triangle shape is the clearer of the two: a basis change
+on the ancillas, then two ``CX`` layers, the first pairs each site with its own ancilla
+and the second reaches to the next site along the line.
 
 .. plot::
    :context: close-figs
@@ -631,12 +628,12 @@ Both are two ``CX`` layers deep, and adding sites to the line widens them withou
 them; that is the whole constant-depth claim, visible by inspection. The west and north
 Cliffords differ only in their single-qubit layers, so they are not drawn separately.
 
-What the synthesis still needs is where each term ends up. A line of :math:`L` sites carries
+What the synthesis still needs is determining where each term ends up. A line of :math:`L` sites carries
 :math:`L - 1` bonds, each contributing one term, so the helper below returns one entry per
-bond: the qubit that term lands on, and the single-qubit Pauli it became. Crucially these are
-read off the conjugation rather than predicted: unlike 1D, where one ``CZ`` brickwork
+bond: the qubit that the term landed on, and the single-qubit Pauli it became. Crucially, these are
+read off the conjugation rather than predicted.  Unlike 1D, where one ``CZ`` brickwork
 maps :math:`X_{j+1} \mapsto Z_j X_{j+1} Z_{j+2}` in closed form, there is no such formula
-here, and the ancillas of a column line are not even contiguous. The only thing that differs
+here, and the ancillas of a column line are not contiguous. The only thing that differs
 between the flow sets is the Pauli string going in, which step 3 already printed:
 
 .. plot::
@@ -667,28 +664,27 @@ between the flow sets is the Pauli string going in, which step 3 already printed
    ...     return supports
 
 
-The images must come out distinct as well as weight-1, so that each term can be rotated
+The images must come out distinct and weight-1, so that each term can be rotated
 independently on its own qubit; the two-qubit depth of :math:`2` is already visible in the
-four constructions above, each emitting exactly two ``CX`` layers whatever the line length.
-Both properties are checked below across every flow set, every line and several lattice
-sizes. Step 6 then calls ``clifford_supports`` for real, so it is a working part of the
+four constructions above, each emitting two ``CX`` layers irrespective of the line length.
+Below, both properties are checked across every flow set, every line, and several lattice
+sizes. Step 6 then calls ``clifford_supports``, so it is a working part of the
 synthesis rather than only a demonstration.
 
 .. plot::
    :context:
    :nofigs:
 
-   Nothing above actually runs the four Cliffords, so pin their two claims here: two-qubit
-   depth 2, and distinct weight-1 images. Both are what the constant-depth result rests on, and
-   both are swept over every flow set, every line of a lattice, and several sizes; a slip that
-   put a rotation on the site where it belonged on the ancilla would survive a single-line spot
-   check but break a longer one.
+   Nothing above actually runs the four Cliffords, so note their two claims here: two-qubit
+   depth 2, and distinct weight-1 images. The constant-depth result rests on those claims, and
+   both are swept over every flow set, every line of a lattice, and several sizes. Thus, if a rotation was put on the site where it belonged on the ancilla, it would pass a single-line spot
+   check but fail a longer one.
 
-   Consider what this does not pin, deliberately. Exchanging a control and target in one of the
-   second ``CX`` layers still diagonalizes the flow set (the terms simply land on the
+   Consider what this does not claim, deliberately. Exchanging a control and target in one of the
+   second ``CX`` layers still diagonalizes the flow set (the terms land on the
    ancillas instead of the sites) and the synthesis stays correct, because
    ``clifford_supports`` reads the supports off the conjugation rather than assuming them.
-   There is more than one valid Clifford here, and the sweep is checking the property that
+   There is more than one valid Clifford here, and the sweep checks the property that
    matters (distinct, weight-1, constant depth) rather than one particular circuit.
 
    >>> def cliffords_are_depth_two_and_distinct(rows, cols):
@@ -732,7 +728,7 @@ cheaper than one might fear:
 
 .. important::
    The components of a single flow set are vertex-disjoint: the west set's rows share
-   no qubit. So all of a flow set's Cliffords can be emitted together and they share the
+   no qubits. So all of a flow set's Cliffords can be emitted together and they share the
    same two two-qubit layers, rather than queueing up one row after another. A flow set
    therefore costs a fixed number of layers (two for the Clifford and two for its inverse)
    no matter how many rows or columns the lattice has, which is why the total
@@ -863,8 +859,8 @@ As in 1D, this is deliberately written for this encoding: it recognizes the four
 shapes and raises on anything else rather than falling back silently. It also assumes the
 one-flow-set-per-gate split above, and says so; more than one hopping shape in a single
 gate means the grouping was not applied, which is an error rather than something to work
-around. ``reps`` is here for the same reason as in 1D: a product formula is where the number
-of Trotter steps belongs, as in Qiskit's own :class:`~qiskit.synthesis.LieTrotter`.
+around. ``reps`` is here for the same reason as in 1D: the number
+of Trotter steps belongs in a product formula, as in Qiskit's own :class:`~qiskit.synthesis.LieTrotter`.
 
 7. The result: constant depth
 -----------------------------
@@ -919,21 +915,21 @@ edge makes the difference plain:
    <Figure size ... with 2 Axes>
 
 The two-qubit depth is 24 and constant from :math:`3 \times 3` to :math:`8 \times 8`
-(that is 18 qubits up to 128) while :class:`~qiskit.synthesis.LieTrotter` applied to
-the identical encoded Hamiltonian grows linearly with the lattice edge, from 47 to 92. The
+(that is 18 qubits up to 128), while :class:`~qiskit.synthesis.LieTrotter` applied to
+the identically encoded Hamiltonian grows linearly with the lattice edge, from 47 to 92. The
 gate count grows under both, since there are :math:`O(N)` terms to apply either way; what
 the flow sets remove is the growth in how many layers those gates occupy.
 
-The budget splits cleanly into 16 for the hopping and 8 for the interaction:
+The budget splits into 16 for the hopping and eight for the interaction:
 
 * Each of the four flow sets costs :math:`2 + 2` two-qubit layers: its Clifford going in
-  and the inverse coming out, both depth 2 by construction, with only single-qubit rotations
+  and the inverse coming out, both depth two by construction, with only single-qubit rotations
   in between. That is :math:`4 \times 4 = 16`, which is the figure Ref. [1]_ quotes,
   since it counts the hopping terms only. Setting :math:`U = 0` in the code above reproduces
   it.
-* The diagonal group adds the remaining 8. Its ``Rzz`` gates pack into four layers, and each
-  ``Rzz`` decomposes into two ``CX`` around a single-qubit rotation, so :math:`4 \times 2 = 8`.
-  Four layers is optimal: on a square lattice the interaction reaches only nearest
+* The diagonal group adds the remaining eight. Its ``Rzz`` gates pack into four layers, and each
+  ``Rzz`` decomposes into two ``CX`` gates around a single-qubit rotation, so :math:`4 \times 2 = 8`.
+  Four layers is optimal: on a square lattice, the interaction reaches only nearest
   neighbors, so every interior site carries four ``Rzz`` gates (one per bond) and can
   take part in only one at a time.
 
@@ -1008,7 +1004,7 @@ Random statevectors detect any discrepancy far more cheaply than building the fu
    ``rows`` and ``cols``, or between a row line and a column line, can cancel out on
    :math:`3 \times 3` and still be wrong everywhere else. Repeat the check on the two
    rectangular lattices, which are transposes of each other, so the row and column paths are
-   exercised at genuinely different lengths.
+   exercised at different lengths.
 
    >>> all(agrees_up_to_one_phase(r, c) == (True, True) for r, c in [(2, 3), (3, 2)])
    True
@@ -1025,7 +1021,7 @@ Random statevectors detect any discrepancy far more cheaply than building the fu
 9. Verify the physics on the stabilizer subspace
 ------------------------------------------------
 
-This is the genuinely two-dimensional wrinkle. In 1D the encoding was an isometry, and
+This is the two-dimensional wrinkle. In 1D, the encoding was an isometry, and
 comparing spectra against a Jordan-Wigner reference was enough. VC is not an isometry: it
 uses :math:`2N` qubits for :math:`N` modes, so a :math:`2^{2N}`-dimensional space holds a
 :math:`2^N`-dimensional physical one. This is generic to local encodings in two dimensions
@@ -1117,12 +1113,11 @@ no :math:`2^{18} \times 2^{18}` matrices required:
    True True
    True True
 
-With the stabilizers in hand the comparison needs no basis correspondence at all, because
+With the stabilizers in hand, the comparison needs no basis correspondence, because
 :math:`V_j = Z_j` means the occupations live on the same physical qubits in both
 pictures. So: write a product state directly on the physical qubits with the ancillas in
 :math:`|0\rangle`, project it onto the stabilizer subspace, evolve with the encoded
-Hamiltonian, and read the site densities :math:`\langle n_j \rangle = (1 - \langle Z_j
-\rangle)/2` off both sides.
+Hamiltonian, and read the site densities :math:`\langle n_j \rangle = (1 - \langle Z_j \rangle)/2` off both sides.
 
 Every step here stays at the level of a vector. The projector is applied one
 :math:`(1 + S)/2` factor at a time instead of being multiplied out, and the time evolution
@@ -1209,10 +1204,10 @@ What to take away
   interaction group.
 - **Each orientation is its own Pauli shape.** :math:`T_{kj} = -V_j V_k T_{jk}` turns
   ``XXZ`` into ``YYZ`` and ``XYXY`` into ``YXXY``, so the four flow sets need four
-  Cliffords. Assuming one Clifford covers both orientations of an axis is the easiest way to
+  Cliffords. Assuming that one Clifford covers both orientations of an axis is the easiest way to
   get a 2D flow-set synthesis wrong.
-- **Read supports off the conjugation.** In 1D one ``CZ`` brickwork gives the images in
-  closed form; in 2D there is no such formula, and column lines have non-contiguous ancillas,
+- **Read supports off the conjugation.** In 1D, one ``CZ`` brickwork gives the images in
+  closed form. In 2D there is no such formula, and column lines have non-contiguous ancillas,
   so a hand-derived guess at where each term lands is fragile. Conjugating and inspecting the
   result costs one :class:`~qiskit.quantum_info.Clifford` construction and cannot be wrong;
   it also means an equally valid Clifford that lands the terms elsewhere keeps working.
@@ -1222,13 +1217,13 @@ What to take away
   and raising when it does not hold, is what keeps ``synthesize`` short.
 - **Verify on the subspace.** A :math:`2N`-qubit encoding of :math:`N` modes is faithful
   only where the stabilizers say it is. Because VC keeps :math:`V_j = Z_j`, the cheapest
-  honest check is to project a product state and compare densities: no intertwiner and
-  no spectral matching, which is unreliable anyway when the restricted Hamiltonian is
+  reliable check is to project a product state and compare densities: no intertwiner and
+  no spectral matching, which is unreliable when the restricted Hamiltonian is
   degenerate.
 
 .. note::
    The encoded Hamiltonian commutes with the stabilizers, so the projection only has to be
-   applied to the initial state: the evolution preserves the subspace by itself. On real
+   applied to the initial state. The evolution preserves the subspace by itself. On real
    hardware this is also what makes the encoding useful as an error-detection resource:
    the stabilizers can be measured.
 
@@ -1241,7 +1236,7 @@ its diagonalizing Cliffords in closed form, but Derby-Klassen spends one ancilla
 plaquette instead of one per site, for a qubit-to-mode ratio of :math:`3/2` rather than
 :math:`2`. Its transfer operators have different Pauli shapes, so a port amounts to
 rewriting the encoding function of :ref:`step 3 <flowsets_2d_encoding>` and finding
-the Clifford for each new shape; the grouping, the layout and the synthesis scaffolding
+the Clifford for each new shape; the grouping, the layout, and the synthesis scaffolding
 carry over untouched.
 
 The second is the lattice itself. Everything here assumes open boundaries and a single
@@ -1261,9 +1256,9 @@ that two dimensions makes bigger.
    counted in that setting. Real devices have a restricted coupling map, and mapping this
    encoding onto one is a substantial problem in its own right: the VC register is a
    :math:`2N`-qubit graph whose gates run between a site and its own ancilla, between
-   neighboring sites, and between neighboring ancillas, so a layout has to keep all three
-   kinds of pair adjacent at once. If it cannot, the transpiler inserts ``SWAP`` gates, and
-   the layers they add are exactly what the constant-depth construction was buying back.
+   neighboring sites and between neighboring ancillas, so a layout has to keep all three
+   kinds of pairs adjacent simultaneously. If it cannot, the transpiler inserts ``SWAP`` gates, and
+   the layers they add are what the constant-depth construction was buying back.
    Ref. [1]_ likewise quotes its depth figure under an assumed square connectivity graph with
    ``CX`` as the only native entangler. Finding good layouts and routing strategies for local
    encodings on a given device topology is beyond this guide's scope.

--- a/docs/guides/circuit.rst
+++ b/docs/guides/circuit.rst
@@ -5,7 +5,7 @@ Work with fermionic circuits
 
 .. important::
 
-   The concepts in this guide are currently available only in the Python API.
+   The functions described in this guide are currently available only in the Python API.
    Equivalent functionality will be made available through the C API in a future
    release.
 
@@ -58,15 +58,14 @@ For example, you can implement time evolution for any operator implementing the
 Build a fermionic circuit
 -------------------------
 
-The example below implements the time evolution discussed in the previous section.
+The example below implements the time evolution described in the previous section.
 It constructs a :class:`.FermionicCircuit` by specifying the number of fermionic
 modes, then adds fermionic gates from the :mod:`qiskit_fermions.circuit.library`
 to implement the time evolution.
 
 The example also demonstrates how to incorporate domain knowledge into an
-operator by using :ref:`operator term grouping <grouping_explanation>`. By assigning group indices to the Hamiltonian terms, structural information is
-information that optimization passes can exploit throughout the transpilation
-stack.
+operator by using :ref:`operator term grouping <grouping_explanation>`. By assigning group indices to the Hamiltonian terms, optimization passes can use that information throughout the transpilation
+stack, making it *structural information*. 
 
 .. tab-set::
 
@@ -107,14 +106,14 @@ stack.
          // The C API for FermionicCircuit is not available yet.
 
 .. plot::
-   :alt: A simple FermionicCircuit with a single time evolution gate.
+   :alt: A simple `FermionicCircuit` with a single time evolution gate.
    :context: close-figs
 
    >>> circuit.draw("mpl", fold=-1)
    <Figure size ... with 1 Axes>
 
 .. plot::
-   :alt: A decomposed FermionicCircuit with several time evolution gates.
+   :alt: A decomposed `FermionicCircuit` with several time evolution gates.
    :context: close-figs
 
    >>> circuit.decompose().draw("mpl", fold=-1)
@@ -140,7 +139,7 @@ Next steps
   documentation.
 - Explore the :ref:`operators explanation guide <operators_explanation>` to understand
   how to construct fermionic Hamiltonians that you can use with fermionic circuits.
-- Review the :ref:`SQDRIFT <sqdrift_getting_started>` getting-started guide for a practical
+- Review the :ref:`SQDRIFT <sqdrift_getting_started>` getting started guide for a practical
   end-to-end example.
 - Read the :ref:`ffsim backend guide <ffsim_backend_explanation>` to understand how a
   :class:`.FermionicCircuit` can be simulated directly, and how these generic mode indices take on

--- a/docs/guides/ffsim.rst
+++ b/docs/guides/ffsim.rst
@@ -5,15 +5,15 @@ The ffsim simulation backend
 
 .. important::
 
-   The concepts in this guide are currently available only in the Python API.
+   The functions described in this guide are currently available only in the Python API.
    Equivalent functionality will be made available through the C API in a future
    release.
 
 The :ref:`getting-started guides <lucj_getting_started>` simulate fermionic circuits and
 Hamiltonians with `ffsim`_, calling :func:`ffsim.apply_unitary`, :func:`ffsim.linear_operator`, or
-:func:`ffsim.sample_state_vector` directly on :class:`.FermionicCircuit`\ s and
-:class:`.FermionOperator`\ s. This guide explains why that works and what is actually happening
-underneath: this package couples deliberately with ffsim's simulation protocols rather than
+:func:`ffsim.sample_state_vector` directly on :class:`.FermionicCircuit`\ objects and
+:class:`.FermionOperator`\ objects. This guide explains why that works and what is happening
+underneath. This package couples deliberately with ffsim's simulation protocols rather than
 building its own simulation API, and it does so in a way that keeps a native (scipy-only)
 simulation path available for users who cannot or do not want to install ffsim.
 
@@ -21,24 +21,24 @@ Why couple with ffsim
 ---------------------
 
 `ffsim`_ is a high-performance simulator for fermionic quantum circuits that exploits
-particle-number and spin-Z conservation to represent state vectors far more compactly than a
-generic :math:`2^n`-dimensional qubit statevector. It defines two small protocols that any object
+particle number and spin-Z conservation to represent state vectors more compactly than a
+generic :math:`2^n`-dimensional qubit statevector. It defines two protocols that any object
 can implement to participate in its simulation machinery (see :mod:`qiskit_fermions.protocols`
 for this package's own protocols, which follow the same design):
 
-- :class:`ffsim.SupportsApplyUnitary`, via a method ``_apply_unitary_(vec, norb, nelec, copy)``
-  applying the object as a unitary to a fixed-particle-number state vector, and
-- :class:`ffsim.SupportsLinearOperator`, via a method ``_linear_operator_(norb, nelec)`` returning a
+- :class:`ffsim.SupportsApplyUnitary`, by the method ``_apply_unitary_(vec, norb, nelec, copy)``,
+  applying the object as a unitary to a fixed-particle-number state vector
+- :class:`ffsim.SupportsLinearOperator`, by the method ``_linear_operator_(norb, nelec)``, returning a
   :class:`scipy.sparse.linalg.LinearOperator` view of the object on that same sector.
 
 Rather than invent a separate simulation interface, every fermionic gate in
-:mod:`qiskit_fermions.circuit.library` and :class:`.FermionOperator` implement these exact
-protocols. The direct payoff is that ffsim's own tools work natively on this package's objects,
-with no conversion step: :func:`ffsim.apply_unitary` can simulate a :class:`.FermionicCircuit`
+:mod:`qiskit_fermions.circuit.library` and :class:`.FermionOperator` implement these 
+protocols. The direct payoff is that ffsim's tools work natively on this package's objects,
+with no conversion step, :func:`ffsim.apply_unitary` can simulate a :class:`.FermionicCircuit`
 end to end, :func:`ffsim.linear_operator` (or plain :func:`scipy.sparse.linalg.eigsh`) can
 diagonalize a :class:`.FermionOperator`, and sampling utilities like
 :func:`ffsim.sample_state_vector` (used in the :ref:`SKQD guide <skqd_getting_started>` to turn a
-simulated statevector into measurement counts) work out of the box.
+simulated statevector into measurement counts) work without modification.
 
 .. plot::
    :context:
@@ -68,8 +68,8 @@ simulated statevector into measurement counts) work out of the box.
    ...     reference = ffsim.hartree_fock_state(norb, nelec)
    ...     state = ffsim.apply_unitary(reference, circuit, norb=norb, nelec=nelec)  # native ffsim call
 
-This is the concrete reason for coupling with ffsim's protocols rather than, say, only offering a
-bespoke ``simulate()`` method: it lets ffsim's existing, actively developed ecosystem of simulation
+This is the reason for coupling with ffsim's protocols rather than only offering a
+bespoke ``simulate()`` method. It lets ffsim's existing, actively developed ecosystem of simulation
 and sampling utilities apply to this package's circuits and operators unchanged, and it lets users
 already working with ffsim mix in this package's gates and operators without learning a second
 simulation API.
@@ -79,19 +79,19 @@ A native path when ffsim is unavailable
 
 Coupling with ffsim's protocols does not make ffsim a hard dependency. `ffsim`_ transitively
 depends on `PySCF <https://pyscf.org/>`_, which does not support Windows, so ffsim is declared as
-an optional extra (``pip install "qiskit-fermions[simulation]"``, or transitively via ``[all]``),
-guarded at runtime by :data:`~qiskit_fermions.utils.optionals.HAS_FFSIM` (as you already saw above).
-On Windows, that extra simply resolves to nothing (a silent no-op via a ``sys_platform`` marker),
+an optional extra (``pip install "qiskit-fermions[simulation]"``, or transitively by ``[all]``),
+guarded at runtime by :data:`~qiskit_fermions.utils.optionals.HAS_FFSIM` (as was shown above).
+On Windows, that extra resolves to nothing (a silent no-op through a ``sys_platform`` marker),
 rather than an install failure.
 
 Simulation must still work without ffsim, so :class:`.SupportsLinearOperator` is backed
 by an independent native Rust FCI (full configuration interaction) kernel, not a wrapper
-around ffsim's own linear-algebra routines. It compiles an operator's terms once into a scatter map
+around ffsim's linear algebra routines. It compiles an operator's terms into a scatter map
 over the fixed-particle-number determinant basis, then reuses that compiled form across repeated
-matrix-vector products. This is the protocol method ffsim itself expects
-(:class:`ffsim.SupportsLinearOperator`): it happens to be implemented without ffsim, and it is
-cross-checked against ffsim's own matrix elements in this package's test suite, but it does not call
-into ffsim at all. Handing a :class:`.FermionOperator` to :func:`scipy.sparse.linalg.eigsh` or
+matrix-vector products. This is the protocol method ffsim expects
+(:class:`ffsim.SupportsLinearOperator`): it is implemented without ffsim, and it is
+cross-checked against ffsim's matrix elements in this package's test suite, but it does not call
+into ffsim. Handing a :class:`.FermionOperator` to :func:`scipy.sparse.linalg.eigsh` or
 :func:`scipy.sparse.linalg.expm_multiply` (as :meth:`.Evolution._apply_unitary_placed_` does
 internally) therefore works identically whether or not ffsim is installed:
 
@@ -108,19 +108,19 @@ internally) therefore works identically whether or not ffsim is installed:
    >>> print(f"ground-state energy: {energy[0]:.6f}")
    ground-state energy: -0.500000
 
-Some gates go further and branch on :data:`~qiskit_fermions.utils.optionals.HAS_FFSIM` at simulate
-time purely for performance: :class:`.OrbitalRotation` is one example, whose ``_apply_unitary_``
+Some gates go further and branch on :data:`~qiskit_fermions.utils.optionals.HAS_FFSIM` at simulation
+time for performance. :class:`.OrbitalRotation` is one example, whose ``_apply_unitary_``
 implementation delegates to ffsim's dedicated Givens-rotation kernel
 (:func:`ffsim.apply_orbital_rotation`) when ffsim is installed, and otherwise falls back to
 expressing the rotation as :math:`\exp(G)` for a one-body generator :math:`G` and applying that
 through the same native-kernel-plus-:func:`~scipy.sparse.linalg.expm_multiply` path used throughout
 this section. Both paths implement the same protocol method and produce the same result; ffsim is
-a performance choice here, not a correctness dependency. Gates without such a fast path
-(:class:`.Evolution`, and everything built out of it, such as :class:`.UCJ`) simply use the
+a performance choice, not a correctness dependency. Gates without such a fast path
+(:class:`.Evolution`, and everything built out of it, such as :class:`.UCJ`) use the
 ffsim-independent path unconditionally.
 
-In short: ffsim's protocols are the interface; ffsim itself is an accelerator you can uninstall.
-This is also why the two getting-started guides that use ffsim directly (:ref:`LUCJ
+In short: ffsim's protocols are the interface; ffsim is an accelerator you can uninstall.
+This is also why the two getting started guides that use ffsim directly (:ref:`LUCJ
 <lucj_getting_started>` and :ref:`SKQD <skqd_getting_started>`) internally guard their ffsim-specific
 code with :data:`~qiskit_fermions.utils.optionals.HAS_FFSIM` the same way this guide does.
 
@@ -132,10 +132,10 @@ vector over the *fixed-particle-number determinant basis* for that ``(norb, nele
 mirroring ffsim's (and, transitively, PySCF's) FCI space setup, rather than the full
 :math:`2^{\text{num\_modes}}`-dimensional space a general qubit simulator would use. This is a much
 smaller space (its size is a product of binomial coefficients rather than a power of two), but it
-comes with a hard restriction: only operators and gates that **preserve** particle number (and, in
+comes with a hard restriction: only operators and gates that preserve particle number (and, in
 the spinful case, each spin species' particle number individually) can be represented in it. An
-operator whose action would move amplitude to a different particle number simply has nowhere to go
-in this fixed-sector picture.
+operator whose action would move amplitude to a different particle number has nowhere to go
+in this fixed-sector situation.
 
 The native kernel resolves this by silently dropping any term that would leave the sector, projecting
 its contribution to zero rather than raising an error, since the kernel's contract is "matrix-vector
@@ -143,7 +143,7 @@ product on this sector," not "validate this operator." For most callers this dro
 wrong thing: applying :math:`\exp(-i t H)` for a Hamiltonian :math:`H` with a
 non-particle-conserving term would silently turn a would-be unitary into a non-unitary,
 physically-meaningless map. So the higher-level entry points that build a unitary out of the kernel
-add an explicit guard before ever calling it:
+add an explicit guard before calling it:
 
 - :class:`.Evolution` checks :meth:`.FermionOperator.conserves_sector` and raises a
   :class:`ValueError` if the operator does not conserve the ``(norb, nelec)`` sector.
@@ -171,39 +171,37 @@ add an explicit guard before ever calling it:
    ...     print("rejected:", exc)
    rejected: Evolution requires an operator that conserves the (norb, nelec) sector: every term must preserve the particle number of each spin species (norb=2, nelec=(1, 1)).
 
-Calling :meth:`.SupportsLinearOperator._linear_operator_` *directly* on a non-conserving operator bypasses
+Calling :meth:`.SupportsLinearOperator._linear_operator_` directly on a non-conserving operator bypasses
 this guard (it is a lower-level building block, not a validated simulation entry point) and will
 return a matrix-vector product that silently zeroes the non-conserving amplitude rather than raising.
 
 The practical consequence is that non-particle-preserving simulation is not possible in fermionic
-space at all, by construction of the fixed-sector representation: not as a missing feature, but
-as the price of the compact FCI-space representation that makes fermionic simulation tractable in
-the first place. If your algorithm genuinely needs particle-number-violating operators (for example,
+space, by construction of the fixed-sector representation: not as a missing feature, but
+as the price of the compact FCI-space representation that makes fermionic simulation tractable. If your algorithm needs particle-number-violating operators (for example,
 a qubit-native error channel, or an operator built for a mapped Hamiltonian that does not conserve
-particle number term by term), transpile to qubits first and simulate the resulting
-:class:`~qiskit.circuit.QuantumCircuit` with a qubit-level simulator instead, which has no such
-restriction. Any transpilation route works for this; the
+particle numbers term by term), transpile to qubits first and simulate the resulting
+:class:`~qiskit.circuit.QuantumCircuit` with a qubit-level simulator instead. Any transpilation route works for this; the
 :ref:`fermionic circuit <fermionic_circuit_explanation>` and :ref:`transpilation
 <transpilation_explanation>` guides go into more detail, but
 :func:`~qiskit_fermions.transpiler.presets.generate_preset_jw_pass_manager` is a reasonable default
-choice to reach for.
+choice.
 
 The block-spin convention for spinful systems
 ---------------------------------------------
 
 ``nelec`` is typed ``int | tuple[int, int]``, and its type, not a separate flag, is what selects
-between the two supported mode layouts:
+one of the two supported mode layouts:
 
-- an **int** selects the **spinless** interpretation: the ``norb`` modes are treated directly as
-  spinless orbitals, and ``nelec`` is simply the total particle count.
-- a **pair** ``(n_alpha, n_beta)`` selects the **spinful** interpretation of ``2 * norb`` modes under
+- An **int** selects the **spinless** interpretation: the ``norb`` modes are treated directly as
+  spinless orbitals, and ``nelec`` is the total particle count.
+- A **pair** ``(n_alpha, n_beta)`` selects the **spinful** interpretation of ``2 * norb`` modes under
   a fixed **block-spin convention**: modes ``0 .. norb`` are the alpha (spin-up) orbitals and modes
   ``norb .. 2 * norb`` are the beta (spin-down) orbitals. Each spin species is conserved
   *independently*: an alpha-only term can move an electron between alpha modes but never into a
   beta mode, and vice versa.
 
 This dispatch happens at every ffsim-protocol entry point in this package (gate constructors,
-``_apply_unitary_placed_`` implementations, and the native Rust kernel's own sector compilation),
+``_apply_unitary_placed_`` implementations, and the native Rust kernel's sector compilation),
 and it is the convention used throughout the :ref:`LUCJ <lucj_getting_started>` and
 :ref:`SKQD <skqd_getting_started>` guides (for example,
 :meth:`.InitializeModes.from_hartree_fock` fills alpha occupations into modes ``0 .. n_alpha`` and
@@ -229,14 +227,14 @@ Next steps
 ^^^^^^^^^^
 
 - Walk through the :ref:`LUCJ <lucj_getting_started>` guide to see this backend used end to end,
-  including the pure-scipy path (via :func:`ffsim.linear_operator`, itself backed by the same
+  including the pure-scipy path (through the :func:`ffsim.linear_operator`, itself backed by the same
   ``_linear_operator_`` protocol method described here) for evaluating an ansatz's energy.
 - Walk through the :ref:`SKQD <skqd_getting_started>` guide to see :func:`ffsim.apply_unitary` and
   :func:`ffsim.sample_state_vector` used together to sample circuits built from this package's gates.
 - Read the :ref:`fermionic circuit guide <fermionic_circuit_explanation>` for the generic,
   spin-agnostic mode indexing used outside of simulation calls.
 - Read the :ref:`transpilation guide <transpilation_explanation>` for how to leave fermionic space
-  entirely and simulate on qubits, which is required for non-particle-conserving operators.
+   and simulate on qubits, which is required for non-particle-conserving operators.
 - Browse :mod:`qiskit_fermions.protocols` for the full catalog of protocols this package defines,
   including the conversion protocols (:class:`.SupportsFermionOperator`,
   :class:`.SupportsMajoranaOperator`) that are unrelated to ffsim.

--- a/docs/guides/grouping.rst
+++ b/docs/guides/grouping.rst
@@ -17,10 +17,10 @@ or problem-specific symmetries), you can unlock several benefits:
 
 - **Optimized circuit synthesis**: Grouped terms carry problem-specific
   information through the stack, enabling simpler optimization of the
-  synthesized circuits, resulting in reduced circuit depth and gate count.
+  synthesized circuits. This results in reduced circuit depth and gate count.
 
 - **Physical structure preservation**: Groups encode meaningful structure from the
-  original problem (for example, interaction patterns or symmetries), that can be exploited
+  original problem (for example, interaction patterns or symmetries) that can be exploited
   for more physically meaningful decompositions.
 
 - **Flow set selection**: Grouping can naturally encode flow sets and other graph-theoretic
@@ -44,7 +44,7 @@ according to the *line flow sets* as shown in Figure 1c of [1]_.
    group indices accordingly.
 
 .. plot::
-   :alt: A simple directed graph on which we define our MajoranaOperator.
+   :alt: A simple directed graph on which we define our `MajoranaOperator`.
    :context: close-figs
    :include-source:
 
@@ -65,7 +65,7 @@ according to the *line flow sets* as shown in Figure 1c of [1]_.
     <Figure size ... with 1 Axes>
 
 This is a simple two-by-three lattice of Majorana modes connected by
-directed edges. Each edge represents a term in our operator acting on the two
+directed edges. Each edge represents a term in our operator that acts on the two
 connected modes. We want to group these terms according to their edge labels
 (shown on the graph): terms connected by edges with the same label are placed in
 the same group. The following code shows how that can be done:

--- a/docs/guides/lucj.rst
+++ b/docs/guides/lucj.rst
@@ -5,7 +5,7 @@ Build an LUCJ ansatz
 
 .. important::
 
-   The concepts in this guide are currently available only in the Python API.
+   The functions described in this guide are currently available only in the Python API.
    Equivalent functionality will be made available through the C API in a future
    release.
 
@@ -109,14 +109,14 @@ in packed (lower-triangular) `chemist` ordering, which is what PySCF produces.
 
 The :class:`.UCJ` gate assembles the ansatz directly from the coupled-cluster amplitudes. Its
 :meth:`~qiskit_fermions.circuit.library.UCJ.from_t_amplitudes` constructor performs a *double
-factorization* of the :math:`t_2` amplitudes (via
+factorization* of the :math:`t_2` amplitudes (by using 
 :func:`~qiskit_fermions.linalg.double_factorized_t2`) to obtain the per-layer diagonal Coulomb
 matrices and orbital rotations, and derives an optional final orbital rotation from the
 :math:`t_1` amplitudes.
 
-The number of ansatz repetitions :math:`L` equals the number of terms in the double
+The number of ansatz repetitions, :math:`L`, equals the number of terms in the double
 factorization. Truncating it with the ``n_reps`` argument trades some accuracy for a shallower
-circuit; here we keep the two largest terms, which recovers most of the correlation energy while
+circuit. Here, we keep the two largest terms, which recovers most of the correlation energy while
 halving the number of layers.
 
 .. plot::
@@ -165,8 +165,8 @@ Because every gate in the circuit implements ffsim's :class:`ffsim.SupportsApply
 the whole :class:`.FermionicCircuit` can be applied to a fixed particle-number state vector with
 :func:`ffsim.apply_unitary`, starting from the Hartree-Fock reference. The
 :class:`.FermionOperator` likewise implements ffsim's :class:`ffsim.SupportsLinearOperator`
-protocol, so we can obtain a SciPy :class:`~scipy.sparse.linalg.LinearOperator` for it via
-:func:`ffsim.linear_operator` and evaluate the ansatz energy as the expectation value of the
+protocol, so we can obtain a SciPy :class:`~scipy.sparse.linalg.LinearOperator` for it by using 
+:func:`ffsim.linear_operator`, and evaluate the ansatz energy as the expectation value of the
 molecular Hamiltonian.
 
 .. plot::
@@ -205,7 +205,7 @@ two repetitions:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :class:`.UCJ` gate above is initialized from an *exact* double factorization of the :math:`t_2`
-amplitudes: the number of ansatz repetitions :math:`L` is whatever that factorization yields (up to
+amplitudes. The number of ansatz repetitions :math:`L` is whatever that factorization yields (up to
 the ``n_reps`` truncation), and each layer reproduces one factorized term exactly. `ffsim`_
 additionally offers an optimized ("compressed") double factorization, its
 ``from_t_amplitudes(..., optimize=True)``, which variationally fits the amplitudes with a chosen,
@@ -256,8 +256,8 @@ way recovers the same correlation energy at this (small) system size:
    compressed LUCJ energy: -1.14618323 Hartree
 
 .. note::
-   ``diag_coulomb_mats`` from ``optimize=True`` may carry tiny imaginary round-off; :class:`.UCJ`
-   takes their real part and raises only if the imaginary part is not negligible. For a better fit at
+   ``diag_coulomb_mats`` from ``optimize=True`` might carry tiny imaginary round-off values; :class:`.UCJ`
+   takes their real part and raises an error only if the imaginary part is not negligible. For a better fit at
    a given ``n_reps`` (at increased classical cost) see ffsim's ``multi_stage_start`` /
    ``multi_stage_step`` options.
 
@@ -266,7 +266,7 @@ way recovers the same correlation energy at this (small) system size:
 6. Transpile the ansatz to a qubit circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To run the ansatz on hardware it must be lowered from fermionic modes to qubits.
+To run the ansatz on hardware, it must be lowered from fermionic modes to qubits.
 The :func:`~qiskit_fermions.transpiler.presets.generate_preset_jw_pass_manager` preset builds a
 staged pipeline that maps the fermionic circuit through the Jordan-Wigner transformation and
 synthesizes each gate into a qubit-level circuit. The composite :class:`.UCJ` gate must first be
@@ -288,9 +288,9 @@ pipeline's optimization stage can act on them, so we pass ``circuit.decompose()`
    >>> print(dict(sorted(transpiled.count_ops().items())))
    {'p': 16, 'rzz': 12, 'x': 2, 'xx_plus_yy': 28}
 
-Without a target device this maps onto ``2 * norb`` qubits with all-to-all connectivity assumed; the
-orbital rotations synthesize into :class:`~qiskit.circuit.library.XXPlusYYGate`\ s and the diagonal
-Coulomb evolutions into :class:`~qiskit.circuit.library.RZZGate`\ s:
+Without a target device, this maps onto ``2 * norb`` qubits with all-to-all connectivity assumed; the
+orbital rotations synthesize into :class:`~qiskit.circuit.library.XXPlusYYGate`\ objects and the diagonal
+Coulomb evolutions into :class:`~qiskit.circuit.library.RZZGate`\ objects:
 
 .. plot::
    :alt: The Jordan-Wigner transpiled LUCJ circuit.
@@ -357,7 +357,7 @@ directly, the router must insert many ``SWAP`` gates to bridge them:
 
 .. rubric:: Restrict the ansatz to the hardware-implementable interactions
 
-The fix is to feed ``allowed_pairs_ab`` back into the ansatz construction, via the
+The fix is to feed ``allowed_pairs_ab`` back into the ansatz construction, through the
 ``interaction_pairs`` argument of :meth:`~qiskit_fermions.circuit.library.UCJ.from_t_amplitudes`,
 so the diagonal Coulomb operator only contains alpha-beta terms the coupling map can implement
 directly. The ansatz then matches the device topology and the router barely has to touch it:
@@ -384,7 +384,7 @@ Drawing only the active qubits (``idle_wires=False``) shows the circuit restrict
 chains and the alpha-beta bridge, expressed in the device basis gates. Layout and routing scatter the
 logical modes across the device's physical qubits, so we pass a ``wire_order`` taken from the
 circuit's final layout (:meth:`~qiskit.transpiler.TranspileLayout.final_index_layout` lists the
-physical qubit each input qubit ended up on, in input-qubit order) to draw the wires back in the
+physical qubit each input qubit ended on, in input-qubit order) to draw the wires back in the
 original mode order:
 
 .. plot::
@@ -402,7 +402,7 @@ original mode order:
    ansatz with a nearest-neighbor ``pairs_aa`` chain and hardware-filtered ``pairs_ab`` bridges keeps
    the synthesized circuit close to the device topology, minimizing the routing overhead (inserted
    ``SWAP`` gates). See :class:`.GivensDecompositionSlaterDeterminantSynthesis` for a related
-   synthesis choice (``minimize_2q_gate_count``) trading two-qubit gate count against routed depth.
+   synthesis choice (``minimize_2q_gate_count``), trading two-qubit gate count against routed depth.
 
 .. skip: end
 

--- a/docs/guides/mappers.rst
+++ b/docs/guides/mappers.rst
@@ -10,7 +10,7 @@ different operator algebras and prepare operators for quantum circuit execution.
 Implement custom mappers
 ------------------------
 
-The mappers module is designed to make it straightforward to implement custom
+The mappers module makes it straightforward to implement custom
 mappings. Mappers work by transforming the fundamental
 actions (creation, annihilation, Majorana, and so on) that compose an operator, then
 combining these transformed actions according to the target representation's rules.
@@ -63,7 +63,7 @@ The key steps to implement any custom mapper are:
    to the target representation. In the example above, Majorana actions map to Pauli
    strings according to Jordan-Wigner rules.
 
-2. **Use one of the provided mapping functions**: the :mod:`~qiskit_fermions.mappers`
+2. **Use one of the provided mapping functions**: The :mod:`~qiskit_fermions.mappers`
    module provides utility functions to handle iterating over the operator terms and
    subsequent applications of the custom action map for the operator
    representations provided by the :mod:`~qiskit_fermions.operators` module. For example,
@@ -80,14 +80,14 @@ term in the operator while preserving mathematical equivalence.
 
    You can also iterate the terms of an operator manually rather than
    using one of the provided iterator functions. See the section on `term iteration
-   <term_iteration_and_reconstruction>`_ in the operators guide for more details on that.
+   <term_iteration_and_reconstruction>`_ in the operators guide for details.
 
 Library implementations
 -----------------------
 
 The :mod:`qiskit_fermions.mappers.library` module provides efficient, thoroughly
 tested implementations of common mappings. These follow the same underlying pattern
-as custom mappers but are optimized for production use and available in both the
+as custom mappers but are optimized for production use and are available in both the
 Python and C APIs.
 
 The example below applies a library mapper to the same :class:`.MajoranaOperator`

--- a/docs/guides/merge_slater_determinant.rst
+++ b/docs/guides/merge_slater_determinant.rst
@@ -5,12 +5,12 @@ Optimize Slater determinant preparation
 
 .. important::
 
-   The concepts in this guide are currently available only in the Python API.
-   Equivalent functionality will be made available via the C API in a future release.
+   The functions described in this guide are currently available only in the Python API.
+   Equivalent functionality will be made available through the C API in a future release.
 
-An :class:`.InitializeModes` gate declares a reference mode occupation; an
+An :class:`.InitializeModes` gate declares a reference mode occupation; an 
 :class:`.OrbitalRotation` gate rotates the single-particle basis. Placed back to back, the two
-gates *prepare a Slater determinant*: the modes start in the reference determinant and are then
+gates prepare a *Slater determinant*: the modes start in the reference determinant and are then
 rotated into the target orbitals. The :class:`.PrepareSlaterDeterminant` gate captures that
 composition, and because it knows the reference occupation, transpiling it can use the rectangular
 :func:`~qiskit_fermions.linalg.givens_decomposition_slater`, which realizes only the *occupied*
@@ -19,15 +19,15 @@ is a strictly cheaper synthesis (see the payoff at the end of this guide).
 
 The :class:`.MergeSlaterDeterminantPreparation` transpiler pass detects the
 :class:`.InitializeModes`-then-:class:`.OrbitalRotation` pattern in a :class:`.FermionicCircuit` and
-rewrites it into :class:`.PrepareSlaterDeterminant` gate(s), so a later synthesis stage picks up the
-reduced decomposition automatically. Under simulation the rewrite is a no-op on the state:
+rewrites it into :class:`.PrepareSlaterDeterminant` gates, so a later synthesis stage picks up the
+reduced decomposition automatically. Under simulation, the rewrite is a no-op on the state:
 :class:`.PrepareSlaterDeterminant` is *validate-then-rotate* (it validates the reference occupation
-and then applies the rotation, just as the two separate gates do), so the merge only unlocks the
+and then applies the rotation, just as the two separate gates do), so the merge unlocks the
 cheaper synthesis without changing the prepared state.
 
-Throughout this guide we draw a circuit before and after the pass, side by side: the input on the
-left, and on the right the result of running the pass on it. Two helpers do that: ``merge``
-runs the pass on a copy of the circuit (via its :class:`.FermionicDAGCircuit`) and converts the
+Throughout this guide we draw a circuit before and after the pass, side by side; the input is on the
+left, and the result of running the pass on it is on the right. Two helpers do that: ``merge``
+runs the pass on a copy of the circuit (by using its :class:`.FermionicDAGCircuit`) and converts the
 result back to a drawable :class:`.FermionicCircuit`, and ``draw_merge`` draws both halves into a
 single before/after figure:
 
@@ -80,7 +80,7 @@ sector. Slater determinant preparation is done per spin sector because each sect
 Full-register (or spinless)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The simplest pattern: an :class:`.InitializeModes` immediately followed by an
+The simplest pattern is using :class:`.InitializeModes`, immediately followed by an
 :class:`.OrbitalRotation` on the *same* modes. This is the spinless case (one determinant over all
 modes) and also a spinful circuit whose rotation spans both sectors at once. The two gates fuse into
 a single :class:`.PrepareSlaterDeterminant`:
@@ -99,8 +99,8 @@ a single :class:`.PrepareSlaterDeterminant`:
 Per spin sector
 ~~~~~~~~~~~~~~~
 
-The same shape restricted to one spin half. Here two independent initialize-then-rotate pairs, one
-per sector, each fuse on their own into a :class:`.PrepareSlaterDeterminant`:
+This is the same shape, but restricted to one spin half. Here, two independent initialize-then-rotate pairs, one
+per sector each fuse on their own into a :class:`.PrepareSlaterDeterminant`:
 
 .. plot::
    :alt: Two per-sector initialize-and-rotate pairs, each fusing into its own preparation.
@@ -118,14 +118,14 @@ per sector, each fuse on their own into a :class:`.PrepareSlaterDeterminant`:
 Global initialization, per-spin rotations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A single full-register (``2 * norb``) :class:`.InitializeModes` followed by *two*
-:class:`.OrbitalRotation`\ s, one on each contiguous spin half. The pass splits the global
+This entails a single full-register (``2 * norb``) :class:`.InitializeModes` followed by *two*
+:class:`.OrbitalRotation`\ actions, one on each contiguous spin half. The pass splits the global
 occupation at the sector boundary and emits **two** :class:`.PrepareSlaterDeterminant` gates. The
-two rotations may appear in either order.
+two rotations can appear in either order.
 
 This is the shape produced by the local unitary cluster Jastrow (LUCJ) workflow (see the
-:ref:`LUCJ guide <lucj_getting_started>`):
-a user places an :class:`.InitializeModes` (typically the Hartree-Fock reference via
+:ref:`LUCJ guide <lucj_getting_started>`);
+A user places an :class:`.InitializeModes` (typically the Hartree-Fock reference by using 
 :meth:`~qiskit_fermions.circuit.library.InitializeModes.from_hartree_fock`) at the front of the
 circuit and appends a :class:`.UCJ` ansatz, whose first two per-spin orbital rotations directly
 follow the initialization once the ansatz is decomposed.
@@ -146,7 +146,7 @@ This pattern also fires when only *one* spin half is rotated by a gate directly 
 initialization, the shape produced when just one spin sector's orbital rotation happens to sit at
 the front of the circuit. The rotated half becomes a :class:`.PrepareSlaterDeterminant` with its
 rotation, and the other half is prepared with an *identity* rotation. The identity preparation
-synthesizes to nothing more than the reference X gates the :class:`.InitializeModes` would have
+synthesizes to the reference `X` gates that the :class:`.InitializeModes` would have
 emitted for that half anyway, so padding it costs no extra gates while still unlocking the reduced
 Slater synthesis on the rotated half:
 
@@ -164,11 +164,11 @@ Slater synthesis on the rotated half:
 What is left untouched
 ----------------------
 
-The pass is deliberately conservative: it only fuses when the two gates genuinely compose into a
+The pass is deliberately conservative. It only fuses when the two gates genuinely compose into a
 Slater determinant preparation, and copies everything else through unchanged. "Immediately
 followed" is understood over the circuit's data-flow graph: the :class:`.OrbitalRotation` fuses
 only when the :class:`.InitializeModes` is its *sole* predecessor across all of its modes. In the
-figures below the before and after are identical: nothing fused.
+figures below, the before and after are identical: nothing fused.
 
 An operation in between
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -227,9 +227,9 @@ six-orbital preparation all the way to a :class:`~qiskit.circuit.QuantumCircuit`
 .. note::
    The preset runs :class:`.MergeOrbitalRotations` immediately before
    :class:`.MergeSlaterDeterminantPreparation`. This matters when a *run* of consecutive
-   :class:`.OrbitalRotation` gates follows the initialization: the earlier pass first collapses the
+   :class:`.OrbitalRotation` gates follows the initialization. The earlier pass first collapses the
    run into a single rotation, which :class:`.MergeSlaterDeterminantPreparation` then contracts with
-   the initialization into one :class:`.PrepareSlaterDeterminant`. Without that ordering only the
+   the initialization into one :class:`.PrepareSlaterDeterminant`. Without that ordering, only the
    first rotation of the run would be absorbed and the rest would synthesize with the full square
    decomposition.
 
@@ -263,9 +263,9 @@ six-orbital preparation all the way to a :class:`~qiskit.circuit.QuantumCircuit`
    >>> prepared.draw("mpl", fold=-1)
    <Figure size ... with 1 Axes>
 
-Compare that to synthesizing the same orbital rotation on its own: with no preceding
+Compare that to synthesizing the same orbital rotation on its own. With no preceding
 initialization there is nothing to merge, so the preset falls back to the full square
-decomposition, which is both deeper and carries diagonal phase gates:
+decomposition, which is deeper and carries diagonal phase gates:
 
 .. plot::
    :context:

--- a/docs/guides/operators.rst
+++ b/docs/guides/operators.rst
@@ -72,9 +72,9 @@ Internal storage format
 
 Internally, operators are stored in arrays inspired by sparse matrix data formats:
 
-- **Coefficients array**: The complex coefficient for each term.
-- **Mode indices array**: The fermionic modes that each action acts upon.
-- **Boundaries array**: Indices marking where each term's modes begin and end in the mode array.
+- **Coefficients array**: The complex coefficient for each term
+- **Mode indices array**: The fermionic modes that each action acts upon
+- **Boundaries array**: Indices marking where each term's modes begin and end in the mode array
 
 .. important::
 
@@ -83,7 +83,7 @@ Internally, operators are stored in arrays inspired by sparse matrix data format
    that specifies the type of fermionic action acting on the respective mode
    index. In contrast, the :class:`MajoranaOperator` class does not require
    this distinction since it encodes that information in the parity of the mode
-   index. See the API documentation for your specific operator type to
+   index. See the API documentation for your operator type to
    understand the full storage format.
 
 The following examples show how these arrays are organized. First is a direct
@@ -391,7 +391,7 @@ reference of all available operations.
    individual operator implementations might offer additional convenience methods
    not part of the protocol. For example, some operators provide an
    ``is_hermitian()`` method that implements this check. Always consult
-   the API documentation for your specific operator type to discover all
+   the API documentation for your operator type to discover all
    available functionality.
 
 
@@ -423,7 +423,7 @@ operator forms for correctness and efficiency.
    fermionic normal ordering uses anticommutation relations (:math:`\{c_i, c_j^\dagger\} = \delta_{ij}`),
    while Majorana normal ordering uses different algebra conventions
    (:math:`\{\gamma_i, \gamma_j\} = 2\delta_{ij}`). Always consult the
-   documentation for your specific operator type to understand how normal
+   documentation for your operator type to understand how normal
    ordering is implemented.
 
 .. tab-set-code::

--- a/docs/guides/skqd.rst
+++ b/docs/guides/skqd.rst
@@ -5,7 +5,7 @@ Generate Krylov time-evolution circuits (SKQD)
 
 .. important::
 
-   The concepts in this guide are currently available only in the Python API.
+   The functions described in this guide are currently available only in the Python API.
    Equivalent functionality will be made available through the C API in a future
    release.
 
@@ -70,7 +70,7 @@ and the two-body part carrying the on-site Coulomb repulsion :math:`U` on the im
    H_2 = U \, a^\dagger_{0\uparrow} a_{0\uparrow} a^\dagger_{0\downarrow} a_{0\downarrow}.
 
 We work at the particle-hole-symmetric point :math:`\mu = -U/2`. These two parts map directly onto
-the one-body integrals ``h1e`` (bath hopping, impurity hybridization, impurity on-site energy) and
+the one-body integrals ``h1e`` (bath hopping, impurity hybridization, and impurity on-site energy) and
 the single two-body integral ``h2e`` (the impurity Coulomb term). We first assemble them in the
 position basis, where the model is naturally defined.
 
@@ -104,7 +104,7 @@ The bath part of the SIAM is a free-fermion chain, so it is diagonalized by a ch
 momentum basis. This is the decisive step for SKQD: because the bath is translationally
 invariant, the ground state is not sparse in the position basis, but it is sparse in the
 momentum basis, where the bath Hamiltonian is diagonal. The single-particle orbital rotation that
-performs this change is problem-specific linear algebra: it diagonalizes the bath hopping matrix
+performs this change is problem-specific linear algebra.  It diagonalizes the bath hopping matrix
 while leaving the impurity orbital untouched, then relocates the impurity to a central site:
 
 .. plot::
@@ -151,8 +151,8 @@ integrals is a standard basis change of the electronic-structure tensors:
    ... )
 
 Because the rotation leaves the impurity orbital fixed (it acts only on the bath), the on-site
-interaction is unchanged: ``h2e_momentum`` remains a single number-number term, just like ``h2e``;
-the only change is that the impurity has been relocated to a central index. We can see this directly
+interaction is unchanged: ``h2e_momentum`` remains a single number-number term, just like ``h2e``.
+The only change is that the impurity has been relocated to a central index. We can see this directly
 in the integral tensors, which each carry one nonzero entry:
 
 .. plot::
@@ -170,7 +170,7 @@ This locality is what keeps the interaction cheap to synthesize later.
 We assemble the one-body integrals into a :class:`.FermionOperator` with the electronic-integral
 constructor :meth:`~qiskit_fermions.operators.FermionOperator.from_1body_tril_spin_sym`, which expects
 them packed into lower-triangular ordering. The two-body part is a single number-number term, so
-rather than route it through the two-body integral machinery we build it directly with
+rather than route it through the two-body integral machinery, we build it directly with
 :func:`.cre`/:func:`.ann`: the on-site Coulomb operator :math:`U \, n_{p\uparrow} n_{p\downarrow}`
 for the impurity mode :math:`p` (its :math:`\uparrow` mode at index ``p``, its :math:`\downarrow` mode
 at index ``p + norb`` in the block-spin layout). Both constructors spin-double the ``norb`` spatial
@@ -178,8 +178,8 @@ orbitals into ``2 * norb`` fermionic modes.
 
 We keep the one-body part :math:`H_1` and the two-body part :math:`H_2` as separate operators
 rather than summing them eagerly, matching the terms :math:`H_1` and :math:`H_2` of the section-1 equations.
-Building each piece once (in both bases) lets us reuse them below: summed, they give the full
-Hamiltonian for the exact diagonalization in either basis; individually, :math:`H_2` (momentum basis)
+Building each piece once (in both bases) lets us reuse them below. Summed, they give the full
+Hamiltonian for the exact diagonalization in either basis. Individually, :math:`H_2` (momentum basis)
 is the operator the Trotter step evolves in step 4.
 
 .. plot::
@@ -214,7 +214,7 @@ is the operator the Trotter step evolves in step 4.
    ...     (one_body_momentum + two_body_momentum).normal_ordered().simplify(atol=1e-14)
    ... )
 
-The basis change is a unitary similarity transform, so it leaves the spectrum untouched: we can
+The basis change is a unitary similarity transform, so it leaves the spectrum untouched. We can
 confirm the operator is correct by comparing its lowest eigenvalue in the
 :math:`(\text{norb}, \text{nelec})` sector against an exact diagonalization. The
 :class:`.FermionOperator` exposes a SciPy :class:`~scipy.sparse.linalg.LinearOperator` (backed by a
@@ -262,8 +262,8 @@ determinants is not:
    determinants for 99% weight: 21 (momentum)
 
 The two operators share the same energy, but the position-basis ground state is spread over
-thousands of determinants while the momentum basis concentrates it onto a couple dozen, which is
-the whole reason SKQD sampling works in the momentum basis and not the position basis.
+thousands of determinants, while the momentum basis concentrates it onto around 20, which is
+why SKQD sampling works in the momentum basis and not the position basis.
 
 3. Prepare the reference state
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -278,7 +278,7 @@ single Slater determinant. That means we can prepare it with one :class:`.Prepar
 gate, given the single-particle rotation the network implements.
 
 Because each :external:class:`~qiskit.circuit.library.XXPlusYYGate` acts as a Givens rotation on a
-pair of modes, we can build that
+pair of modes, we can build that 
 rotation directly in the single-particle picture (one Givens matrix per gate) instead of emitting
 the two-qubit gates by hand. The gates form a brickwork of nearest-neighbor rotations that fans out
 from the Fermi level in expanding layers, spreading each near-Fermi electron across the empty modes
@@ -314,7 +314,7 @@ just above it:
    >>> reference_rotation = fermi_level_rotation(norb, nelec[0])
 
 .. note::
-   The rotation above is expressed in the momentum basis, matching the Hamiltonian: the electrons
+   The rotation above is expressed in the momentum basis, matching the Hamiltonian. The electrons
    near the Fermi level are the highest-energy occupied momentum modes, and the network excites them
    into the lowest-energy empty ones. This is why the reference must be built after the basis change
    of the previous step, not before.
@@ -349,11 +349,11 @@ circuit depth. The one-body evolution :math:`e^{-i t H_1}` is a free-fermion (fe
 operation, so it is a single-particle basis rotation (an :class:`.OrbitalRotation` with
 unitary :math:`e^{-i t \, \mathbf{h}_1}`) rather than something that has to be Pauli-Trotterized
 term by term. The two-body evolution :math:`e^{-i t H_2}` acts only on the single on-site
-interaction term. Building the step this way is what lets the transpiler emit a shallow brickwork of
-Givens rotations plus a single two-qubit interaction gate, the shallow structure the
+interaction term. Building the step this way lets the transpiler emit a shallow brickwork of
+Givens rotations plus a single two-qubit interaction gate, the shallow structure that the
 `SKQD`_ publication builds by hand.
 
-The two-body part is already in hand: it is the ``two_body_momentum`` operator built in step 2 (the
+We already have the two-body part. It is the ``two_body_momentum`` operator built in step 2 (the
 single on-site term). The one-body evolution :math:`e^{-i t H_1}` is spin-independent, so it is a
 single per-sector :class:`.OrbitalRotation` with unitary :math:`e^{-i t \, \mathbf{h}_1}` that we
 apply once to each spin sector, the same parallel structure as the reference-state preparation.
@@ -362,8 +362,8 @@ Each Krylov circuit evolves for a total time :math:`k \, \Delta t`. We realize t
 second-order Trotter product of :math:`k` steps of size :math:`\Delta t`, so the per-step error
 stays fixed as the Krylov dimension grows. Each step sandwiches a full one-body rotation (one per
 spin sector) between two half-steps of the (cheap, single-term) two-body evolution. The Krylov
-dimension :math:`D` is simply the number of such circuits, with ``dim`` ranging from ``0`` (reference
-state only) up to :math:`D - 1`.
+dimension :math:`D` is the number of such circuits, with ``dim`` ranging from ``0`` (reference
+state only) to :math:`D - 1`.
 
 .. plot::
    :context:
@@ -395,9 +395,9 @@ state only) up to :math:`D - 1`.
    ...     return circuit
 
 .. note::
-   The fermionic circuit carries no measurements: measurement is a qubit-level concept, so we add it
-   after transpilation, once the fermionic gates have been synthesized onto qubits. Convenience
-   ``measure`` instructions on :class:`.FermionicCircuit` may be introduced in the
+   The fermionic circuit carries no measurements. Measurement is a qubit-level concept, so we add it
+   after transpilation, after the fermionic gates have been synthesized onto qubits. Convenience
+   ``measure`` instructions on :class:`.FermionicCircuit` might be introduced in the
    `future <https://github.com/Qiskit/qiskit-fermions/issues/219>`_.
 
 5. Transpile to qubit circuits
@@ -410,10 +410,10 @@ interaction gate.
 
 Because every fermionic gate here has a default synthesis, we can use the ready-made
 :func:`.generate_preset_jw_pass_manager` directly rather than hand-assembling the stages. Any
-keyword arguments are forwarded to the qubit stage; we pass ``optimization_level=0`` for a faithful,
+keyword arguments are forwarded to the qubit stage. We pass ``optimization_level=0`` for a faithful,
 unoptimized picture of the synthesized depth. Generating the full family of Krylov circuits is then
-a loop over the Krylov dimension. We keep the untranspiled :class:`.FermionicCircuit`\ s alongside
-the transpiled qubit circuits: the fermionic ones drive the exact (statevector) simulation in step
+a loop over the Krylov dimension. We keep the untranspiled :class:`.FermionicCircuit`\ objects alongside
+the transpiled qubit circuits. The fermionic ones drive the exact (statevector) simulation in step
 6, while the transpiled ones (with measurements added) are what a backend would execute.
 
 .. plot::
@@ -452,11 +452,11 @@ of the time-evolution operator.
    [4, 12, 21, 30, 39]
 
 .. note::
-   Splitting the Hamiltonian is what keeps these depths modest. The one-body evolution is a genuine
+   Splitting the Hamiltonian keeps these depths modest. The one-body evolution is a genuine
    orbital rotation, so it synthesizes to an :external:class:`~qiskit.circuit.library.XXPlusYYGate`
-   brickwork on adjacent qubits, while each half-step of the on-site interaction is a single
+   brickwork on adjacent qubits. Each half step of the on-site interaction is a single
    :external:class:`~qiskit.circuit.library.RZZGate` coupling the impurity's two spin
-   modes, the cheap term the second-order product sandwiches around the rotation. Handing the whole
+   modes; the cheap term that the second-order product sandwiches around the rotation. Handing the whole
    Hamiltonian to one :class:`.Evolution` gate instead would Pauli-Trotterize the one-body part term
    by term, propagating long Jordan-Wigner ``Z``-strings across the (long-range) impurity-bath
    couplings and inflating the depth by an order of magnitude.
@@ -488,8 +488,8 @@ version of that step to see the bitstrings SKQD would collect. We simulate each 
 :class:`.FermionicCircuit` with :func:`ffsim.apply_unitary` and sample the resulting statevector with
 :func:`ffsim.sample_state_vector`.
 
-Because a :class:`.PrepareSlaterDeterminant` gate is validate-then-rotate under simulation (it
-checks that the incoming state occupies its reference determinant, then applies the rotation), the
+A :class:`.PrepareSlaterDeterminant` gate is validate-then-rotate under simulation (it
+checks that the incoming state occupies its reference determinant, then applies the rotation). Therefore, the
 input is the plain occupation determinant: the lowest ``nocc`` modes filled per spin, with no
 rotation. The gate applies ``reference_rotation`` itself.
 
@@ -516,8 +516,7 @@ rotation. The gate applies ``reference_rotation`` itself.
 
 Pooling the samples from all five Krylov circuits, the support is tiny: a few hundred distinct
 bitstrings out of the :math:`\binom{8}{4}^2 = 4900` determinants in the ``(4, 4)`` sector. This
-concentration, a direct consequence of the momentum-basis sparsity established in step 2, is
-what makes the subsequent classical diagonalization tractable.
+concentration, a direct consequence of the momentum-basis sparsity established in step 2, makes the subsequent classical diagonalization tractable.
 
 Plotting the counts with :func:`qiskit.visualization.plot_histogram` makes the sparsity visible: a
 handful of configurations dominate, led by the reference determinant.
@@ -538,23 +537,23 @@ handful of configurations dominate, led by the reference determinant.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The sampled bitstrings are the input to the classical half of SKQD: the Hamiltonian is projected onto
-the subspace the sampled configurations span and diagonalized there. We hand this off to the
+the subspace that the sampled configurations span and is diagonalized there. We hand this off to the
 `qiskit-addon-sqd <https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd>`_ package, whose
 :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` runs the full sample-based
-quantum diagonalization loop: it builds a subspace from batches of the sampled configurations,
-diagonalizes the Hamiltonian in it, and iteratively refines the subspace via configuration
+quantum diagonalization loop. It builds a subspace from batches of the sampled configurations,
+diagonalizes the Hamiltonian in it, and iteratively refines the subspace by using configuration
 recovery: flipping occupations to repair configurations that violate the known particle-number
-symmetry. Configuration recovery is designed to undo the damage of hardware noise, which corrupts
-sampled bitstrings into the wrong particle-number sector; we sample noiselessly here, so there is
-nothing to repair on that front.
+symmetry. Configuration recovery is designed to undo hardware noise damage, which corrupts
+sampled bitstrings into the wrong particle-number sector. We sample noiselessly here, so there is
+nothing to repair.
 
 .. skip: start if(not (HAS_FFSIM and HAS_QISKIT_ADDON_SQD))
 
 The solver consumes the sampled counts as a :external:class:`~qiskit.primitives.BitArray`, which we
-build directly from the pooled ``counts`` of step 6. It diagonalizes in the same momentum basis the
+build directly from the pooled ``counts`` from step 6. It diagonalizes in the same momentum basis the
 rest of the construction uses, so it takes the ``h1e_momentum`` and ``h2e_momentum`` integrals from
 step 2 directly, with no repacking. The recovered energy matches the exact reference to well under a
-milli-Hartree, from only a few hundred sampled configurations; because the SQD energy is a variational
+milli-Hartree, from only a few hundred sampled configurations. Because the SQD energy is a variational
 upper bound on the true ground state, it always sits at or above ``reference_energy`` (still in scope
 from step 2):
 
@@ -589,8 +588,8 @@ from step 2):
 We visualize the run: the energy's convergence across the iterations, and the average
 occupancy of each spatial orbital in the recovered ground state. The per-iteration energy is the
 lowest across that iteration's batches, and the occupancy sums the ``orbital_occupancies`` over the
-two spin sectors. Even without noise to correct, the energy still decreases from iteration to
-iteration: each iteration diagonalizes within ``num_batches`` batches of only ``samples_per_batch``
+two spin sectors. Even without noise to correct, the energy decreases from iteration to
+iteration. Each iteration diagonalizes within ``num_batches`` batches of only ``samples_per_batch``
 configurations subsampled from the pool, and the iterative refinement due to bitstring carryover
 steadily improves which configurations land in those batches, so the recovered energy improves:
 
@@ -629,18 +628,18 @@ Next steps
 ^^^^^^^^^^
 
 This guide ran the whole SKQD pipeline on a noiseless statevector simulator. On hardware, the
-transpiled ``circuits`` would be executed and measured in place of the statevector sampling of step
-6, with the resulting counts feeding the same step-7 diagonalization unchanged. Refer to the `Qiskit
-documentation <https://quantum.cloud.ibm.com/docs/guides/intro-to-patterns>`_ for running circuits,
+transpiled ``circuits`` would be executed and measured in place of the statevector sampling in step
+6, with the resulting counts feeding the step-7 diagonalization unchanged. Refer to the `Qiskit
+documentation <https://quantum.cloud.ibm.com/docs/guides/intro-to-patterns>`_ for help running circuits,
 and to the `SQD addon tutorials
-<https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd/guides/overview>`_ for more on the
+<https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd/guides/overview>`_ for information about the
 subspace-diagonalization post-processing, including its behavior on noisy samples, where
 configuration recovery does the most work.
 
 Read the :ref:`ffsim backend guide <ffsim_backend_explanation>` to understand why
 :func:`ffsim.apply_unitary` and :func:`ffsim.sample_state_vector` work natively on this package's
-fermionic circuits, and why the fixed-particle-number sector used in step 6 is what makes the
-momentum-basis sparsity established in step 2 sample-efficient in the first place.
+fermionic circuits, and why the fixed-particle-number sector used in step 6 makes the
+momentum-basis sparsity established in step 2 sample-efficient.
 
 
 .. _SQD: https://arxiv.org/abs/2405.05068

--- a/docs/guides/sqdrift.rst
+++ b/docs/guides/sqdrift.rst
@@ -11,7 +11,7 @@ This is achieved by subsampling smaller time evolution operators from the
 Hamiltonian based on its coefficients, which is known as the `qDRIFT`_
 Trotterization method.
 
-This getting-started guide shows how to generate an ensemble of such randomized
+This getting started guide shows how to generate an ensemble of such randomized
 circuits.
 
 1. Hamiltonian setup
@@ -89,7 +89,7 @@ detail in :ref:`this guide <grouping_explanation>`.
    in the next step.
 
    The terms that fit this description are those that are diagonal
-   in the occupation-number basis, i.e. the products of number operators
+   in the occupation-number basis, that is, the products of number operators
    (:math:`a^\dagger_i a_i`). This includes the constant energy offset, whose
    time evolution only introduces a global phase into the circuit, the
    individual number-operators whose time evolution amounts to single-qubit Z
@@ -111,10 +111,10 @@ detail in :ref:`this guide <grouping_explanation>`.
 
           qf_ferm_op_filter_diagonal_terms(canon);
 
-   Filtering here, once, is considerably cheaper than filtering repeatedly:
+   Filtering here, once, is considerably cheaper than filtering repeatedly.
    :class:`.QDriftTrotterization` runs once per transpiled circuit, so
-   filtering the Hamiltonian beforehand, rather than on every call, avoids
-   redoing the same work for every circuit generated from it.
+   filtering the Hamiltonian initially, rather than on every call, avoids
+   redoing work for every circuit generated from it.
 
 3. Prepare the time evolution circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -167,15 +167,15 @@ not use the time evolution of the entire Hamiltonian, a circuit whose depth
 would exceed the capabilities of currently available quantum computing hardware.
 
 Instead, it will subsample a fixed number of ``groups`` of Hamiltonian terms for
-each circuit, every time we transpile the circuit. Through this, we can generate
+each circuit, every time we transpile the circuit. Thus, we can generate
 multiple circuit randomizations as required by the `SqDRIFT`_ algorithm by
 repeatedly running the transpilation pipeline.
 
-This step also introduces the few parameters with which one can tweak the
-ensemble of circuits to generate:
+This step also introduces the few parameters you can use to customize the
+circuits to generate:
 
-* the number of circuits to generate: ``num_sqdrift_randomizations``
-* the length of each circuit in terms of excitation groups: ``num_groups``
+* The number of circuits to generate: ``num_sqdrift_randomizations``
+* The length of each circuit in terms of excitation groups: ``num_groups``
 
 .. tab-set-code::
 
@@ -211,18 +211,18 @@ ensemble of circuits to generate:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Beyond the diagonal terms filtered out in the previous step, a sampled
-excitation can *still* fail to affect the sampled bitstrings: whenever it acts
+excitation can *still* fail to affect the sampled bitstrings. Whenever it acts
 entirely within a set of modes whose occupation is already fixed (all occupied
 or all unoccupied), it cannot move a particle from one to the other, so it
 leaves the state (and thus the eventual measurement outcome) unchanged.
 Setting ``filter_trivial=True`` on the :class:`.QDriftTrotterization` pass
 rejects such terms as they are sampled and re-draws a replacement, so that
-every one of the ``num_groups`` slots of the resulting circuit contributes a
+each of the ``num_groups`` slots of the resulting circuit contributes a
 non-trivial excitation.
 
 This filtering needs to know which modes start out occupied. It therefore
 requires an :class:`.InitializeModes` gate preceding the :class:`.Evolution`
-gate(s) in the circuit; :meth:`.InitializeModes.from_hartree_fock` is a
+gates in the circuit. :meth:`.InitializeModes.from_hartree_fock` is a
 convenient way to construct one. We add one here for the N2 Hartree-Fock
 reference (seven alpha and seven beta electrons in 14 spatial orbitals) and compare the
 sampled excitations with and without ``filter_trivial=True``:

--- a/docs/guides/transpilation.rst
+++ b/docs/guides/transpilation.rst
@@ -5,8 +5,8 @@ Transpile fermionic circuits
 
 .. important::
 
-   The concepts in this guide are currently available only in the Python API.
-   Equivalent functionality will be made available via the C API in a future release.
+   The functions described in this guide are currently available only in the Python API.
+   Equivalent functionality will be made available through the C API in a future release.
 
 This guide explains how to transpile a :class:`.FermionicCircuit` to a standard
 :class:`~qiskit.circuit.QuantumCircuit`. We continue with the same time evolution
@@ -22,7 +22,7 @@ this project split the transpilation into the following stages:
    Converts the input circuit to a directed acyclic graph (DAG) data structure.
 
 **Optimization**
-   Fermionic-level optimizations that keep the circuit in fermionic space. These
+   Keeps the circuit in fermionic space. These
    passes exploit fermionic structure and commutation relations while
    problem-aware knowledge remains fully available.
 
@@ -38,7 +38,7 @@ this project split the transpilation into the following stages:
    standard quantum gates.
 
 **Qubit**
-   Standard Qiskit transpilation on the resulting qubit circuit, including
+   Transpiles the resulting qubit circuit by using standard Qiskit methods, including
    optimization, layout, and routing for your target hardware.
 
 **Output**
@@ -144,7 +144,7 @@ Advanced workflows
 ------------------
 
 The preset pass manager provides a convenient starting point. For more advanced
-use cases, you can:
+use cases, you can do the following:
 
 - Customize the transpiler passes run during each stage.
 - Implement custom fermion-to-qubit mappings by creating synthesis plugins (see

--- a/docs/guides/vqe_outer_loop.rst
+++ b/docs/guides/vqe_outer_loop.rst
@@ -1,11 +1,11 @@
 .. _vqe_outer_loop_how_to:
 
-Running the outer VQE parameter optimization loop
-=================================================
+Run the outer VQE parameter optimization loop
+=============================================
 
 .. important::
 
-   The concepts in this guide are currently available only in the Python API.
+   The functions described in this guide are currently available only in the Python API.
    Equivalent functionality will be made available through the C API in a future
    release.
 
@@ -24,12 +24,12 @@ ansatz gate, using :class:`.UCJ` as a concrete example.
 .. note::
    Fermionic ansatz gates such as :class:`.UCJ` are built from concrete numeric tensors
    (``diag_coulomb_mats``, ``orbital_rotations``), not from :class:`~qiskit.circuit.Parameter`
-   objects: their synthesis (see :class:`.GivensDecompositionOrbitalRotationSynthesis`) performs a
+   objects. Their synthesis (see :class:`.GivensDecompositionOrbitalRotationSynthesis`) performs a
    numeric Givens decomposition of the rotation matrix, which has no symbolic equivalent. So rather
    than binding parameters into one fixed circuit, this guide drives an outer loop: a classical
    optimizer proposes a flat real vector :math:`\boldsymbol{\theta}`, which
    :meth:`.UCJ.from_parameters` unpacks into a fresh ansatz gate, evaluated once per optimizer step.
-   This mirrors how `ffsim`_'s own VQE examples treat its equivalent UCJ operators.
+   This mirrors how `ffsim`_'s VQE examples treat its equivalent UCJ operators.
 
 .. invisible-code-block: python
 
@@ -42,7 +42,7 @@ ansatz gate, using :class:`.UCJ` as a concrete example.
 
 As a concrete example, we use the :class:`.UCJ` ansatz for a hydrogen molecule in the ``6-31g``
 basis, following the :ref:`LUCJ guide <lucj_getting_started>`, which covers the classical
-calculation, the Hamiltonian construction, and the ansatz gate itself in more detail; this guide
+calculation, the Hamiltonian construction, and the ansatz gate in more detail. This guide
 focuses on the optimization loop around it instead. We reuse the molecule's coupled-cluster
 singles and doubles (CCSD) :math:`t_1`/
 :math:`t_2` amplitudes as the initial point for the optimization, rather than for a fixed ansatz.
@@ -100,18 +100,17 @@ The molecular Hamiltonian is built the same way as in the LUCJ guide:
 The optimizer needs a flat real vector, but the ansatz tensors are constrained: each orbital
 rotation must be unitary, and each diagonal Coulomb matrix must be real symmetric.
 :meth:`.UCJ.to_parameters` and :meth:`.UCJ.from_parameters` handle this conversion natively,
-parametrizing the *unconstrained* generators and mapping them onto valid tensors: an orbital
+parametrizing the unconstrained generators and mapping them onto valid tensors: an orbital
 rotation :math:`U = \exp(A)` for a complex anti-Hermitian generator :math:`A`, and a diagonal
 Coulomb matrix written directly by its upper triangle and diagonal, then symmetrized.
 
 .. tip::
-   The rest of this guide only ever calls ``num_parameters``/``from_parameters``/``to_parameters``
-   on the ansatz, never anything :class:`.UCJ`-specific. Any ansatz gate exposing that same
-   three-method interface can be dropped in here unchanged; :ref:`step 6 <vqe_outer_loop_ucc>` does
-   that with :class:`.UCC`.
+   The rest of this guide only calls ``num_parameters``/``from_parameters``/``to_parameters``
+   on the ansatz, never anything :class:`.UCJ`-specific. Any ansatz gate that exposes the same
+   three-method interface can thus be used with these instructions unchanged, as done in :ref:`step 6 <vqe_outer_loop_ucc>` with :class:`.UCC`.
 
 We fix a single repetition (``n_reps=1``) here to keep the optimization fast for this guide, and
-keep the final orbital rotation from the :math:`t_1` amplitudes out of ``theta`` (see step 3);
+keep the final orbital rotation from the :math:`t_1` amplitudes out of ``theta`` (see step 3).
 :meth:`.UCJ.num_parameters` reports how many parameters this leaves.
 
 .. plot::
@@ -137,8 +136,8 @@ it via the Hamiltonian's :func:`ffsim.linear_operator`.
 The final orbital rotation is initialized from the :math:`t_1` amplitudes and held fixed throughout:
 since that rotation already captures the singles, the optimization can focus on the
 :math:`t_2`-derived repetition tensors, and ``theta`` stays :math:`\mathcal{O}(N^2)` parameters
-shorter. This is a choice, not a requirement: freezing it does restrict the variational manifold,
-so for systems with significant singles character you may well want it optimized too. Passing
+shorter. This is a choice, not a requirement. Freezing it does restrict the variational manifold,
+so for systems with significant singles character you might want it optimized too. Passing
 ``with_final_orbital_rotation=True`` to both :meth:`.UCJ.num_parameters` and
 :meth:`.UCJ.from_parameters` folds it into ``theta``, which then also makes the two explicit
 ``final_orbital_rotation`` assignments below unnecessary.
@@ -176,21 +175,21 @@ so for systems with significant singles character you may well want it optimized
    ...     state = params_to_vec(theta)
    ...     return np.vdot(state, linop @ state).real
 
-Each call to ``params_to_vec`` builds an entirely new :class:`.UCJ` gate: there is no persistent
-circuit carrying bound parameters, only the mapping from ``theta`` to tensors to a gate to a state.
+Each call to ``params_to_vec`` builds a new :class:`.UCJ` gate. There is no persistent
+circuit carrying bound parameters, only the mapping from ``theta`` to tensors, to a gate, to a state.
 
 4. Run the outer loop with a generic optimizer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Starting the optimizer from :math:`\boldsymbol{\theta} = \mathbf{0}` (the identity rotation and a
-zero diagonal Coulomb matrix, i.e. the Hartree-Fock reference itself) lands on a nearby local
+zero diagonal Coulomb matrix, that is, the Hartree-Fock reference) lands on a nearby local
 minimum barely below Hartree-Fock. With only one repetition, the ansatz is not expressive enough
 near that point for a gradient-based search to escape it unassisted. A classically computed
-starting point is a much better choice, so we reuse the CCSD-initialized ansatz from step 1: calling
+starting point is a much better choice, so we reuse the CCSD-initialized ansatz from step 1.  We call
 :meth:`~.UCJ.to_parameters` on it (with its final rotation cleared, since ``theta`` excludes it)
 gives ``theta0``, which is then handed to :func:`scipy.optimize.minimize` together with ``energy``.
 Any ``scipy`` gradient-free or finite-difference method works here since ``energy`` returns a plain
-float; no gradient of the fermionic ansatz is implemented.
+float. No gradient of the fermionic ansatz is implemented.
 
 .. plot::
    :context:
@@ -213,7 +212,7 @@ float; no gradient of the fermionic ansatz is implemented.
    and :func:`ffsim.linear_operator`), and ``minimize`` here uses numeric finite-difference
    gradients, the optimization trajectory (in particular the number of iterations needed)
    can vary slightly between runs, machines, and BLAS backends. We give the optimizer a generous
-   iteration budget and check convergence with a tolerance rather than pinning down an exact
+   iteration budget and check convergence with a tolerance rather than specifying an exact
    iteration count.
 
 .. plot::
@@ -230,28 +229,28 @@ float; no gradient of the fermionic ansatz is implemented.
    >>> bool(abs(result.fun - ccsd.e_tot) < 1e-4)
    True
 
-Even with a generous iteration budget, each ``energy`` evaluation only reveals a single scalar,
+Even with a generous iteration budget, each ``energy`` evaluation only reveals a single scalar, which is 
 a wasteful use of the full state vector ``params_to_vec`` already computed internally.
 
 5. Run the outer loop with ffsim's linear method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`ffsim`_ ships :func:`ffsim.optimize.minimize_linear_method`, an optimizer purpose-built for
-wavefunction ansatzes: rather than a scalar ``energy``, it takes ``params_to_vec`` directly (the
+`ffsim`_ ships :func:`ffsim.optimize.minimize_linear_method`, an optimizer built for
+wavefunction ansatzes. Rather than a scalar ``energy``, it takes ``params_to_vec`` directly (the
 function returning the state, as built in step 3 above) together with the Hamiltonian
-:class:`~scipy.sparse.linalg.LinearOperator`, and uses the extra structure this exposes
+:class:`~scipy.sparse.linalg.LinearOperator`.  It then uses the extra structure this exposes
 (gradients and an approximate Hessian of the state with respect to :math:`\boldsymbol{\theta}`)
-to take much better-informed steps than a generic finite-difference method can. See `ffsim's own
+to take better informed steps than a generic finite-difference method can. See `ffsim's 
 how-to guide on simulating VQE
 <https://qiskit-community.github.io/ffsim/how-to-guides/simulate-vqe.html>`_ for the method's
-background and a walkthrough using ffsim's own ansatz classes; the same optimizer is applied
+background and a walkthrough using ffsim's ansatz classes. The same optimizer is applied
 to the :class:`.UCJ` gate and ``params_to_vec`` built above, unchanged.
 
 .. note::
    By default, each step also runs an inner search over the ``regularization``/``variation``
-   hyperparameters, which can itself become numerically sensitive once the ansatz is already very
+   hyperparameters, which can become numerically sensitive when the ansatz is very
    close to the optimum, occasionally causing a step to stall. Since a good fixed ``regularization``
-   and ``variation`` are already known to work well starting this close to the CCSD solution, we
+   and ``variation`` are already known to work well when close to the CCSD solution, we
    disable that inner search here for a reliably reproducible trajectory.
 
 .. plot::
@@ -283,11 +282,11 @@ of ``params_to_vec`` that a generic finite-difference method cannot.
 6. Swap in a different ansatz
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Nothing above is specific to :class:`.UCJ`. Because the loop only ever calls
+Nothing above is specific to :class:`.UCJ`. Because the loop only calls
 ``num_parameters``/``from_parameters``/``to_parameters``, another ansatz exposing that interface
 drops straight in. :class:`.UCC` implements the unitary coupled-cluster ansatz
 :math:`e^{T - T^\dagger}` and exposes those three methods, so the only changes are the
-class name and its shape arguments: :class:`.UCC` is sized by the occupied/virtual split
+class name and its shape arguments. :class:`.UCC` is sized by the occupied/virtual split
 (``norb``, ``nocc``) rather than by a repetition count.
 
 .. note::
@@ -324,8 +323,8 @@ the singles live (it only factorizes :math:`t_2`), which is why steps 3 and 4 ha
 fixed outside ``theta``. Every amplitude is a parameter, so :meth:`.UCC.to_parameters` gives
 the warm start directly, and the whole question of freezing a rotation does not arise. Should you
 want one anyway, to widen the manifold beyond what the singles already span, append an
-:class:`.OrbitalRotation` to the circuit yourself; unlike UCJ's flag, it is then yours to either
-keep fixed or fold into ``theta`` by hand.
+:class:`.OrbitalRotation` to the circuit yourself. Unlike UCJ's flag, it is then yours to either
+keep fixed or manually fold into ``theta``.
 
 .. plot::
    :context:
@@ -352,7 +351,7 @@ Both ansatzes reach the CCSD energy on this molecule. Their parameter counts dif
 reading anything general into that at this size; the two scale quite differently. :class:`.UCJ`'s
 count is :math:`O(n_\text{orb}^2)` per repetition, while :class:`.UCC`'s doubles are
 :math:`O(n_\text{occ}^2 n_\text{vrt}^2)`, so UCC starts smaller on tiny systems and ends up much
-larger. At half filling the crossover is already around eight orbitals:
+larger. At half filling, the crossover is already around eight orbitals:
 
 .. plot::
    :context:
@@ -368,14 +367,14 @@ larger. At half filling the crossover is already around eight orbitals:
    norb=20  UCJ (n_reps=1): 820   UCC: 5150
 
 This is a trade-off, not a ranking, and the comparison above is deliberately generous to UCJ by
-holding ``n_reps=1``: repetitions are what buy UCJ its expressivity, and its count grows linearly in
+holding ``n_reps=1``. Repetitions buy UCJ its expressivity, and its count grows linearly in
 them. What matters for this guide is that switching between the two costs three lines.
 
 .. note::
    The two ansatzes also differ in how faithfully their circuits reproduce the gate. :class:`.UCJ`
    synthesizes exactly, whereas :class:`.UCC`'s excitation terms do not commute, so its circuit
    :meth:`~qiskit.circuit.Gate.definition` is a first-order product formula. The simulation path used
-   above applies the exponential exactly, so the optimization here is unaffected; but a circuit
+   above applies the exponential exactly, so the optimization here is unaffected, but a circuit
    transpiled for hardware carries a Trotter error, tightened with a higher-order product formula.
 
 .. skip: end
@@ -384,18 +383,18 @@ Next steps
 ^^^^^^^^^^
 
 - See the :ref:`LUCJ guide <lucj_getting_started>` for how :class:`.UCJ` is normally constructed
-  from coupled-cluster amplitudes, and how to transpile it onto qubits for hardware execution;
-  the same transpilation applies to ``UCJ.from_parameters(lm_result.x, ...)`` here, built from the
+  from coupled-cluster amplitudes, and how to transpile it onto qubits for hardware execution. 
+  The same transpilation applies to ``UCJ.from_parameters(lm_result.x, ...)`` here, built from the
   converged parameter vector from step 5.
 - See :class:`.UCC` for the unitary coupled-cluster ansatz swapped in at step 6, including its
-  ``"unrestricted"`` and ``"spinless"`` variants and the opt-in ``antisymmetric`` parameterization
+  ``"unrestricted"`` and ``"spinless"`` variants, and the opt-in ``antisymmetric`` parameterization
   of the :math:`t_2` amplitudes.
-- Read the :ref:`ffsim backend guide <ffsim_backend_explanation>` for why :func:`ffsim.apply_unitary`
+- Read the :ref:`ffsim backend guide <ffsim_backend_explanation>` to learn why :func:`ffsim.apply_unitary`
   and :func:`ffsim.linear_operator` work natively on :class:`.FermionicCircuit` and
   :class:`.FermionOperator`.
 - See `ffsim's how-to guide on simulating VQE
   <https://qiskit-community.github.io/ffsim/how-to-guides/simulate-vqe.html>`_ for a walkthrough
-  of :func:`~ffsim.optimize.minimize_linear_method` using ffsim's own ansatz classes, and for tuning
+  of :func:`~ffsim.optimize.minimize_linear_method` using ffsim's ansatz classes, and for tuning
   the linear method's other hyperparameters (``regularization``, ``variation``, and more).
 
 .. _ffsim: https://qiskit-community.github.io/ffsim/


### PR DESCRIPTION
I was asked to do a close-reading edit of the Fermions guides before pulling them into the docs site.  So you'll see a lot of changes, but please understand that the vast majority of the changes are style tweaks with an eye to improving translatability and ease of understanding.  For example, we try to use fewer words when possible (this helps with translation and readability), so "extra" words like "simply" are removed.  Similarly, I tried to break up long sentences (the goal is 20 words).  

The only really necessary changes are to get rid of the Latin abbreviations (i.e.,,,). 

Feel free to contact me with any questions!